### PR TITLE
CASSANDRASC-58: Support retries in Sidecar Client on Invalid Checksum

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id "nebula.ospackage" version "8.3.0"
     id 'nebula.ospackage-application' version "8.3.0"
     id 'com.google.cloud.tools.jib' version '2.2.0'
+    id 'org.asciidoctor.jvm.convert' version '3.1.0'
 }
 
 ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-5.0.jar" // trunk is currently 5.0.jar - update when trunk moves

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compileOnly('org.jetbrains:annotations:23.0.0')
     compileOnly('com.google.code.findbugs:jsr305:3.0.2') // required for the @NotThreadSafe annotation
     compileOnly(group: 'com.datastax.cassandra', name: 'cassandra-driver-core', version: '3.11.3')
+    compileOnly(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
 
     testImplementation("com.google.guava:guava:${project.rootProject.guavaVersion}")
     testImplementation('org.mockito:mockito-inline:4.10.0')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
     testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
+    testImplementation(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
 }
 

--- a/common/src/main/java/org/apache/cassandra/sidecar/common/http/SidecarHttpResponseStatus.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/http/SidecarHttpResponseStatus.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.http;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Non-standard HTTP response status codes used in Sidecar
+ */
+public class SidecarHttpResponseStatus extends HttpResponseStatus
+{
+    /**
+     * 455 INVALID CHECKSUM
+     */
+    public static final HttpResponseStatus CHECKSUM_MISMATCH = newStatus(455, "Checksum Mismatch");
+
+    /**
+     * Creates a new instance with the specified {@code code} and its {@code reasonPhrase}.
+     *
+     * @param code         the HTTP status code
+     * @param reasonPhrase the HTTP status reason
+     */
+    public SidecarHttpResponseStatus(int code, String reasonPhrase)
+    {
+        super(code, reasonPhrase);
+    }
+
+    private static HttpResponseStatus newStatus(int statusCode, String reasonPhrase)
+    {
+        return new SidecarHttpResponseStatus(statusCode, reasonPhrase);
+    }
+}

--- a/common/src/test/java/org/apache/cassandra/sidecar/common/http/SidecarHttpResponseStatusTest.java
+++ b/common/src/test/java/org/apache/cassandra/sidecar/common/http/SidecarHttpResponseStatusTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.cassandra.sidecar.common.http.SidecarHttpResponseStatus.CHECKSUM_MISMATCH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SidecarHttpResponseStatus}
+ */
+class SidecarHttpResponseStatusTest
+{
+
+    @Test
+    void testInvalidChecksum()
+    {
+        assertThat(CHECKSUM_MISMATCH.code()).isEqualTo(455);
+        assertThat(CHECKSUM_MISMATCH.reasonPhrase()).isEqualTo("Checksum Mismatch");
+    }
+}

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,14 +1,4 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
-    }
-}
-
-apply plugin: 'org.asciidoctor.convert'
+apply plugin: 'org.asciidoctor.jvm.convert'
 
 asciidoctor {
     sourceDir = file("src")

--- a/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
@@ -31,7 +31,8 @@ import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.ext.web.handler.HttpException;
-import org.apache.cassandra.sidecar.common.http.SidecarHttpResponseStatus;
+
+import static org.apache.cassandra.sidecar.common.http.SidecarHttpResponseStatus.CHECKSUM_MISMATCH;
 
 /**
  * Implementation of {@link ChecksumVerifier}. Here we use MD5 implementation of {@link java.security.MessageDigest}
@@ -61,7 +62,7 @@ public class MD5ChecksumVerifier implements ChecksumVerifier
                  .compose(this::calculateMD5)
                  .compose(computedChecksum -> {
                      if (!expectedChecksum.equals(computedChecksum))
-                         return Future.failedFuture(new HttpException(SidecarHttpResponseStatus.CHECKSUM_MISMATCH.code(),
+                         return Future.failedFuture(new HttpException(CHECKSUM_MISMATCH.code(),
                                                                       String.format("Checksum mismatch. "
                                                                                     + "computed_checksum=%s, "
                                                                                     + "expected_checksum=%s, "

--- a/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
@@ -25,13 +25,13 @@ import java.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.ext.web.handler.HttpException;
+import org.apache.cassandra.sidecar.common.http.SidecarHttpResponseStatus;
 
 /**
  * Implementation of {@link ChecksumVerifier}. Here we use MD5 implementation of {@link java.security.MessageDigest}
@@ -61,7 +61,7 @@ public class MD5ChecksumVerifier implements ChecksumVerifier
                  .compose(this::calculateMD5)
                  .compose(computedChecksum -> {
                      if (!expectedChecksum.equals(computedChecksum))
-                         return Future.failedFuture(new HttpException(HttpResponseStatus.BAD_REQUEST.code(),
+                         return Future.failedFuture(new HttpException(SidecarHttpResponseStatus.CHECKSUM_MISMATCH.code(),
                                                                       String.format("Checksum mismatch. "
                                                                                     + "computed_checksum=%s, "
                                                                                     + "expected_checksum=%s, "

--- a/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandlerTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandlerTest.java
@@ -38,6 +38,7 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.http.SidecarHttpResponseStatus;
 import org.apache.cassandra.sidecar.snapshots.SnapshotUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,7 +78,8 @@ public class SSTableUploadHandlerTest extends BaseUploadsHandlerTest
         UUID uploadId = UUID.randomUUID();
         ensureStagingDirectoryExists();
         sendUploadRequestAndVerify(context, uploadId, "ks", "tbl", "with-incorrect-md5.db", "incorrectMd5",
-                                   Files.size(Paths.get(FILE_TO_BE_UPLOADED)), HttpResponseStatus.BAD_REQUEST.code(),
+                                   Files.size(Paths.get(FILE_TO_BE_UPLOADED)),
+                                   SidecarHttpResponseStatus.CHECKSUM_MISMATCH.code(),
                                    false);
     }
 


### PR DESCRIPTION
In rare occasions an SSTable upload will receive a corrupted SSTable. Bit flips are expected to occur occassionally while transmitting SSTables from client to server.

This commit adds support for retries in Sidecar Client when a checksum mismatch is encountered during SSTable upload. Allowing for clients to retry