### PR TITLE
Improving CircleCI build reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,42 +2,87 @@
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
-version: 2
-jobs:
-  build:
-    docker:
-      - image: circleci/openjdk:8-jdk
+version: 2.1
 
+# need to reuse the same base environment for several tests
+aliases:
+  base_job: &base_job
+    machine:
+      image: ubuntu-1604:201903-01
     working_directory: ~/repo
-
     environment:
       TERM: dumb
 
+# we might modify this in the future to accept a parameter for the java package to install
+commands:
+  install_java:
+    description: "Installs Java 8 using AdoptOpenJDK"
+    parameters:
+      version:
+        type: string
+
+    steps:
+      - run: wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+      - run: sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y << parameters.version>>
+
+  install_common:
+    description: "Installs common software and certificates"
+    steps:
+      - run: sudo apt-get update
+      - run: sudo apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+
+jobs:
+  java8:
+    <<: *base_job
+
     steps:
       - checkout
+      - install_common
+      
+      - install_java:
+          version: adoptopenjdk-8-hotspot
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "build.gradle" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
-      - run: ./gradlew dependencies
-
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: v1-dependencies-{{ checksum "build.gradle" }}
+      - run: sudo update-java-alternatives -s adoptopenjdk-8-hotspot-amd64 && java -version
 
       # make sure it builds with build steps like swagger docs and dist
-      - run: ./gradlew build
-
-      # run tests!
-      - run: ./gradlew check
+      - run: ./gradlew build --stacktrace
 
       - store_artifacts:
           path: build/reports
           destination: test-reports
+
       - store_test_results:
+          path: ~/repo/build/test-results/
+
+  java11:
+    <<: *base_job
+    steps:
+      - checkout
+      - install_common
+
+      - install_java:
+          version: adoptopenjdk-11-hotspot
+
+      - run: sudo update-java-alternatives -s adoptopenjdk-11-hotspot-amd64 && java -version
+
+      - run: ./gradlew build --stacktrace
+
+      - store_artifacts:
           path: build/reports
