### PR TITLE
CASSANDRASC-59: Expose JMX host and port from JMXClient

### DIFF
--- a/common/src/main/java/org/apache/cassandra/sidecar/common/JmxClient.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/JmxClient.java
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.VisibleForTesting;
  */
 public class JmxClient implements NotificationListener, Closeable
 {
-    public static final String JMX_SERVICE_URL_FMT = "service:jmx:rmi://%s/jndi/rmi://%s:%d/jmxrmi";
+    public static final String JMX_SERVICE_URL_FMT = "service:jmx:rmi://%s:%d/jndi/rmi://%s:%d/jmxrmi";
     public static final String REGISTRY_CONTEXT_SOCKET_FACTORY = "com.sun.jndi.rmi.factory.socket";
     private final JMXServiceURL jmxServiceURL;
     private MBeanServerConnection mBeanServerConnection;
@@ -203,14 +203,15 @@ public class JmxClient implements NotificationListener, Closeable
         if (host == null)
             return null;
 
-        if (host.contains(":"))
+        if (host.contains(":") && host.charAt(0) != '[')
         {
-            host = "[" + host + "]";
             // Use square brackets to surround IPv6 addresses to fix CASSANDRA-7669 and CASSANDRA-17581
+            host = "[" + host + "]";
         }
+
         try
         {
-            return new JMXServiceURL(String.format(JMX_SERVICE_URL_FMT, host, host, port));
+            return new JMXServiceURL(String.format(JMX_SERVICE_URL_FMT, host, port, host, port));
         }
         catch (MalformedURLException e)
         {

--- a/common/src/main/java/org/apache/cassandra/sidecar/common/JmxClient.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/JmxClient.java
@@ -188,6 +188,16 @@ public class JmxClient implements NotificationListener, Closeable
         return connected;
     }
 
+    public String host()
+    {
+        return jmxServiceURL.getHost();
+    }
+
+    public int port()
+    {
+        return jmxServiceURL.getPort();
+    }
+
     private static JMXServiceURL buildJmxServiceURL(String host, int port)
     {
         if (host == null)


### PR DESCRIPTION
In this commit, we expose the JMX host and port from JMXClient to make it available to implementations of the `ICassandraAdapter`.

This information can be valuable as different implementations and integrations need to have this information available during the application execution.