### PR TITLE
CASSANDRASC-63: Support credential rotation in JmxClient

### DIFF
--- a/common/src/main/java/org/apache/cassandra/sidecar/common/JmxClient.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/JmxClient.java
@@ -170,6 +170,11 @@ public class JmxClient implements NotificationListener, Closeable
                                   : "JMX Authentication failed";
             throw new JmxAuthenticationException(errorMessage, securityException);
         }
+        catch (RuntimeException runtimeException)
+        {
+            // catch exceptions coming from the lambdas and wrap them in a JmxAuthenticationException
+            throw new JmxAuthenticationException(runtimeException);
+        }
     }
 
     @Override

--- a/common/src/main/java/org/apache/cassandra/sidecar/common/exceptions/JmxAuthenticationException.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/exceptions/JmxAuthenticationException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.exceptions;
+
+/**
+ * Exceptions encountered during JMX client authentication to the server
+ */
+public class JmxAuthenticationException extends RuntimeException
+{
+    /**
+     * Constructs a JMX authentication exception with the specified detail
+     * message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     */
+    public JmxAuthenticationException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * Constructs a JMX authentication exception with the specified detail
+     * message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     *                by the {@link #getMessage()} method).
+     * @param cause   the cause (which is saved for later retrieval by the
+     *                {@link #getCause()} method).  (A {@code null} value is
+     *                permitted, and indicates that the cause is nonexistent or
+     *                unknown.)
+     */
+    public JmxAuthenticationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/org/apache/cassandra/sidecar/common/exceptions/JmxAuthenticationException.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/exceptions/JmxAuthenticationException.java
@@ -36,6 +36,23 @@ public class JmxAuthenticationException extends RuntimeException
     }
 
     /**
+     * Constructs a JMX authentication exception with the specified cause
+     * and a detail message of {@code (cause==null ? null : cause.toString())}
+     * (which typically contains the class and detail message of
+     * {@code cause}).  This constructor is useful for runtime exceptions
+     * that are little more than wrappers for other throwables.
+     *
+     * @param cause the cause (which is saved for later retrieval by the
+     *              {@link #getCause()} method).  (A {@code null} value is
+     *              permitted, and indicates that the cause is nonexistent or
+     *              unknown.)
+     */
+    public JmxAuthenticationException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    /**
      * Constructs a JMX authentication exception with the specified detail
      * message and cause.
      *

--- a/src/test/java/org/apache/cassandra/sidecar/TestModule.java
+++ b/src/test/java/org/apache/cassandra/sidecar/TestModule.java
@@ -64,7 +64,7 @@ public class TestModule extends AbstractModule
     protected Configuration abstractConfig(InstancesConfig instancesConfig)
     {
         WorkerPoolConfiguration workPoolConf = new WorkerPoolConfiguration("test-pool", 10, 30000);
-        return new Configuration.Builder()
+        return new Configuration.Builder<>()
                .setInstancesConfig(instancesConfig)
                .setHost("127.0.0.1")
                .setPort(6475)

--- a/src/test/java/org/apache/cassandra/sidecar/TestSslModule.java
+++ b/src/test/java/org/apache/cassandra/sidecar/TestSslModule.java
@@ -18,7 +18,8 @@
 
 package org.apache.cassandra.sidecar;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,46 +35,49 @@ public class TestSslModule extends TestModule
 {
     private static final Logger logger = LoggerFactory.getLogger(TestSslModule.class);
 
-
     @Override
     public Configuration abstractConfig(InstancesConfig instancesConfig)
     {
-        final String keyStorePath = TestSslModule.class.getClassLoader().getResource("certs/test.p12").getPath();
-        final String keyStorePassword = "password";
+        String keyStorePath = TestSslModule.class.getClassLoader()
+                                                 .getResource("certs/test.p12")
+                                                 .getPath();
+        String keyStorePassword = "password";
 
-        final String trustStorePath = TestSslModule.class.getClassLoader().getResource("certs/ca.p12").getPath();
-        final String trustStorePassword = "password";
+        String trustStorePath = TestSslModule.class.getClassLoader()
+                                                         .getResource("certs/ca.p12")
+                                                         .getPath();
+        String trustStorePassword = "password";
 
-        if (!new File(keyStorePath).exists())
+        if (!Files.exists(Paths.get(keyStorePath)))
         {
-            logger.error("JMX password file not found");
+            logger.error("JMX password file not found in path={}", keyStorePath);
         }
-        if (!new File(trustStorePath).exists())
+        if (!Files.exists(Paths.get(trustStorePath)))
         {
-            logger.error("Trust Store file not found");
+            logger.error("Trust Store file not found in path={}", trustStorePath);
         }
 
         WorkerPoolConfiguration workerPoolConf = new WorkerPoolConfiguration("test-pool", 10,
                                                                              30000);
 
-        return new Configuration.Builder()
-                           .setInstancesConfig(instancesConfig)
-                           .setHost("127.0.0.1")
-                           .setPort(6475)
-                           .setHealthCheckFrequency(1000)
-                           .setKeyStorePath(keyStorePath)
-                           .setKeyStorePassword(keyStorePassword)
-                           .setTrustStorePath(trustStorePath)
-                           .setTrustStorePassword(trustStorePassword)
-                           .setSslEnabled(true)
-                           .setRateLimitStreamRequestsPerSecond(1)
-                           .setRequestIdleTimeoutMillis(300_000)
-                           .setRequestTimeoutMillis(300_000L)
-                           .setConcurrentUploadsLimit(80)
-                           .setMinSpacePercentRequiredForUploads(0)
-                           .setSSTableImportCacheConfiguration(new CacheConfiguration(60_000, 100))
-                           .setServerWorkerPoolConfiguration(workerPoolConf)
-                           .setServerInternalWorkerPoolConfiguration(workerPoolConf)
-                           .build();
+        return new Configuration.Builder<>()
+               .setInstancesConfig(instancesConfig)
+               .setHost("127.0.0.1")
+               .setPort(6475)
+               .setHealthCheckFrequency(1000)
+               .setKeyStorePath(keyStorePath)
+               .setKeyStorePassword(keyStorePassword)
+               .setTrustStorePath(trustStorePath)
+               .setTrustStorePassword(trustStorePassword)
+               .setSslEnabled(true)
+               .setRateLimitStreamRequestsPerSecond(1)
+               .setRequestIdleTimeoutMillis(300_000)
+               .setRequestTimeoutMillis(300_000L)
+               .setConcurrentUploadsLimit(80)
+               .setMinSpacePercentRequiredForUploads(0)
+               .setSSTableImportCacheConfiguration(new CacheConfiguration(60_000, 100))
+               .setServerWorkerPoolConfiguration(workerPoolConf)
+               .setServerInternalWorkerPoolConfiguration(workerPoolConf)
+               .build();
     }
 }


### PR DESCRIPTION
JMX credentials in a Cassandra instance can be rotated on a cadence, on every bounce, or by some other means. In those cases, the `JmxClient` will no longer be able to connect to the instance completely losing the ability to talk to that instance.

In this commit, we allow the `JmxClient` to support credential changes to be continue to talk to the Cassandra instance uninterrupted without any potential downtime to the Sidecar service.