### PR TITLE
CASSANDRASC-61: Add Release Audit Tool (RAT) plugin to Sidecar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,8 @@ jobs:
     steps:
       - checkout
       - run: ./gradlew docs:asciidoctor
-      - run: test -f docs/build/html5/user.html
+      - run: test -f docs/build/user.html
+      - run: test -f docs/build/development.html
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Java Gradle CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-java/ for more details
@@ -49,7 +67,7 @@ jobs:
 
      - run: BRANCHES="cassandra-4.0 cassandra-4.1" scripts/build-dtest-jars.sh
      - run: echo 'export DTEST_JAR=$(cd dtest-jars && find . -name 'dtest-4.1*.jar' -maxdepth 1)' >> "$BASH_ENV"
-     - run: ./gradlew -i test integrationTest --stacktrace -Dcassandra.sidecar.versions_to_test="4.0,4.1"
+     - run: ./gradlew --info check --stacktrace -Dcassandra.sidecar.versions_to_test="4.0,4.1"
 
      - store_artifacts:
          path: build/reports
@@ -66,7 +84,7 @@ jobs:
       - checkout
 
       - run: CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -i test integrationTest --stacktrace
+      - run: ./gradlew --info check --stacktrace
 
       - store_artifacts:
           path: build/reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Contributing to Apache Cassandra Sidecar
 
 We warmly welcome and appreciate contributions from the community.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,3 +4,11 @@ Copyright 2023- The Apache Software Foundation
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
 
+
+Eclipse Public License - v 1.0,GNU Lesser General Public License
+
+Logback Classic Module (1.2.3)
+logback-classic module
+
+Logback Core Module (1.2.3)
+logback-core module

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,11 +4,3 @@ Copyright 2023- The Apache Software Foundation
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).
 
-
-Eclipse Public License - v 1.0,GNU Lesser General Public License
-
-Logback Classic Module (1.2.3)
-logback-classic module
-
-Logback Core Module (1.2.3)
-logback-core module

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Apache Cassandra Sidecar [WIP]
 
 This is a Sidecar for the highly scalable Apache Cassandra database.