+          destination: test-reports
+
+      - store_test_results:
+          path: ~/repo/build/test-results/
+
+workflows:
+  version: 2
+
+  test_java_8:
+    jobs:
+      - java8
+
+  test_java_11:
+    jobs:
+      - java11

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ For more information, see [the Apache Cassandra web site](http://cassandra.apach
 
 Requirements
 ------------
-  1. Java >= 1.8 (OpenJDK or Oracle)
-  2. Apache Cassandra 4.0
+  1. Java >= 1.8 (OpenJDK or Oracle), or Java 11
+  2. Apache Cassandra 4.0.  We depend on virtual tables which is a 4.0 only feature.
 
 Getting started
 ---------------
@@ -19,6 +19,13 @@ Apache Cassandra running on the host & port specified in `conf/sidecar.yaml`.
     $ ./gradlew run
   
 You can use `build`, `test` to build & test the project.
+
+CircleCI Testing
+-----------------
+
+You will need to use the "Add Projects" function of CircleCI to set up CircleCI on your fork.  When promoted to create a branch, 
+do not replace the CircleCI config, choose the option to do it manually.  CircleCI will pick up the in project configuration.
+
 
 Wondering where to go from here?
 --------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,9 @@ configurations {
 }
 
 dependencies {
-    compile 'io.vertx:vertx-web:3.6.3'
-    compile 'io.vertx:vertx-dropwizard-metrics:3.6.3'
-    compile 'io.vertx:vertx-web-client:3.6.3'
+    compile 'io.vertx:vertx-web:3.8.5'
+    compile 'io.vertx:vertx-dropwizard-metrics:3.8.5'
+    compile 'io.vertx:vertx-web-client:3.8.5'
 
     // Trying to be exactly compatible with Cassandra's deps
     compile 'org.slf4j:slf4j-api:1.7.25'
@@ -94,12 +94,12 @@ dependencies {
     swaggerUI 'org.webjars:swagger-ui:3.10.0'
 
     testCompile group: 'org.cassandraunit', name: 'cassandra-unit-shaded', version: '3.3.0.2'
-    testCompile 'com.datastax.cassandra:cassandra-driver-core:3.6+:tests'
+    testCompile 'com.datastax.cassandra:cassandra-driver-core:3.6.+:tests'
     testCompile 'org.apache.commons:commons-exec:1.3+'
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
-    testCompile group: 'io.vertx', name: 'vertx-junit5', version: '3.6.3'
+    testCompile group: 'io.vertx', name: 'vertx-junit5', version: '3.8.5'
 
-    integrationTestCompile group: 'com.datastax.oss.simulacron', name: 'simulacron-driver-3x', version: '0.8.7'
+    integrationTestCompile group: 'com.datastax.oss.simulacron', name: 'simulacron-driver-3x', version: '0.8.10'
 }
 
 swaggerSources {
@@ -146,6 +146,10 @@ test {
     useJUnitPlatform()
     systemProperty "javax.net.ssl.trustStore", "$projectDir/src/test/resources/certs/ca.p12"
     systemProperty "javax.net.ssl.trustStorePassword", "password"
+    reports {
+        junitXml.enabled = true
+        html.enabled = true
+    }
 }
 
 task integrationTest(type: Test) {
@@ -165,6 +169,7 @@ checkstyle {
 
 spotbugs {
     toolVersion = '4.0.0'
+    excludeFilter = file("src/main/resources/spotbugs-exclude.xml")
 }
 
 tasks.withType(com.github.spotbugs.SpotBugsTask) {

--- a/src/integration/java/org/apache/cassandra/sidecar/HealthServiceIntegrationTest.java
+++ b/src/integration/java/org/apache/cassandra/sidecar/HealthServiceIntegrationTest.java
@@ -194,6 +194,7 @@ public class HealthServiceIntegrationTest
             {
                 while ((System.currentTimeMillis() - start) < 20000 && !checks.get(node).get())
                     Thread.sleep(250);
+
                 logger.info("Started node " + checkNumber);
                 assertTrue(checks.get(node).get(), "Failed on node " + checkNumber);
                 checkNumber++;

--- a/src/main/resources/spotbugs-exclude.xml
+++ b/src/main/resources/spotbugs-exclude.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+        xmlns="https://spotbugs.readthedocs.io/en/stable/filter.html"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/4.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/4.0.0/spotbugs/etc/findbugsfilter.xsd">
+
+
+    <!--  SpotBugs erroneously flags this error for try-with-resources in JDK11 (possibly limited to OpenJDK): -->
+    <!-- https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
+</FindBugsFilter>

--- a/src/test/java/org/apache/cassandra/sidecar/AbstractHealthServiceTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/AbstractHealthServiceTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.sidecar;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +37,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.mocks.MockHealthCheck;
 import org.apache.cassandra.sidecar.routes.HealthService;
 
+
 /**
  * Provides basic tests shared between SSL and normal http health services
  */
@@ -49,7 +52,7 @@ public abstract class AbstractHealthServiceTest
     public abstract boolean isSslEnabled();
 
     @BeforeEach
-    void setUp()
+    void setUp() throws InterruptedException
     {
         Injector injector = Guice.createInjector(getTestModule());
         HttpServer server = injector.getInstance(HttpServer.class);
@@ -59,7 +62,10 @@ public abstract class AbstractHealthServiceTest
         vertx = injector.getInstance(Vertx.class);
         config = injector.getInstance(Configuration.class);
 
-        server.listen(config.getPort());
+        VertxTestContext context = new VertxTestContext();
+        server.listen(config.getPort(), context.completing());
+
+        context.awaitCompletion(5, TimeUnit.SECONDS);
     }
 
     @AfterEach


### PR DESCRIPTION
Switched to Circle machine image - docker has issues with networking in
tests
Added alias for builds to expand on later
Added Java install as a command to later support Java 11
Fix storing of test results
Updated readme with Java 11
Upgrade vertx
Wait for vertx server startup before sending requests
Update simulacron to latest bug fix version