### PR TITLE
CASSANDRASC-49: Set the copyright profile on generating idea project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 }
 
 plugins {
+    id 'idea'
     id 'java'
     id 'java-test-fixtures'
     id 'application'
@@ -23,10 +24,7 @@ plugins {
     id 'com.google.cloud.tools.jib' version '2.2.0'
 }
 
-
-
 allprojects {
-    apply plugin: 'idea'
     apply plugin: 'jacoco'
     apply plugin: 'checkstyle'
     apply plugin: "com.github.spotbugs"
@@ -149,9 +147,13 @@ dependencies {
     testFixturesImplementation("io.vertx:vertx-web:${project.vertxVersion}")
 }
 
-task copyCodeStyle(type: Copy) {
-    from "ide/idea/codeStyleSettings.xml"
+task copyIdeaSettings(type: Copy) {
+    from "ide/idea"
     into ".idea"
+}
+
+tasks.named('idea').configure {
+    dependsOn copyIdeaSettings
 }
 
 // Lets copy the distributions from build/install directory to /bin and /lib

--- a/ide/idea/copyright/Apache_License_2_0.xml
+++ b/ide/idea/copyright/Apache_License_2_0.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="myName" value="Apache License 2.0" />
+    <option name="notice" value="Licensed to the Apache Software Foundation (ASF) under one&#10;or more contributor license agreements.  See the NOTICE file&#10;distributed with this work for additional information&#10;regarding copyright ownership.  The ASF licenses this file&#10;to you under the Apache License, Version 2.0 (the&#10;&quot;License&quot;); you may not use this file except in compliance&#10;with the License.  You may obtain a copy of the License at&#10;&#10;    http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+  </copyright>
+</component>

--- a/ide/idea/copyright/profiles_settings.xml
+++ b/ide/idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Apache License 2.0" />
+</component>


### PR DESCRIPTION
Automatically add the ApacheV2 license header to new files