### PR TITLE
CASSANDRASC-40 Fix search in list snapshot endpoint

### DIFF
--- a/common/src/main/java/org/apache/cassandra/sidecar/common/data/ListSnapshotFilesResponse.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/data/ListSnapshotFilesResponse.java
@@ -52,14 +52,14 @@ public class ListSnapshotFilesResponse
      */
     public static class FileInfo
     {
-        public final long size;
-        public final String host;
-        public final int port;
-        public final int dataDirIndex;
-        public final String snapshotName;
-        public final String keySpaceName;
-        public final String tableName;
-        public final String fileName;
+        private final long size;
+        private final String host;
+        private final int port;
+        private final int dataDirIndex;
+        private final String snapshotName;
+        private final String keySpaceName;
+        private final String tableName;
+        private final String fileName;
 
         public FileInfo(@JsonProperty("size") long size,
                         @JsonProperty("host") String host,
@@ -83,6 +83,70 @@ public class ListSnapshotFilesResponse
         public String ssTableComponentPath()
         {
             return Paths.get(keySpaceName, tableName, fileName).toString();
+        }
+
+        /**
+         * @return the size of the file
+         */
+        public long getSize()
+        {
+            return size;
+        }
+
+        /**
+         * @return the host where the file is hosted
+         */
+        public String getHost()
+        {
+            return host;
+        }
+
+        /**
+         * @return the port of the service hosting the file
+         */
+        public int getPort()
+        {
+            return port;
+        }
+
+        /**
+         * @return the index to the data directory
+         */
+        public int getDataDirIndex()
+        {
+            return dataDirIndex;
+        }
+
+        /**
+         * @return the name of the snapshot
+         */
+        public String getSnapshotName()
+        {
+            return snapshotName;
+        }
+
+        /**
+         * @return the name of the keyspace this file belongs to
+         */
+        public String getKeySpaceName()
+        {
+            return keySpaceName;
+        }
+
+        /**
+         * @return the name of the table this file belongs to
+         */
+        public String getTableName()
+        {
+            return tableName;
+        }
+
+        /**
+         * @return the name of the file
+         */
+        public String getFileName()
+        {
+            return fileName;
         }
 
         public boolean equals(Object o)

--- a/common/src/main/java/org/apache/cassandra/sidecar/common/data/ListSnapshotFilesResponse.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/data/ListSnapshotFilesResponse.java
@@ -23,11 +23,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import com.google.common.annotations.Beta;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A class representing a response for the {@link ListSnapshotFilesRequest}
+ * A class representing a response for the {@link ListSnapshotFilesRequest}.
+ * This class is expected to evolve and has been mark with the {@link Beta} annotation.
  */
+@Beta
 public class ListSnapshotFilesResponse
 {
     private final List<FileInfo> snapshotFilesInfo;
@@ -52,14 +56,14 @@ public class ListSnapshotFilesResponse
      */
     public static class FileInfo
     {
-        private final long size;
-        private final String host;
-        private final int port;
-        private final int dataDirIndex;
-        private final String snapshotName;
-        private final String keySpaceName;
-        private final String tableName;
-        private final String fileName;
+        public final long size;
+        public final String host;
+        public final int port;
+        public final int dataDirIndex;
+        public final String snapshotName;
+        public final String keySpaceName;
+        public final String tableName;
+        public final String fileName;
 
         public FileInfo(@JsonProperty("size") long size,
                         @JsonProperty("host") String host,
@@ -83,70 +87,6 @@ public class ListSnapshotFilesResponse
         public String ssTableComponentPath()
         {
             return Paths.get(keySpaceName, tableName, fileName).toString();
-        }
-
-        /**
-         * @return the size of the file
-         */
-        public long getSize()
-        {
-            return size;
-        }
-
-        /**
-         * @return the host where the file is hosted
-         */
-        public String getHost()
-        {
-            return host;
-        }
-
-        /**
-         * @return the port of the service hosting the file
-         */
-        public int getPort()
-        {
-            return port;
-        }
-
-        /**
-         * @return the index to the data directory
-         */
-        public int getDataDirIndex()
-        {
-            return dataDirIndex;
-        }
-
-        /**
-         * @return the name of the snapshot
-         */
-        public String getSnapshotName()
-        {
-            return snapshotName;
-        }
-
-        /**
-         * @return the name of the keyspace this file belongs to
-         */
-        public String getKeySpaceName()
-        {
-            return keySpaceName;
-        }
-
-        /**
-         * @return the name of the table this file belongs to
-         */
-        public String getTableName()
-        {
-            return tableName;
-        }
-
-        /**
-         * @return the name of the file
-         */
-        public String getFileName()
-        {
-            return fileName;
         }
 
         public boolean equals(Object o)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=1.0-SNAPSHOT
 junitVersion=5.4.2
 kubernetesClientVersion=9.0.0
-cassandra40Version=4.0.4
+cassandra40Version=4.0.5
 vertxVersion=4.2.1

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -17,4 +17,10 @@
         <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
     </Match>
 
+    <!-- Ignore DMI_HARDCODED_ABSOLUTE_FILENAME for testing SnapshotDirectory.of with strings that are paths -->
+    <Match>
+        <Class name="org.apache.cassandra.sidecar.snapshots.SnapshotDirectoryTest" />
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandler.java
+++ b/src/main/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandler.java
@@ -136,7 +136,7 @@ public class ListSnapshotFilesHandler extends AbstractHandler
             String keyspace = request.getKeyspace();
             // table name might include a dash (-) with the table UUID, so we always use it as part of the response
             String tableName;
-            if (isSecondaryIndexFile(path))
+            if (isSecondaryIndexFile(path, keyspace))
             {
                 tableName = path.getName(nameCount - TABLE_NAME_SUBPATH_INDEX_FROM_END_SECONDARY)
                                 .toString();
@@ -160,9 +160,18 @@ public class ListSnapshotFilesHandler extends AbstractHandler
         return response;
     }
 
-    private boolean isSecondaryIndexFile(Path path)
+    /**
+     * Checks whether the given path is a secondary index file by checking the parent directory "/snapshots/" as
+     * well as the provided "/&lt;{@code keyspace}&gt;/".
+     *
+     * @param path     the path to check
+     * @param keyspace the name of the keyspace
+     * @return true if the path is a secondary index file, false otherwise
+     */
+    private boolean isSecondaryIndexFile(Path path, String keyspace)
     {
-        return path.getNameCount() >= 4 &&
+        return path.getNameCount() >= 6 &&
+               path.getName(path.getNameCount() - 6).endsWith(keyspace) &&
                path.getName(path.getNameCount() - 4).endsWith(SNAPSHOTS_DIR_NAME);
     }
 

--- a/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotDirectory.java
+++ b/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotDirectory.java
@@ -1,0 +1,54 @@
+package org.apache.cassandra.sidecar.snapshots;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.google.common.base.Preconditions;
+
+import static org.apache.cassandra.sidecar.snapshots.SnapshotPathBuilder.SNAPSHOTS_DIR_NAME;
+
+/**
+ * An object that encapsulates the parts of a snapshot directory
+ */
+public class SnapshotDirectory
+{
+    public final String dataDirectory;
+    public final String keyspace;
+    public final String tableName;
+    public final String snapshotName;
+
+    SnapshotDirectory(String dataDirectory, String keyspace, String tableName, String snapshotName)
+    {
+        this.dataDirectory = dataDirectory;
+        this.keyspace = keyspace;
+        this.tableName = tableName;
+        this.snapshotName = snapshotName;
+    }
+
+    /**
+     * Parses a snapshot directory string into a {@link SnapshotDirectory} object. The snapshot directory
+     * has the following structure {@code /&lt;data_dir&gt;/&lt;ks&gt;/&lt;table&gt;/snapshots/&lt;snapshot_name&gt;}.
+     *
+     * @param snapshotDirectory the absolute path to the snapshot directory
+     * @return the {@link SnapshotDirectory} object representing the provided {@code snapshotDirectory}
+     */
+    public static SnapshotDirectory of(String snapshotDirectory)
+    {
+        Path snapshotDirectoryPath = Paths.get(snapshotDirectory);
+        int nameCount = snapshotDirectoryPath.getNameCount();
+        Preconditions.checkArgument(nameCount >= 5, "Invalid snapshotDirectory. " +
+                                                    "Expected at least 5 parts but found " + nameCount);
+        String snapshotName = snapshotDirectoryPath.getName(nameCount - 1).toString();
+        String snapshotDirName = snapshotDirectoryPath.getName(nameCount - 2).toString();
+        String tableName = snapshotDirectoryPath.getName(nameCount - 3).toString();
+        String keyspace = snapshotDirectoryPath.getName(nameCount - 4).toString();
+        String dataDirectory = File.separator + snapshotDirectoryPath.subpath(0, nameCount - 4);
+
+        Preconditions.checkArgument(SNAPSHOTS_DIR_NAME.equalsIgnoreCase(snapshotDirName),
+                                    "Invalid snapshotDirectory. The expected directory structure is " +
+                                    "'/<data_dir>/<ks>/<table>/snapshots/<snapshot_name>'");
+
+        return new SnapshotDirectory(dataDirectory, keyspace, tableName, snapshotName);
+    }
+}

--- a/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
+++ b/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
@@ -60,7 +60,7 @@ public class SnapshotPathBuilder
 {
     private static final Logger logger = LoggerFactory.getLogger(SnapshotPathBuilder.class);
     private static final String DATA_SUB_DIR = "/data";
-    public static final int SNAPSHOTS_MAX_DEPTH = 4;
+    public static final int SNAPSHOTS_MAX_DEPTH = 5;
     public static final String SNAPSHOTS_DIR_NAME = "snapshots";
     protected final Vertx vertx;
     protected final FileSystem fs;
@@ -249,7 +249,6 @@ public class SnapshotPathBuilder
 
         return vertx.executeBlocking(promise ->
         {
-
             // a filter to keep directories ending in "/snapshots/<snapshotName>"
             BiPredicate<Path, BasicFileAttributes> filter = (path, basicFileAttributes) ->
             {

--- a/src/test/java/org/apache/cassandra/sidecar/TestModule.java
+++ b/src/test/java/org/apache/cassandra/sidecar/TestModule.java
@@ -59,15 +59,15 @@ public class TestModule extends AbstractModule
 
     @Provides
     @Singleton
-    public Configuration configuration()
+    public Configuration configuration(InstancesConfig instancesConfig)
     {
-        return abstractConfig();
+        return abstractConfig(instancesConfig);
     }
 
-    protected Configuration abstractConfig()
+    protected Configuration abstractConfig(InstancesConfig instancesConfig)
     {
         return new Configuration.Builder()
-               .setInstancesConfig(getInstancesConfig())
+               .setInstancesConfig(instancesConfig)
                .setHost("127.0.0.1")
                .setPort(6475)
                .setHealthCheckFrequency(1000)

--- a/src/test/java/org/apache/cassandra/sidecar/TestSslModule.java
+++ b/src/test/java/org/apache/cassandra/sidecar/TestSslModule.java
@@ -23,6 +23,8 @@ import java.io.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+
 /**
  * Changes to the TestModule to define SSL dependencies
  */
@@ -32,7 +34,7 @@ public class TestSslModule extends TestModule
 
 
     @Override
-    public Configuration abstractConfig()
+    public Configuration abstractConfig(InstancesConfig instancesConfig)
     {
         final String keyStorePath = TestSslModule.class.getClassLoader().getResource("certs/test.p12").getPath();
         final String keyStorePassword = "password";
@@ -50,7 +52,7 @@ public class TestSslModule extends TestModule
         }
 
         return new Configuration.Builder()
-                           .setInstancesConfig(getInstancesConfig())
+                           .setInstancesConfig(instancesConfig)
                            .setHost("127.0.0.1")
                            .setPort(6475)
                            .setHealthCheckFrequency(1000)

--- a/src/test/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandlerTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandlerTest.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.util.Modules;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
@@ -155,7 +157,7 @@ public class ListSnapshotFilesHandlerTest
                                                "snapshot1",
                                                "keyspace1",
                                                "table1-1234",
-                                               "secondary.db")
+                                               ".index/secondary.db")
         );
         ListSnapshotFilesResponse.FileInfo fileInfoNotExpected =
         new ListSnapshotFilesResponse.FileInfo(11,
@@ -194,17 +196,11 @@ public class ListSnapshotFilesHandlerTest
 
     class ListSnapshotTestModule extends AbstractModule
     {
-        @Override
-        protected void configure()
+        @Provides
+        @Singleton
+        public InstancesConfig getInstancesConfig() throws IOException
         {
-            try
-            {
-                bind(InstancesConfig.class).toInstance(mockInstancesConfig(temporaryFolder.getCanonicalPath()));
-            }
-            catch (IOException e)
-            {
-                throw new RuntimeException(e);
-            }
+            return mockInstancesConfig(temporaryFolder.getCanonicalPath());
         }
     }
 }

--- a/src/test/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandlerTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/routes/ListSnapshotFilesHandlerTest.java
@@ -103,7 +103,7 @@ public class ListSnapshotFilesHandlerTest
         ListSnapshotFilesResponse.FileInfo fileInfoExpected =
         new ListSnapshotFilesResponse.FileInfo(11,
                                                "localhost",
-                                               9043,
+                                               6475,
                                                0,
                                                "snapshot1",
                                                "keyspace1",
@@ -112,7 +112,7 @@ public class ListSnapshotFilesHandlerTest
         ListSnapshotFilesResponse.FileInfo fileInfoNotExpected =
         new ListSnapshotFilesResponse.FileInfo(11,
                                                "localhost",
-                                               9043,
+                                               6475,
                                                0,
                                                "snapshot1",
                                                "keyspace1",

--- a/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotDirectoryTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotDirectoryTest.java
@@ -1,0 +1,74 @@
+package org.apache.cassandra.sidecar.snapshots;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class SnapshotDirectoryTest
+{
+
+    @ParameterizedTest
+    @ValueSource(strings = { "not-valid", "/two-levels/not-valid", "three/levels/not-valid", "four/levels/not/valid" })
+    void failsOnInvalidLengthDirectory()
+    {
+        assertThatIllegalArgumentException()
+        .isThrownBy(() -> SnapshotDirectory.of("not-valid"))
+        .withMessageContaining("Invalid snapshotDirectory. Expected at least 5 parts but found");
+    }
+
+    @Test
+    void failsOnInvalidDirectory()
+    {
+        assertThatIllegalArgumentException()
+        .isThrownBy(() -> SnapshotDirectory.of("/cassandra/data/ks1/tbl2/sneaky/test-snapshot"))
+        .withMessage("Invalid snapshotDirectory. The expected directory structure is " +
+                     "'/<data_dir>/<ks>/<table>/snapshots/<snapshot_name>'");
+    }
+
+    @Test
+    void testValidDirectory1()
+    {
+        String snapshotDirectory = "/cassandra/data/ks1/tbl2/snapshots/test-snapshot";
+        SnapshotDirectory directory = SnapshotDirectory.of(snapshotDirectory);
+        assertThat(directory.dataDirectory).isEqualTo("/cassandra/data");
+        assertThat(directory.keyspace).isEqualTo("ks1");
+        assertThat(directory.tableName).isEqualTo("tbl2");
+        assertThat(directory.snapshotName).isEqualTo("test-snapshot");
+    }
+
+    @Test
+    void testValidDirectory2()
+    {
+        String snapshotDirectory = "/cassandra/data/ks1/tbl2/SNAPSHOTS/test-snapshot";
+        SnapshotDirectory directory = SnapshotDirectory.of(snapshotDirectory);
+        assertThat(directory.dataDirectory).isEqualTo("/cassandra/data");
+        assertThat(directory.keyspace).isEqualTo("ks1");
+        assertThat(directory.tableName).isEqualTo("tbl2");
+        assertThat(directory.snapshotName).isEqualTo("test-snapshot");
+    }
+
+    @Test
+    void testValidDirectory3()
+    {
+        String snapshotDirectory = "/datadir/inventory/shipping/snapshots/2022-07-23";
+        SnapshotDirectory directory = SnapshotDirectory.of(snapshotDirectory);
+        assertThat(directory.dataDirectory).isEqualTo("/datadir");
+        assertThat(directory.keyspace).isEqualTo("inventory");
+        assertThat(directory.tableName).isEqualTo("shipping");
+        assertThat(directory.snapshotName).isEqualTo("2022-07-23");
+    }
+
+    @Test
+    void testValidDirectory4()
+    {
+        String snapshotDirectory = "/cassandra/disk1/data/inventory/shipping/snapshots/2022-07-23/";
+        SnapshotDirectory directory = SnapshotDirectory.of(snapshotDirectory);
+        assertThat(directory.dataDirectory).isEqualTo("/cassandra/disk1/data");
+        assertThat(directory.keyspace).isEqualTo("inventory");
+        assertThat(directory.tableName).isEqualTo("shipping");
+        assertThat(directory.snapshotName).isEqualTo("2022-07-23");
+    }
+}

--- a/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotSearchTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotSearchTest.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.sidecar.snapshots;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -130,8 +129,7 @@ public class SnapshotSearchTest
         //noinspection rawtypes
         List<Future> futures = snapshotDirectories.stream()
                                                   .map(directory -> instance
-                                                                    .listSnapshotDirectory(host,
-                                                                                           directory,
+                                                                    .listSnapshotDirectory(directory,
                                                                                            includeSecondaryIndexFiles))
                                                   .collect(Collectors.toList());
 
@@ -146,18 +144,15 @@ public class SnapshotSearchTest
         List<String> snapshotFiles = ar.list()
                                        .stream()
                                        .flatMap(l -> ((List<SnapshotPathBuilder.SnapshotFile>) l).stream())
-                                       .map(SnapshotPathBuilder.SnapshotFile::getFileName)
+                                       .map(snapshotFile -> snapshotFile.path)
                                        .sorted()
                                        .collect(Collectors.toList());
 
         assertThat(snapshotFiles.size()).isEqualTo(expectedFiles.size());
 
-        List<String> expectedFileNames = expectedFiles.stream()
-                                                      .map(expectedFile -> Paths.get(expectedFile)
-                                                                                .getFileName()
-                                                                                .toString())
-                                                      .sorted()
-                                                      .collect(Collectors.toList());
-        assertThat(snapshotFiles).containsAll(expectedFileNames);
+        for (int i = 0; i < expectedFiles.size(); i++)
+        {
+            assertThat(snapshotFiles.get(i)).endsWith(expectedFiles.get(i));
+        }
     }
 }

--- a/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
+++ b/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
@@ -81,14 +81,14 @@ public class SnapshotUtils
         InstanceMetadataImpl localhost = new InstanceMetadataImpl(1,
                                                                   "localhost",
                                                                   9043,
-                                                                  Collections.singletonList(rootPath + "/d1/data"),
+                                                                  Collections.singletonList(rootPath + "/d1"),
                                                                   null,
                                                                   versionProvider,
                                                                   1000);
         InstanceMetadataImpl localhost2 = new InstanceMetadataImpl(2,
                                                                    "localhost2",
                                                                    9043,
-                                                                   Collections.singletonList(rootPath + "/d2/data"),
+                                                                   Collections.singletonList(rootPath + "/d2"),
                                                                    null,
                                                                    versionProvider,
                                                                    1000);


### PR DESCRIPTION
This commit fixes test setup in SnapshotUtils. Because of the incorrect test setup
the execution is providing incorrect results. For example, assume the following path

/cassandra-test/data/ks/tbl/snapshots/test-snapshot

The test was configuring data directories as ["/cassandra-test/data"], but in a real
execution data directories is provided as ["/cassandra-test"]. This is causing the
endpoint to return incorrect values in the JSON payload.

Additionally, the response was providing the port for Cassandra and not the Sidecar
port.