--- a/adapters/base/build.gradle
+++ b/adapters/base/build.gradle
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 plugins {
     id 'java-library'
     id 'idea'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+
+import java.nio.file.Files
 import java.nio.file.Paths
 
 buildscript {
@@ -366,7 +368,7 @@ applicationDistribution.from("LICENSE.txt") {
 
 tasks.register('buildIgnoreRatList', Exec) {
     description 'Builds a list of ignored files for the rat task from the unversioned git files'
-    commandLine 'bash', '-c', 'git clean --force --dry-run -x | cut -c 14-'
+    commandLine 'bash', '-c', "git clean --force -d --dry-run -x | cut -c 14-"
     doFirst {
         standardOutput new FileOutputStream("${buildDir}/.rat-excludes.txt")
     }
@@ -375,8 +377,18 @@ tasks.register('buildIgnoreRatList', Exec) {
 }
 
 rat {
+
+    def excludeFilePath = Paths.get("${buildDir}/.rat-excludes.txt")
+    def excludeLines = Files.readAllLines(excludeFilePath)
+    excludeLines.each { line ->
+        if (line.endsWith("/")) {
+            excludes.add("**/" + line + "**")
+        } else {
+            excludes.add(line)
+        }
+    }
+
     // List of Gradle exclude directives, defaults to ['**/.gradle/**']
-    excludes.add("**/build/**")
     excludes.add("CHANGES.txt")
 
     // Documentation files
@@ -386,20 +398,8 @@ rat {
     excludes.add("gradlew")
     excludes.add("gradlew.bat")
 
-    // idea generated files
-    excludes.add("**/.idea/**")
-
     // resource files for test
     excludes.add("**/test**/resources/**")
-
-    // resources
-    excludes.add("**/resources/sidecar.version")
-
-    // script files
-    excludes.add("**/scripts/**")
-
-    // Rat excludes file, one directive per line
-    excludeFile.set(layout.projectDirectory.file("build/.rat-excludes.txt"))
 
     // XML, TXT and HTML reports directory, defaults to 'build/reports/rat'
     reportDir.set(file("build/reports/rat"))
@@ -412,4 +412,7 @@ copyDist.dependsOn installDist, copyJolokia
 check.dependsOn checkstyleMain, checkstyleTest, integrationTest, jacocoTestReport
 build.dependsOn copyDist, copyJolokia, copyDocs
 run.dependsOn build
-rat.dependsOn buildIgnoreRatList
+
+tasks.named('rat').configure {
+    dependsOn(buildIgnoreRatList)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -395,6 +395,9 @@ rat {
     // resources
     excludes.add("**/resources/sidecar.version")
 
+    // script files
+    excludes.add("**/scripts/**")
+
     // Rat excludes file, one directive per line
     excludeFile.set(layout.projectDirectory.file("build/.rat-excludes.txt"))
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.nio.file.Paths
 
 buildscript {
@@ -23,7 +42,11 @@ plugins {
     id 'nebula.ospackage-application' version "8.3.0"
     id 'com.google.cloud.tools.jib' version '2.2.0'
     id 'org.asciidoctor.jvm.convert' version '3.1.0'
+
+    // Release Audit Tool (RAT) plugin for checking project licenses
+    id("org.nosphere.apache.rat") version "0.8.0"
 }
+
 
 ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-5.0.jar" // trunk is currently 5.0.jar - update when trunk moves
 println("Using DTest jar: ${ext.dtestJar}")
@@ -341,6 +364,44 @@ applicationDistribution.from("LICENSE.txt") {
     into ""
 }
 
+tasks.register('buildIgnoreRatList', Exec) {
+    description 'Builds a list of ignored files for the rat task from the unversioned git files'
+    commandLine 'bash', '-c', 'git clean --force --dry-run -x | cut -c 14-'
+    doFirst {
+        standardOutput new FileOutputStream("${buildDir}/.rat-excludes.txt")
+    }
+    // allows task to fail when git/cut commands are unavailable or fail
+    ignoreExitValue = true
+}
+
+rat {
+    // List of Gradle exclude directives, defaults to ['**/.gradle/**']
+    excludes.add("**/build/**")
+    excludes.add("CHANGES.txt")
+
+    // Documentation files
+    excludes.add("**/docs/src/**")
+    // gradle files
+    excludes.add("gradle/**")
+    excludes.add("gradlew")
+    excludes.add("gradlew.bat")
+
+    // idea generated files
+    excludes.add("**/.idea/**")
+
+    // resource files for test
+    excludes.add("**/test**/resources/**")
+
+    // resources
+    excludes.add("**/resources/sidecar.version")
+
+    // Rat excludes file, one directive per line
+    excludeFile.set(layout.projectDirectory.file("build/.rat-excludes.txt"))
+
+    // XML, TXT and HTML reports directory, defaults to 'build/reports/rat'
+    reportDir.set(file("build/reports/rat"))
+}
+
 integrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
 
 // copyDist gets called on every build
@@ -348,3 +409,4 @@ copyDist.dependsOn installDist, copyJolokia
 check.dependsOn checkstyleMain, checkstyleTest, integrationTest, jacocoTestReport
 build.dependsOn copyDist, copyJolokia, copyDocs
 run.dependsOn build
+rat.dependsOn buildIgnoreRatList

--- a/build.gradle
+++ b/build.gradle
@@ -391,6 +391,7 @@ rat {
     }
 
     // List of Gradle exclude directives, defaults to ['**/.gradle/**']
+    excludes.add("**/build/**")
     excludes.add("CHANGES.txt")
 
     // Documentation files

--- a/build.gradle
+++ b/build.gradle
@@ -378,13 +378,15 @@ tasks.register('buildIgnoreRatList', Exec) {
 
 rat {
 
-    def excludeFilePath = Paths.get("${buildDir}/.rat-excludes.txt")
-    def excludeLines = Files.readAllLines(excludeFilePath)
-    excludeLines.each { line ->
-        if (line.endsWith("/")) {
-            excludes.add("**/" + line + "**")
-        } else {
-            excludes.add(line)
+    doFirst {
+        def excludeFilePath = Paths.get("${buildDir}/.rat-excludes.txt")
+        def excludeLines = Files.readAllLines(excludeFilePath)
+        excludeLines.each { line ->
+            if (line.endsWith("/")) {
+                excludes.add("**/" + line + "**")
+            } else {
+                excludes.add(line)
+            }
         }
     }
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,3 +1,23 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
 # Cassandra Sidecar Client
 
 The Sidecar Client is a fully featured client to access Cassandra Sidecar endpoints. It offers support for

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,5 +1,3 @@
-import java.nio.file.Paths
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -17,6 +15,8 @@ import java.nio.file.Paths
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import java.nio.file.Paths
 
 plugins {
     id('idea')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 plugins {
     id 'java-library'
     id "java-test-fixtures"

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 apply plugin: 'org.asciidoctor.jvm.convert'
 
 asciidoctor {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 version=1.0-SNAPSHOT
 junitVersion=5.9.2
 vertxVersion=4.2.1

--- a/ide/idea/codeStyleSettings.xml
+++ b/ide/idea/codeStyleSettings.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project version="4">
   <component name="ProjectCodeStyleSettingsManager">
     <option name="PER_PROJECT_SETTINGS">

--- a/ide/idea/copyright/profiles_settings.xml
+++ b/ide/idea/copyright/profiles_settings.xml
@@ -1,3 +1,20 @@
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <component name="CopyrightManager">
   <settings default="Apache License 2.0" />
 </component>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 rootProject.name = "cassandra-sidecar"
 
 include "adapters:base"

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <FindBugsFilter
         xmlns="https://spotbugs.readthedocs.io/en/stable/filter.html"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/main/dist/conf/sidecar.yaml
+++ b/src/main/dist/conf/sidecar.yaml
@@ -1,4 +1,22 @@
 #
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
 # Cassandra SideCar configuration file
 #
 cassandra_instances:

--- a/src/main/resources/docs/index.html
+++ b/src/main/resources/docs/index.html
@@ -1,5 +1,21 @@
 <!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitatins under the License.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8">

--- a/vertx-client/src/test/resources/log4j2.xml
+++ b/vertx-client/src/test/resources/log4j2.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <Configuration status="ERROR">
     <Properties>
         <Property name="LOG_PATTERN">%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} %p %m%n</Property>


### PR DESCRIPTION
This commit adds the Release Audit Tool (RAT) plugin to `build.gradle` which adds a new build task `rat`. This new task will make sure that the license headers are present in source files during the `check` task.

To run the RAT plugin, you can run:

```
./gradlew rat
```