### PR TITLE
CASSANDRASC-71 Allow configuring permissions for uploaded SSTables

### DIFF
--- a/src/main/dist/conf/sidecar.yaml
+++ b/src/main/dist/conf/sidecar.yaml
@@ -75,6 +75,7 @@ sidecar:
   sstable_upload:
     concurrent_upload_limit: 80
     min_free_space_percent: 10
+    # file_permissions: "rw-r--r--" # when not specified, the default file permissions are owner read & write, group & others read
   allowable_time_skew_in_minutes: 60
   sstable_import:
     poll_interval_millis: 100

--- a/src/main/java/org/apache/cassandra/sidecar/config/SSTableUploadConfiguration.java
+++ b/src/main/java/org/apache/cassandra/sidecar/config/SSTableUploadConfiguration.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.sidecar.config;
 
+import java.nio.file.attribute.PosixFilePermission;
+
 /**
  * Configuration for SSTable component uploads on this service
  */
@@ -32,4 +34,15 @@ public interface SSTableUploadConfiguration
      * @return the configured minimum space percentage required for an SSTable component upload
      */
     float minimumSpacePercentageRequired();
+
+    /**
+     * Returns the String representation of a set of posix file permissions used during an SSTable file upload.
+     * When an SSTable file is created the specified permissions will be used to create the file.
+     * For example, the String {@code rw-r--r--} represents the set of permissions
+     * {@link PosixFilePermission#OWNER_READ}, {@link PosixFilePermission#OWNER_WRITE},
+     * {@link PosixFilePermission#GROUP_READ}, and {@link PosixFilePermission#OTHERS_READ}.
+     *
+     * @return the String representation of a set of posix file permissions used during an SSTable file upload
+     */
+    String filePermissions();
 }

--- a/src/main/java/org/apache/cassandra/sidecar/config/yaml/SSTableUploadConfigurationImpl.java
+++ b/src/main/java/org/apache/cassandra/sidecar/config/yaml/SSTableUploadConfigurationImpl.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.sidecar.config.yaml;
 
+import java.nio.file.attribute.PosixFilePermissions;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.sidecar.config.SSTableUploadConfiguration;
 
@@ -28,8 +30,12 @@ public class SSTableUploadConfigurationImpl implements SSTableUploadConfiguratio
 {
     public static final String CONCURRENT_UPLOAD_LIMIT_PROPERTY = "concurrent_upload_limit";
     public static final int DEFAULT_CONCURRENT_UPLOAD_LIMIT = 80;
+
     public static final String MIN_FREE_SPACE_PERCENT_PROPERTY = "min_free_space_percent";
     public static final float DEFAULT_MIN_FREE_SPACE_PERCENT = 10;
+
+    public static final String FILE_PERMISSIONS_PROPERTY = "file_permissions";
+    public static final String DEFAULT_FILE_PERMISSIONS = "rw-r--r--";
 
     @JsonProperty(value = CONCURRENT_UPLOAD_LIMIT_PROPERTY, defaultValue = DEFAULT_CONCURRENT_UPLOAD_LIMIT + "")
     protected final int concurrentUploadsLimit;
@@ -37,30 +43,39 @@ public class SSTableUploadConfigurationImpl implements SSTableUploadConfiguratio
     @JsonProperty(value = MIN_FREE_SPACE_PERCENT_PROPERTY, defaultValue = DEFAULT_MIN_FREE_SPACE_PERCENT + "")
     protected final float minimumSpacePercentageRequired;
 
+    protected String filePermissions;
+
     public SSTableUploadConfigurationImpl()
     {
-        this(DEFAULT_CONCURRENT_UPLOAD_LIMIT, DEFAULT_MIN_FREE_SPACE_PERCENT);
+        this(DEFAULT_CONCURRENT_UPLOAD_LIMIT, DEFAULT_MIN_FREE_SPACE_PERCENT, DEFAULT_FILE_PERMISSIONS);
     }
 
     public SSTableUploadConfigurationImpl(int concurrentUploadsLimit)
     {
-        this(concurrentUploadsLimit, DEFAULT_MIN_FREE_SPACE_PERCENT);
+        this(concurrentUploadsLimit, DEFAULT_MIN_FREE_SPACE_PERCENT, DEFAULT_FILE_PERMISSIONS);
     }
 
     public SSTableUploadConfigurationImpl(float minimumSpacePercentageRequired)
     {
-        this(DEFAULT_CONCURRENT_UPLOAD_LIMIT, minimumSpacePercentageRequired);
+        this(DEFAULT_CONCURRENT_UPLOAD_LIMIT, minimumSpacePercentageRequired, DEFAULT_FILE_PERMISSIONS);
+    }
+
+    public SSTableUploadConfigurationImpl(String filePermissions)
+    {
+        this(DEFAULT_CONCURRENT_UPLOAD_LIMIT, DEFAULT_MIN_FREE_SPACE_PERCENT, filePermissions);
     }
 
     public SSTableUploadConfigurationImpl(int concurrentUploadsLimit,
-                                          float minimumSpacePercentageRequired)
+                                          float minimumSpacePercentageRequired,
+                                          String filePermissions)
     {
         this.concurrentUploadsLimit = concurrentUploadsLimit;
         this.minimumSpacePercentageRequired = minimumSpacePercentageRequired;
+        setFilePermissions(filePermissions);
     }
 
     /**
-     * @return the maximum number of concurrent SSTable component uploads allowed for this service
+     * {@inheritDoc}
      */
     @Override
     @JsonProperty(value = CONCURRENT_UPLOAD_LIMIT_PROPERTY, defaultValue = DEFAULT_CONCURRENT_UPLOAD_LIMIT + "")
