### PR TITLE
CASSANDRASC-56: Create staging directory if it doesn't exists

### DIFF
--- a/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableCleanupHandler.java
+++ b/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableCleanupHandler.java
@@ -66,7 +66,7 @@ public class SSTableCleanupHandler extends AbstractHandler<String>
                                SocketAddress remoteAddress,
                                String uploadId)
     {
-        uploadPathBuilder.resolveStagingDirectory(host, uploadId)
+        uploadPathBuilder.resolveUploadIdDirectory(host, uploadId)
                          .compose(uploadPathBuilder::isValidDirectory)
                          .compose(stagingDirectory -> context.vertx()
                                                              .fileSystem()

--- a/src/main/java/org/apache/cassandra/sidecar/utils/BaseFileSystem.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/BaseFileSystem.java
@@ -97,6 +97,17 @@ public class BaseFileSystem
     }
 
     /**
+     * Creates the directory if it doesn't exist, and then validates that {@code path} is a valid directory.
+     *
+     * @param path the path to the directory
+     * @return a future of the validated {@code path}, a failed future otherwise
+     */
+    public Future<String> ensureDirectoryExists(String path)
+    {
+        return fs.mkdirs(path).compose(v -> Future.succeededFuture(path));
+    }
+
+    /**
      * @param filename  the path
      * @param predicate a predicate that evaluates based on {@link FileProps}
      * @return a future of the {@code filename} if it exists and {@code predicate} evaluates to true,

--- a/src/main/java/org/apache/cassandra/sidecar/utils/SSTableImporter.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/SSTableImporter.java
@@ -252,7 +252,7 @@ public class SSTableImporter
      */
     private void cleanup(ImportOptions options)
     {
-        uploadPathBuilder.resolveStagingDirectory(options.host, options.uploadId)
+        uploadPathBuilder.resolveUploadIdDirectory(options.host, options.uploadId)
                          .compose(uploadPathBuilder::isValidDirectory)
                          .compose(stagingDirectory -> vertx.fileSystem()
                                                            .deleteRecursive(stagingDirectory, true))

--- a/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandlerTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandlerTest.java
@@ -103,12 +103,17 @@ public class SSTableImportHandlerTest extends BaseUploadsHandlerTest
     }
 
     @Test
-    void testNonExistentUploadDirectory(VertxTestContext context)
+    void testNonExistentUploadDirectory(VertxTestContext context) throws InterruptedException
     {
         UUID uploadId = UUID.randomUUID();
-        client.put(config.getPort(), "localhost", "/api/v1/uploads/" + uploadId + "/keyspaces/ks/tables/table/import")
-              .expect(ResponsePredicate.SC_NOT_FOUND)
-              .send(context.succeedingThenComplete());
+
+        TableOperations mockCFOperations = mock(TableOperations.class);
+        when(mockDelegate.tableOperations()).thenReturn(mockCFOperations);
+
+        String requestURI = "/api/v1/uploads/" + uploadId + "/keyspaces/ks/tables/table/import";
+        clientRequest(context, requestURI,
+                      response -> assertThat(response.statusCode())
+                                  .isEqualTo(HttpResponseStatus.NOT_FOUND.code()));
     }
 
     @Test

--- a/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandlerTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandlerTest.java
@@ -57,7 +57,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     void testUploadWithoutMd5_expectSuccessfulUpload(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "without-md5.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.OK.code(), false);
     }
@@ -66,7 +65,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     void testUploadWithCorrectMd5_expectSuccessfulUpload(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "with-correct-md5.db", "jXd/OF09/siBXSD3SWAm3A==",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.OK.code(), false);
     }
@@ -75,7 +73,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     void testUploadWithIncorrectMd5_expectErrorCode(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "with-incorrect-md5.db", "incorrectMd5",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.BAD_REQUEST.code(),
                                    false);
@@ -85,7 +82,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     void testInvalidFileName_expectErrorCode(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "ks$tbl-me-4-big-Data.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.BAD_REQUEST.code(),
                                    false);
@@ -95,7 +91,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     void testUploadWithoutContentLength_expectSuccessfulUpload(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "without-content-length.db",
                                    "jXd/OF09/siBXSD3SWAm3A==", 0, HttpResponseStatus.OK.code(), false);
     }
@@ -106,7 +101,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
         // if we send more than actual length, vertx goes hung, probably looking for more data than exists in the file,
         // we should see timeout error in this case
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "with-higher-content-length.db", "", 1000, -1, true);
     }
 
@@ -114,7 +108,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     void testUploadWithLesserContentLength_expectSuccessfulUpload(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "with-lesser-content-length.db",
                                    "", Files.size(Paths.get(FILE_TO_BE_UPLOADED)) - 2, HttpResponseStatus.OK.code(),
                                    false);
@@ -124,7 +117,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     public void testInvalidKeyspace(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "invalidKeyspace", "tbl", "with-lesser-content-length.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.BAD_REQUEST.code(),
                                    false);
@@ -134,7 +126,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
     public void testInvalidTable(VertxTestContext context) throws IOException
     {
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "invalidTableName", "with-lesser-content-length.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.BAD_REQUEST.code(),
                                    false);
@@ -146,7 +137,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
         when(mockConfiguration.getMinSpacePercentRequiredForUpload()).thenReturn(100F);
 
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "without-md5.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)),
                                    HttpResponseStatus.INSUFFICIENT_STORAGE.code(), false);
@@ -158,7 +148,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
         when(mockConfiguration.getConcurrentUploadsLimit()).thenReturn(0);
 
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "without-md5.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)),
                                    HttpResponseStatus.TOO_MANY_REQUESTS.code(), false);
@@ -170,7 +159,6 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
         when(mockConfiguration.getConcurrentUploadsLimit()).thenReturn(1);
 
         UUID uploadId = UUID.randomUUID();
-        ensureStagingDirectoryExists();
         CountDownLatch latch = new CountDownLatch(1);
         sendUploadRequestAndVerify(latch, context, uploadId, "invalidKeyspace", "tbl", "without-md5.db", "",
                                    Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.BAD_REQUEST.code(),
@@ -250,10 +238,5 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
             }
             client.close();
         });
-    }
-
-    private void ensureStagingDirectoryExists() throws IOException
-    {
-        Files.createDirectories(Paths.get(SnapshotUtils.makeStagingDir(temporaryFolder.getAbsolutePath())));
     }
 }

--- a/src/test/java/org/apache/cassandra/sidecar/utils/SSTableImporterTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/utils/SSTableImporterTest.java
@@ -92,7 +92,7 @@ class SSTableImporterTest
         // get NullPointerExceptions because the mock is not wired up, and we need to prevent vertx from actually
         // doing a vertx.filesystem().deleteRecursive(). So we return a failed future with a fake path when checking
         // if the directory exists.
-        when(mockUploadPathBuilder.resolveStagingDirectory(anyString(), anyString()))
+        when(mockUploadPathBuilder.resolveUploadIdDirectory(anyString(), anyString()))
         .thenReturn(Future.failedFuture("fake-path"));
         when(mockUploadPathBuilder.isValidDirectory("fake-path")).thenReturn(Future.failedFuture("skip cleanup"));
         importer = new SSTableImporter(vertx, mockMetadataFetcher, mockConfiguration, executorPools,


### PR DESCRIPTION
During SSTable upload, the upload will fail if the configured staging directory does not exist. When this occurs an operator must manually create the directory, which increases the configuration toil.

In this commit, we automatically create the staging directory if it doesn't exists during SSTable upload. This improves the overall operational experience when running the Sidecar.