### PR TITLE
CASSANDRASC-53 Ignore unknown properties during Sidecar client deseri…

### DIFF
--- a/client/src/main/java/org/apache/cassandra/sidecar/client/request/DecodableRequest.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/request/DecodableRequest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -34,7 +35,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public abstract class DecodableRequest<T> extends Request
 {
-    static final ObjectMapper MAPPER = new ObjectMapper();
+    static final ObjectMapper MAPPER = new ObjectMapper()
+                                       // ignore all the properties that are not declared
+                                       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     private final JavaType javaType = MAPPER.constructType(((ParameterizedType) this.getClass().getGenericSuperclass())
                                                            .getActualTypeArguments()[0]);
 

--- a/client/src/test/java/org/apache/cassandra/sidecar/client/request/DecodableRequestTest.java
+++ b/client/src/test/java/org/apache/cassandra/sidecar/client/request/DecodableRequestTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.client.request;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.cassandra.sidecar.common.NodeSettings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Unit tests for the {@link DecodableRequest} class
+ */
+class DecodableRequestTest
+{
+    DecodableRequest<NodeSettings> instance;
+
+    @BeforeEach
+    void setup()
+    {
+        instance = new DecodableRequest<NodeSettings>("https://cassandra-sidecar.com/api/test")
+        {
+            @Override
+            public HttpMethod method()
+            {
+                return HttpMethod.GET;
+            }
+        };
+    }
+
+    @Test
+    void testDecode() throws IOException
+    {
+        String nodeSettingsAsJsonString = "{\"partitioner\":\"partitioner-value\",\"releaseVersion\":\"1.0-TEST\"}";
+
+        NodeSettings nodeSettings = instance.decode(nodeSettingsAsJsonString.getBytes(StandardCharsets.UTF_8));
+        assertThat(nodeSettings.partitioner()).isEqualTo("partitioner-value");
+        assertThat(nodeSettings.releaseVersion()).isEqualTo("1.0-TEST");
+    }
+
+
+    @Test
+    void testDecodeIgnoresUnknownProperties() throws IOException
+    {
+        String nodeSettingsAsJsonString = "{\"partitioner\":\"partitioner-value\",\"releaseVersion\":\"1.0-TEST\"," +
+                                          "\"newProperty\":\"some-value\"}";
+
+        NodeSettings nodeSettings = instance.decode(nodeSettingsAsJsonString.getBytes(StandardCharsets.UTF_8));
+        assertThat(nodeSettings.partitioner()).isEqualTo("partitioner-value");
+        assertThat(nodeSettings.releaseVersion()).isEqualTo("1.0-TEST");
+    }
+
+    @Test
+    void testHeadersAreImmutable()
+    {
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+        .isThrownBy(() -> instance.headers().put("not", "allowed"));
+    }
+}


### PR DESCRIPTION
…alization

This commit modifies the way the `DecodableRequest` handles unknown properties in the JSON payload. To support the evolution of the server API, we allow the Sidecar Client to be more flexible when it encounters unknown properties, and we make it ignore these new properties.