@@ -70,12 +85,45 @@ public class SSTableUploadConfigurationImpl implements SSTableUploadConfiguratio
     }
 
     /**
-     * @return the configured minimum space percentage required for an SSTable component upload
+     * {@inheritDoc}
      */
     @Override
     @JsonProperty(value = MIN_FREE_SPACE_PERCENT_PROPERTY, defaultValue = DEFAULT_MIN_FREE_SPACE_PERCENT + "")
     public float minimumSpacePercentageRequired()
     {
         return minimumSpacePercentageRequired;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonProperty(value = FILE_PERMISSIONS_PROPERTY, defaultValue = DEFAULT_FILE_PERMISSIONS)
+    public String filePermissions()
+    {
+        return filePermissions;
+    }
+
+    @JsonProperty(value = FILE_PERMISSIONS_PROPERTY, defaultValue = DEFAULT_FILE_PERMISSIONS)
+    public void setFilePermissions(String filePermissions)
+    {
+        if (filePermissions != null)
+        {
+            try
+            {
+                // forces a validation of the input
+                this.filePermissions = PosixFilePermissions.toString(PosixFilePermissions.fromString(filePermissions));
+            }
+            catch (IllegalArgumentException exception)
+            {
+                String errorMessage = String.format("Invalid file_permissions configuration=\"%s\"", filePermissions);
+                throw new IllegalArgumentException(errorMessage);
+            }
+        }
+        else
+        {
+            this.filePermissions = null;
+        }
     }
 }

--- a/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
+++ b/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
@@ -123,8 +123,11 @@ public class SSTableUploadHandler extends AbstractHandler<SSTableUploadRequest>
         .compose(validRequest -> uploadPathBuilder.resolveStagingDirectory(host))
         .compose(this::ensureSufficientSpaceAvailable)
         .compose(v -> uploadPathBuilder.build(host, request))
-        .compose(uploadDirectory -> uploader.uploadComponent(httpRequest, uploadDirectory, request.component(),
-                                                             request.expectedChecksum()))
+        .compose(uploadDirectory -> uploader.uploadComponent(httpRequest,
+                                                             uploadDirectory,
+                                                             request.component(),
+                                                             request.expectedChecksum(),
+                                                             configuration.filePermissions()))
         .compose(fs::props)
         .onSuccess(fileProps -> {
             long serviceTimeMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeInNanos);

--- a/src/test/java/org/apache/cassandra/sidecar/config/yaml/SSTableUploadConfigurationImplTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/config/yaml/SSTableUploadConfigurationImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.config.yaml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Unit tests to validate {@link SSTableUploadConfigurationImpl} inputs
+ */
+class SSTableUploadConfigurationImplTest
+{
+    @Test
+    void testNullFilePermissions()
+    {
+        SSTableUploadConfigurationImpl config = new SSTableUploadConfigurationImpl(null);
+        assertThat(config.filePermissions()).isNull();
+    }
+
+    @ParameterizedTest(name = "{index} => invalid permission string \"{0}\"")
+    @ValueSource(strings = { "", "aaaaaaaaa", "rwxaaaaaa", "rwx", "null" })
+    void filePermissionsFailsOnInvalidString(String value)
+    {
+        assertThatIllegalArgumentException()
+        .isThrownBy(() -> new SSTableUploadConfigurationImpl(value))
+        .withMessage("Invalid filePermissions configuration=\"" + value + "\"");
+    }
+
+    @ParameterizedTest(name = "{index} => valid permission string \"{0}\"")
+    @ValueSource(strings = { "---------", "rwx------", "rwxr--r--", "r-xr-xr-x", "r-xr-xrwx" })
+    void testValidFilePermission(String value)
+    {
+        SSTableUploadConfigurationImpl config = new SSTableUploadConfigurationImpl(value);
+        assertThat(config.filePermissions()).isEqualTo(value);
+    }
+}

--- a/src/test/resources/config/sidecar_file_permissions.yaml
+++ b/src/test/resources/config/sidecar_file_permissions.yaml
@@ -75,7 +75,7 @@ sidecar:
   sstable_upload:
     concurrent_upload_limit: 80
     min_free_space_percent: 10
-    # file_permissions: "rw-r--r--" # when not specified, the default file permissions are owner read & write, group & others read
+    file_permissions: "rw-rw-rw-"
   allowable_time_skew_in_minutes: 60
   sstable_import:
     poll_interval_millis: 100

--- a/src/test/resources/config/sidecar_invalid_file_permissions.yaml
+++ b/src/test/resources/config/sidecar_invalid_file_permissions.yaml
@@ -75,7 +75,7 @@ sidecar:
   sstable_upload:
     concurrent_upload_limit: 80
     min_free_space_percent: 10
-    # file_permissions: "rw-r--r--" # when not specified, the default file permissions are owner read & write, group & others read
+    file_permissions: "not-valid"
   allowable_time_skew_in_minutes: 60
   sstable_import:
     poll_interval_millis: 100


### PR DESCRIPTION
This commit introduces a new configuration for SSTable uploads (`file_permissions`) which allows
an operator to configure the desired file permissions used for files that are uploaded via SSTable
upload.