### PR TITLE
CASSANDRASC-40 Fix search in list snapshot endpoint

### DIFF
--- a/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
+++ b/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
@@ -60,7 +60,7 @@ public class SnapshotPathBuilder
 {
     private static final Logger logger = LoggerFactory.getLogger(SnapshotPathBuilder.class);
     private static final String DATA_SUB_DIR = "/data";
-    public static final int SNAPSHOTS_MAX_DEPTH = 4;
+    public static final int SNAPSHOTS_MAX_DEPTH = 5;
     public static final String SNAPSHOTS_DIR_NAME = "snapshots";
     protected final Vertx vertx;
     protected final FileSystem fs;
@@ -249,7 +249,6 @@ public class SnapshotPathBuilder
 
         return vertx.executeBlocking(promise ->
         {
-
             // a filter to keep directories ending in "/snapshots/<snapshotName>"
             BiPredicate<Path, BasicFileAttributes> filter = (path, basicFileAttributes) ->
             {

--- a/src/test/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandlerTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandlerTest.java
@@ -103,7 +103,7 @@ public class ListSnapshotFilesHandlerTest
         ListSnapshotFilesResponse.FileInfo fileInfoExpected =
         new ListSnapshotFilesResponse.FileInfo(11,
                                                "localhost",
-                                               9043,
+                                               6475,
                                                0,
                                                "snapshot1",
                                                "keyspace1",
@@ -112,7 +112,7 @@ public class ListSnapshotFilesHandlerTest
         ListSnapshotFilesResponse.FileInfo fileInfoNotExpected =
         new ListSnapshotFilesResponse.FileInfo(11,
                                                "localhost",
-                                               9043,
+                                               6475,
                                                0,
                                                "snapshot1",
                                                "keyspace1",

--- a/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
+++ b/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
@@ -81,14 +81,14 @@ public class SnapshotUtils
         InstanceMetadataImpl localhost = new InstanceMetadataImpl(1,
                                                                   "localhost",
                                                                   9043,
-                                                                  Collections.singletonList(rootPath + "/d1/data"),
+                                                                  Collections.singletonList(rootPath + "/d1"),
                                                                   null,
                                                                   versionProvider,
                                                                   1000);
         InstanceMetadataImpl localhost2 = new InstanceMetadataImpl(2,
                                                                    "localhost2",
                                                                    9043,
-                                                                   Collections.singletonList(rootPath + "/d2/data"),
+                                                                   Collections.singletonList(rootPath + "/d2"),
                                                                    null,
                                                                    versionProvider,
                                                                    1000);


### PR DESCRIPTION
This commit fixes test setup in SnapshotUtils. Because of the incorrect test setup
the execution is providing incorrect results. For example, assume the following path

/cassandra-test/data/ks/tbl/snapshots/test-snapshot

The test was configuring data directories as ["/cassandra-test/data"], but in a real
execution data directories is provided as ["/cassandra-test"]. This is causing the
endpoint to return incorrect values in the JSON payload.

Additionally, the response was providing the port for Cassandra and not the Sidecar
port.