### PR TITLE
[CASSANDRASC-70] Added Client Methods for Obtaining Sidecar and Cassandra Health

### DIFF
--- a/client/src/main/java/org/apache/cassandra/sidecar/client/RequestContext.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/RequestContext.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.cassandra.sidecar.client.request.CassandraHealthRequest;
 import org.apache.cassandra.sidecar.client.request.CleanSSTableUploadSessionRequest;
 import org.apache.cassandra.sidecar.client.request.ClearSnapshotRequest;
 import org.apache.cassandra.sidecar.client.request.CreateSnapshotRequest;
@@ -33,6 +34,7 @@ import org.apache.cassandra.sidecar.client.request.Request;
 import org.apache.cassandra.sidecar.client.request.RingRequest;
 import org.apache.cassandra.sidecar.client.request.SSTableComponentRequest;
 import org.apache.cassandra.sidecar.client.request.SchemaRequest;
+import org.apache.cassandra.sidecar.client.request.SidecarHealthRequest;
 import org.apache.cassandra.sidecar.client.request.TimeSkewRequest;
 import org.apache.cassandra.sidecar.client.request.UploadSSTableRequest;
 import org.apache.cassandra.sidecar.client.retry.ExponentialBackoffRetryPolicy;
@@ -48,6 +50,8 @@ import org.apache.cassandra.sidecar.common.utils.HttpRange;
  */
 public class RequestContext
 {
+    protected static final SidecarHealthRequest SIDECAR_HEALTH_REQUEST = new SidecarHealthRequest();
+    protected static final CassandraHealthRequest CASSANDRA_HEALTH_REQUEST = new CassandraHealthRequest();
     protected static final SchemaRequest FULL_SCHEMA_REQUEST = new SchemaRequest();
     protected static final TimeSkewRequest TIME_SKEW_REQUEST = new TimeSkewRequest();
     protected static final NodeSettingsRequest NODE_SETTINGS_REQUEST = new NodeSettingsRequest();
@@ -171,6 +175,28 @@ public class RequestContext
         {
             this.retryPolicy = retryPolicy;
             return this;
+        }
+
+        /**
+         * Sets the {@code request} to be a {@link SidecarHealthRequest}
+         * and returns a reference to this Builder enabling method chaining
+         *
+         * @return a reference to this Builder
+         */
+        public Builder sidecarHealthRequest()
+        {
+            return request(SIDECAR_HEALTH_REQUEST);
+        }
+
+        /**
+         * Sets the {@code request} to be a {@link CassandraHealthRequest}
+         * and returns a reference to this Builder enabling method chaining
+         *
+         * @return a reference to this Builder
+         */
+        public Builder cassandraHealthRequest()
+        {
+            return request(CASSANDRA_HEALTH_REQUEST);
         }
 
         /**

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
@@ -28,12 +28,14 @@ import org.slf4j.LoggerFactory;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.cassandra.sidecar.client.request.ImportSSTableRequest;
 import org.apache.cassandra.sidecar.client.retry.IgnoreConflictRetryPolicy;
+import org.apache.cassandra.sidecar.client.retry.OncePerInstanceRetryPolicy;
 import org.apache.cassandra.sidecar.client.retry.RetryPolicy;
 import org.apache.cassandra.sidecar.client.retry.RunnableOnStatusCodeRetryPolicy;
 import org.apache.cassandra.sidecar.client.selection.InstanceSelectionPolicy;
 import org.apache.cassandra.sidecar.client.selection.RandomInstanceSelectionPolicy;
 import org.apache.cassandra.sidecar.common.NodeSettings;
 import org.apache.cassandra.sidecar.common.data.GossipInfoResponse;
+import org.apache.cassandra.sidecar.common.data.HealthResponse;
 import org.apache.cassandra.sidecar.common.data.ListSnapshotFilesResponse;
 import org.apache.cassandra.sidecar.common.data.RingResponse;
 import org.apache.cassandra.sidecar.common.data.SSTableImportResponse;
@@ -66,6 +68,32 @@ public class SidecarClient implements AutoCloseable
                       .instanceSelectionPolicy(new RandomInstanceSelectionPolicy(instancesProvider))
                       .retryPolicy(defaultRetryPolicy);
         executor = requestExecutor;
+    }
+
+    /**
+     * Executes the Sidecar health request using the configured selection policy and with no retries
+     *
+     * @return a completable future of the Sidecar health response
+     */
+    public CompletableFuture<HealthResponse> sidecarHealth()
+    {
+        return executor.executeRequestAsync(requestBuilder()
+                .sidecarHealthRequest()
+                .retryPolicy(new OncePerInstanceRetryPolicy())
+                .build());
+    }
+
+    /**
+     * Executes the Cassandra health request using the configured selection policy and with no retries
+     *
+     * @return a completable future of the Cassandra health response
+     */
+    public CompletableFuture<HealthResponse> cassandraHealth()
+    {
+        return executor.executeRequestAsync(requestBuilder()
+                .cassandraHealthRequest()
+                .retryPolicy(new OncePerInstanceRetryPolicy())
+                .build());
     }
 
     /**

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/request/CassandraHealthRequest.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/request/CassandraHealthRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.client.request;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.data.HealthResponse;
+
+/**
+ * Represents a request to retrieve the Cassandra health
+ */
+public class CassandraHealthRequest extends DecodableRequest<HealthResponse>
+{
+    /**
+     * Constructs a request to retrieve the Cassandra health
+     */
+    public CassandraHealthRequest()
+    {
+        super(ApiEndpointsV1.CASSANDRA_HEALTH_ROUTE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethod method()
+    {
+        return HttpMethod.GET;
+    }
+}

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/request/SidecarHealthRequest.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/request/SidecarHealthRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.client.request;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.data.HealthResponse;
+
+/**
+ * Represents a request to retrieve the Sidecar health
+ */
+public class SidecarHealthRequest extends DecodableRequest<HealthResponse>
+{
+    /**
+     * Constructs a request to retrieve the Sidecar health
+     */
+    public SidecarHealthRequest()
+    {
+        super(ApiEndpointsV1.HEALTH_ROUTE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethod method()
+    {
+        return HttpMethod.GET;
+    }
+}

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/retry/OncePerInstanceRetryPolicy.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/retry/OncePerInstanceRetryPolicy.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.client.retry;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.cassandra.sidecar.client.HttpResponse;
+import org.apache.cassandra.sidecar.client.exception.RetriesExhaustedException;
+import org.apache.cassandra.sidecar.client.request.Request;
+
+/**
+ * A retry policy that attempts to execute the request once on each instance
+ * until the first successful response is received, or fails if none were successful
+ */
+public class OncePerInstanceRetryPolicy extends RetryPolicy
+{
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onResponse(CompletableFuture<HttpResponse> responseFuture,
+                           Request request,
+                           HttpResponse response,
+                           Throwable throwable,
+                           int attempts,
+                           boolean canRetryOnADifferentHost,
+                           RetryAction retryAction)
+    {
+        if (response != null && response.statusCode() == HttpResponseStatus.OK.code())
+        {
+            responseFuture.complete(response);
+        }
+        else if (canRetryOnADifferentHost)
+        {
+            retryAction.retry(attempts + 1, 0L);
+        }
+        else
+        {
+            responseFuture.completeExceptionally(RetriesExhaustedException.of(attempts, request, response, throwable));
+        }
+    }
+}

--- a/common/src/main/java/org/apache/cassandra/sidecar/common/data/HealthResponse.java
+++ b/common/src/main/java/org/apache/cassandra/sidecar/common/data/HealthResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.data;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A class representing a response for a health request
+ * (either {@code SidecarHealthRequest} or {@code CassandraHealthRequest})
+ */
+public class HealthResponse
+{
+    @NotNull
+    private final String status;
+
+    /**
+     * Constructs a {@link HealthResponse} object with the given {@code status}
+     *
+     * @param status the status
+     */
+    public HealthResponse(@NotNull @JsonProperty("status") String status)
+    {
+        this.status = Objects.requireNonNull(status, "status must not be null").toUpperCase();
+    }
+
+    /**
+     * @return the status
+     */
+    @JsonProperty("status")
+    public String status()
+    {
+        return status;
+    }
+
+    /**
+     * @return whether the status is OK
+     */
+    @JsonIgnore
+    public boolean isOk()
+    {
+        return status.equals("OK");
+    }
+}


### PR DESCRIPTION
Methods for obtaining Sidecar and Cassandra health need to be added to the client.
Both of these methods will be used for start-up validation by the Analytics library.