### PR TITLE
CASSANDRASC-64: File descriptor is not being closed on MD5 checksum

### DIFF
--- a/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
+++ b/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
@@ -129,6 +129,20 @@ public class SSTableUploadHandler extends AbstractHandler<SSTableUploadRequest>
         .onFailure(cause -> processFailure(cause, context, host, remoteAddress, request));
     }
 
+    @Override
+    protected void processFailure(Throwable cause, RoutingContext context, String host, SocketAddress remoteAddress,
+                                  SSTableUploadRequest request)
+    {
+        if (cause instanceof IllegalArgumentException)
+        {
+            context.fail(wrapHttpException(HttpResponseStatus.BAD_REQUEST, cause));
+        }
+        else
+        {
+            super.processFailure(cause, context, host, remoteAddress, request);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
+++ b/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
@@ -135,7 +135,7 @@ public class SSTableUploadHandler extends AbstractHandler<SSTableUploadRequest>
     {
         if (cause instanceof IllegalArgumentException)
         {
-            context.fail(wrapHttpException(HttpResponseStatus.BAD_REQUEST, cause));
+            context.fail(wrapHttpException(HttpResponseStatus.BAD_REQUEST, cause.getMessage(), cause));
         }
         else
         {

--- a/src/main/java/org/apache/cassandra/sidecar/utils/HttpExceptions.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/HttpExceptions.java
@@ -54,7 +54,7 @@ public class HttpExceptions
      */
     public static HttpException wrapHttpException(HttpResponseStatus status, Throwable cause)
     {
-        return wrapHttpException(status, cause != null ? cause.getMessage() : null, cause);
+        return wrapHttpException(status, null, cause);
     }
 
     /**

--- a/src/main/java/org/apache/cassandra/sidecar/utils/HttpExceptions.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/HttpExceptions.java
@@ -54,7 +54,7 @@ public class HttpExceptions
      */
     public static HttpException wrapHttpException(HttpResponseStatus status, Throwable cause)
     {
-        return wrapHttpException(status, null, cause);
+        return wrapHttpException(status, cause != null ? cause.getMessage() : null, cause);
     }
 
     /**

--- a/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
@@ -93,12 +93,12 @@ public class MD5ChecksumVerifier implements ChecksumVerifier
             .handler(buf -> digest.update(buf.getBytes()))
             .endHandler(_v -> {
                 result.complete(Base64.getEncoder().encodeToString(digest.digest()));
-                file.end();
+//                file.end();
             })
             .exceptionHandler(cause -> {
                 LOGGER.error("Error while calculating MD5 checksum", cause);
                 result.fail(cause);
-                file.end();
+//                file.end();
             })
             .resume();
         return result.future();

--- a/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifier.java
@@ -31,6 +31,7 @@ import io.vertx.core.file.AsyncFile;
 import io.vertx.core.file.FileSystem;
 import io.vertx.core.file.OpenOptions;
 import io.vertx.ext.web.handler.HttpException;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import static org.apache.cassandra.sidecar.common.http.SidecarHttpResponseStatus.CHECKSUM_MISMATCH;
 
@@ -75,7 +76,8 @@ public class MD5ChecksumVerifier implements ChecksumVerifier
                  });
     }
 
-    private Future<String> calculateMD5(AsyncFile file)
+    @VisibleForTesting
+    Future<String> calculateMD5(AsyncFile file)
     {
         MessageDigest digest;
         try
@@ -93,12 +95,12 @@ public class MD5ChecksumVerifier implements ChecksumVerifier
             .handler(buf -> digest.update(buf.getBytes()))
             .endHandler(_v -> {
                 result.complete(Base64.getEncoder().encodeToString(digest.digest()));
-//                file.end();
+                file.end();
             })
             .exceptionHandler(cause -> {
                 LOGGER.error("Error while calculating MD5 checksum", cause);
                 result.fail(cause);
-//                file.end();
+                file.end();
             })
             .resume();
         return result.future();

--- a/src/main/java/org/apache/cassandra/sidecar/utils/SSTableImporter.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/SSTableImporter.java
@@ -18,10 +18,10 @@
 
 package org.apache.cassandra.sidecar.utils;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -86,7 +86,7 @@ public class SSTableImporter
         this.executorPools = executorPools;
         this.metadataFetcher = metadataFetcher;
         this.uploadPathBuilder = uploadPathBuilder;
-        this.importQueuePerHost = new HashMap<>();
+        this.importQueuePerHost = new ConcurrentHashMap<>();
         executorPools.internal()
                      .setPeriodic(configuration.getSSTableImportPollIntervalMillis(), this::processPendingImports);
     }

--- a/src/main/java/org/apache/cassandra/sidecar/utils/SSTableUploader.java
+++ b/src/main/java/org/apache/cassandra/sidecar/utils/SSTableUploader.java
@@ -88,7 +88,8 @@ public class SSTableUploader
     {
         // pipe read stream to temp file
         return streamToFile(readStream, tempFilePath)
-               .compose(v -> checksumVerifier.verify(expectedChecksum, tempFilePath));
+               .compose(v -> checksumVerifier.verify(expectedChecksum, tempFilePath))
+               .onFailure(throwable -> fs.delete(tempFilePath));
     }
 
     private Future<Void> streamToFile(ReadStream<Buffer> readStream, String tempFilename)

--- a/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
@@ -63,7 +63,7 @@ class MD5ChecksumVerifierTest
     void testFileDescriptorsClosed() throws IOException, NoSuchAlgorithmException,
                                             InterruptedException
     {
-        int iterationCount = 100_000;
+        int iterationCount = 50_000;
         byte[] randomBytes = generateRandomBytes();
         Path randomFilePath = writeBytesToRandomFile(randomBytes);
         String expectedChecksum = Base64.getEncoder()
@@ -88,7 +88,7 @@ class MD5ChecksumVerifierTest
             if (i % 1000 == 0)
             {
                 // Slow down to prevent OOMs
-                Thread.sleep(TimeUnit.MILLISECONDS.toMillis(100));
+                Thread.sleep(TimeUnit.MILLISECONDS.toMillis(500));
                 LOGGER.info("Processed {} elements, latch={}", i, latch.getCount());
             }
         }

--- a/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.utils;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MD5ChecksumVerifier}
+ */
+class MD5ChecksumVerifierTest
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(MD5ChecksumVerifierTest.class);
+
+    static Vertx vertx;
+    static MD5ChecksumVerifier verifier;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void setup()
+    {
+        vertx = Vertx.vertx();
+        verifier = new MD5ChecksumVerifier(vertx.fileSystem());
+    }
+
+    @Test
+    void testFileDescriptorsClosed() throws IOException, NoSuchAlgorithmException,
+                                            InterruptedException
+    {
+        int iterationCount = 100_000;
+        byte[] randomBytes = generateRandomBytes();
+        Path randomFilePath = writeBytesToRandomFile(randomBytes);
+        String expectedChecksum = Base64.getEncoder()
+                                        .encodeToString(MessageDigest.getInstance("MD5")
+                                                                     .digest(randomBytes));
+
+        CountDownLatch latch = new CountDownLatch(iterationCount);
+        for (int i = 0; i < iterationCount; i++)
+        {
+            Future<String> result;
+            // we should exceed the file descriptor limit in most systems, 4096 is the default in some systems
+            if (i % 2 == 0)
+            {
+                result = verifier.verify(expectedChecksum, randomFilePath.toAbsolutePath().toString());
+            }
+            else
+            {
+                result = verifier.verify("invalid", randomFilePath.toAbsolutePath().toString());
+            }
+
+            result.onComplete(complete -> latch.countDown());
+            if (i % 1000 == 0)
+            {
+                // Slow down to prevent OOMs
+                Thread.sleep(TimeUnit.MILLISECONDS.toMillis(100));
+                LOGGER.info("Processed {} elements, latch={}", i, latch.getCount());
+            }
+        }
+
+        assertThat(latch.await(90, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private byte[] generateRandomBytes()
+    {
+        byte[] bytes = new byte[1024];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+
+    private Path writeBytesToRandomFile(byte[] bytes) throws IOException
+    {
+        Path tempPath = tempDir.resolve("random-file.txt");
+        try (RandomAccessFile writer = new RandomAccessFile(tempPath.toFile(), "rw"))
+        {
+            writer.write(bytes);
+        }
+        return tempPath;
+    }
+}

--- a/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
@@ -84,7 +84,7 @@ class MD5ChecksumVerifierTest
         verifier.verify(checksum, filePath.toAbsolutePath().toString())
                 .onComplete(complete -> latch.countDown());
 
-        assertThat(latch.await(90, TimeUnit.SECONDS)).isTrue();
+        assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
 
         assertThat(verifier.file).isNotNull();
         // we can't close the file if it's already closed, so we expect the exception here

--- a/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/utils/MD5ChecksumVerifierTest.java
@@ -31,23 +31,22 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.file.AsyncFile;
+import io.vertx.core.file.FileSystem;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for {@link MD5ChecksumVerifier}
  */
 class MD5ChecksumVerifierTest
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MD5ChecksumVerifierTest.class);
-
     static Vertx vertx;
-    static MD5ChecksumVerifier verifier;
+    static ExposeAsyncFileMD5ChecksumVerifier verifier;
 
     @TempDir
     Path tempDir;
@@ -56,44 +55,42 @@ class MD5ChecksumVerifierTest
     static void setup()
     {
         vertx = Vertx.vertx();
-        verifier = new MD5ChecksumVerifier(vertx.fileSystem());
+        verifier = new ExposeAsyncFileMD5ChecksumVerifier(vertx.fileSystem());
     }
 
     @Test
-    void testFileDescriptorsClosed() throws IOException, NoSuchAlgorithmException,
-                                            InterruptedException
+    void testFileDescriptorsClosedWithValidChecksum() throws IOException, NoSuchAlgorithmException,
+                                                             InterruptedException
     {
-        int iterationCount = 50_000;
         byte[] randomBytes = generateRandomBytes();
         Path randomFilePath = writeBytesToRandomFile(randomBytes);
         String expectedChecksum = Base64.getEncoder()
                                         .encodeToString(MessageDigest.getInstance("MD5")
                                                                      .digest(randomBytes));
 
-        CountDownLatch latch = new CountDownLatch(iterationCount);
-        for (int i = 0; i < iterationCount; i++)
-        {
-            Future<String> result;
-            // we should exceed the file descriptor limit in most systems, 4096 is the default in some systems
-            if (i % 2 == 0)
-            {
-                result = verifier.verify(expectedChecksum, randomFilePath.toAbsolutePath().toString());
-            }
-            else
-            {
-                result = verifier.verify("invalid", randomFilePath.toAbsolutePath().toString());
-            }
+        runTestScenario(randomFilePath, expectedChecksum);
+    }
 
-            result.onComplete(complete -> latch.countDown());
-            if (i % 1000 == 0)
-            {
-                // Slow down to prevent OOMs
-                Thread.sleep(TimeUnit.MILLISECONDS.toMillis(500));
-                LOGGER.info("Processed {} elements, latch={}", i, latch.getCount());
-            }
-        }
+    @Test
+    void testFileDescriptorsClosedWithInvalidChecksum() throws IOException, InterruptedException
+    {
+        Path randomFilePath = writeBytesToRandomFile(generateRandomBytes());
+        runTestScenario(randomFilePath, "invalid");
+    }
+
+    private void runTestScenario(Path filePath, String checksum) throws InterruptedException
+    {
+        CountDownLatch latch = new CountDownLatch(1);
+        verifier.verify(checksum, filePath.toAbsolutePath().toString())
+                .onComplete(complete -> latch.countDown());
 
         assertThat(latch.await(90, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(verifier.file).isNotNull();
+        // we can't close the file if it's already closed, so we expect the exception here
+        assertThatThrownBy(() -> verifier.file.end())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("File handle is closed");
     }
 
     private byte[] generateRandomBytes()
@@ -111,5 +108,26 @@ class MD5ChecksumVerifierTest
             writer.write(bytes);
         }
         return tempPath;
+    }
+
+    /**
+     * Class that extends from {@link MD5ChecksumVerifier} for testing purposes and holds a reference to the
+     * {@link AsyncFile} to ensure that the file has been closed.
+     */
+    static class ExposeAsyncFileMD5ChecksumVerifier extends MD5ChecksumVerifier
+    {
+        AsyncFile file;
+
+        public ExposeAsyncFileMD5ChecksumVerifier(FileSystem fs)
+        {
+            super(fs);
+        }
+
+        @Override
+        Future<String> calculateMD5(AsyncFile file)
+        {
+            this.file = file;
+            return super.calculateMD5(file);
+        }
     }
 }


### PR DESCRIPTION
This commit fixes an issue where the file descriptors are not being closed during the MD5 checksum during SSTable upload. This can potentially cause the JVM to run out of available file descriptors during execution, and it would force an operator to restart the Sidecar process to return to a working state.

In this commit, we ensure the file is closed after the checksum is calculated.

Additionally, this commit fixes a rare ConcurrentModificationException encountered in `SSTableImporter` whree the `importQueuePerHost` does not use a thread-safe map.