### PR TITLE
CASSANDRA-15610 Upgraded gradle dependencies, some of which are blockers for full jav…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,19 @@
+
+buildscript {
+    dependencies {
+        // findBugs needs a newer version of Guava in the buildscript.
+        // otherwise it throws an exception
+        classpath "com.google.guava:guava:28.2-jre"
+    }
+}
+
 plugins {
     id 'java'
     id 'application'
     id 'idea'
     id 'checkstyle'
     id 'jacoco'
-    id 'findbugs'
+    id "com.github.spotbugs" version "3.0.0"
     id 'org.hidetake.swagger.generator' version '2.16.0'
 }
 
@@ -73,6 +82,7 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'ch.qos.logback:logback-core:1.2.3'
     compile 'ch.qos.logback:logback-classic:1.2.3'
+
     compile 'com.datastax.cassandra:cassandra-driver-core:3.6+'
     compile group: 'com.google.inject', name: 'guice', version: '4.2.2'
     compile group: 'org.apache.commons', name: 'commons-configuration2', version: '2.4'
@@ -153,11 +163,13 @@ checkstyle {
     configFile file("checkstyle.xml")
 }
 
-tasks.withType(FindBugs) {
-    reports {
-        xml.enabled false
-        html.enabled true
-    }
+spotbugs {
+    toolVersion = '4.0.0'
+}
+
+tasks.withType(com.github.spotbugs.SpotBugsTask) {
+    reports.xml.enabled = false
+    reports.html.enabled = true
 }
 
 // copyDist gets called on every build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
…a 11 support.

* Upgrading from findbugs (JDK 8 only) to Spotbugs.  FindBugs was abandoned
  years ago and will not be updated.
* Pinned the transitive Guava dependency to version 28-2.re.
* Upgraded the DataStax driver to version 3.8
* Upgraded Gradle to version 6.2.1