### PR TITLE
CASSANDRASC-72 [CircleCI] Split unit tests and integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
   # Runs java 8 tests on a docker image
   unit_java8:
     docker:
-     - image: circleci/openjdk:8-jdk-stretch
+     - image: cimg/openjdk:8.0
     environment:
       skipIntegrationTest: true
     steps:
@@ -110,7 +110,7 @@ jobs:
   # Runs java 11 tests on a docker image
   unit_java11:
     docker:
-      - image: circleci/openjdk:11-jdk-stretch
+      - image: cimg/openjdk:11.0
     environment:
       skipIntegrationTest: true
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
      - checkout
 
-     - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c" BRANCHES="cassandra-4.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+     - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c" BRANCHES="cassandra-4.0" scripts/build-dtest-jars.sh
      - run: ./gradlew -PdtestVersion=4.0.12 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
@@ -97,7 +97,7 @@ jobs:
     steps:
      - checkout
 
-     - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+     - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
@@ -127,6 +127,8 @@ jobs:
   integration_cassandra_40_java11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
+    environment:
+      M2_HOME: "/home/circleci/.m2/repository/"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
     steps:
       - checkout
       - run: CASSANDRA_SHAS="410018ab165b54c378648d52fb4ec815c557e80e" BRANCHES="cassandra-5.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=5.0.0 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew -PdtestVersion=5.0-alpha1 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports
@@ -163,7 +163,7 @@ jobs:
     steps:
       - checkout
       - run: CASSANDRA_SHAS="cbaef9094e83364e6812c65b8411ff7dbffaf9c6" BRANCHES="trunk" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=5.0-alpha1 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
      - checkout
      # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
-     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test=4.0 --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports
@@ -131,7 +131,7 @@ jobs:
       - checkout
       # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
       - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test=4.0 --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
      - checkout
      # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
-     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports
@@ -131,7 +131,7 @@ jobs:
       - checkout
       # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
       - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test=4.0 checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports
@@ -146,7 +146,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: CASSANDRA_SHAS="410018ab165b54c378648d52fb4ec815c557e80e" BRANCHES="cassandra-5.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+      - run: CASSANDRA_SHAS="410018ab165b54c378648d52fb4ec815c557e80e" BRANCHES="cassandra-5.0" scripts/build-dtest-jars.sh
       - run: ./gradlew -PdtestVersion=5.0-alpha1 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
@@ -162,7 +162,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: CASSANDRA_SHAS="cbaef9094e83364e6812c65b8411ff7dbffaf9c6" BRANCHES="trunk" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+      - run: CASSANDRA_SHAS="cbaef9094e83364e6812c65b8411ff7dbffaf9c6" BRANCHES="trunk" scripts/build-dtest-jars.sh
       - run: ./gradlew -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,15 +59,13 @@ commands:
 
 jobs:
   # Runs java 8 tests on a docker image
-  java8:
+  unit_java8:
     docker:
      - image: circleci/openjdk:8-jdk-stretch
-    resource_class: large
+    environment:
+      skipIntegrationTest: true
     steps:
      - checkout
-
-     - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c 8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.0 cassandra-4.1" scripts/build-dtest-jars.sh
-     - run: echo 'export DTEST_JAR=$(find dtest-jars -name 'dtest-4.1*.jar' -type f -maxdepth 1 -exec basename {} \;)' >> "$BASH_ENV"
      - run: ./gradlew --info check --stacktrace -Dcassandra.sidecar.versions_to_test="4.0,4.1"
 
      - store_artifacts:
@@ -77,17 +75,95 @@ jobs:
      - store_test_results:
          path: build/test-results/
 
+  integration_cassandra_40_java8:
+    docker:
+     - image: circleci/openjdk:8-jdk-stretch
+    steps:
+     - checkout
+
+     - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c" BRANCHES="cassandra-4.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+     - run: ./gradlew -PdtestVersion=4.0.12 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+
+     - store_artifacts:
+         path: build/reports
+         destination: test-reports
+
+     - store_test_results:
+         path: build/test-results/
+
+  integration_cassandra_41_java8:
+    docker:
+     - image: circleci/openjdk:8-jdk-stretch
+    steps:
+     - checkout
+
+     - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+
+     - store_artifacts:
+         path: build/reports
+         destination: test-reports
+
+     - store_test_results:
+         path: build/test-results/
+
   # Runs java 11 tests on a docker image
-  java11:
+  unit_java11:
+    docker:
+      - image: circleci/openjdk:11-jdk-stretch
+    environment:
+      skipIntegrationTest: true
+    steps:
+      - checkout
+      - run: ./gradlew --info check -x integrationTest --stacktrace
+
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
+
+      - store_test_results:
+          path: build/test-results/
+
+  integration_cassandra_40_java11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
     resource_class: large
     steps:
       - checkout
+      - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c" BRANCHES="cassandra-4.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+      - run: ./gradlew -PdtestVersion=4.0.12 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
-      - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c cbaef9094e83364e6812c65b8411ff7dbffaf9c6" BRANCHES="cassandra-4.0 trunk" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: echo 'export DTEST_JAR=$(find dtest-jars -name 'dtest-5.*.jar' -type f -maxdepth 1 -exec basename {} \;)' >> "$BASH_ENV"
-      - run: ./gradlew --info check --stacktrace
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
+
+      - store_test_results:
+          path: build/test-results/
+
+  integration_cassandra_50_java11:
+    docker:
+      - image: circleci/openjdk:11-jdk-stretch
+    resource_class: large
+    steps:
+      - checkout
+      - run: CASSANDRA_SHAS="410018ab165b54c378648d52fb4ec815c557e80e" BRANCHES="cassandra-5.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+      - run: ./gradlew -PdtestVersion=5.0.0 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+
+      - store_artifacts:
+          path: build/reports
+          destination: test-reports
+
+      - store_test_results:
+          path: build/test-results/
+
+  integration_cassandra_trunk_java11:
+    docker:
+      - image: circleci/openjdk:11-jdk-stretch
+    resource_class: large
+    steps:
+      - checkout
+      - run: CASSANDRA_SHAS="cbaef9094e83364e6812c65b8411ff7dbffaf9c6" BRANCHES="trunk" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+      - run: ./gradlew -PdtestVersion=5.0-alpha1 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports
@@ -138,25 +214,65 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - java8
-      - java11
+      - unit_java8
+      - integration_cassandra_40_java8:
+          requires:
+            - unit_java8
+      - integration_cassandra_41_java8:
+          requires:
+            - unit_java8
+      - unit_java11
+      - integration_cassandra_40_java11:
+          requires:
+            - unit_java11
+      - integration_cassandra_50_java11:
+          requires:
+            - unit_java11
+      - integration_cassandra_trunk_java11:
+          requires:
+            - unit_java11
       - docs_build:
           requires:
-            - java8
-            - java11
+            - unit_java8
+            - integration_cassandra_40_java8
+            - integration_cassandra_41_java8
+            - unit_java11
+            - integration_cassandra_40_java11
+            - integration_cassandra_50_java11
+            - integration_cassandra_trunk_java11
       - docker_build:
           requires:
-            - java8
-            - java11
+            - unit_java8
+            - integration_cassandra_40_java8
+            - integration_cassandra_41_java8
+            - unit_java11
+            - integration_cassandra_40_java11
+            - integration_cassandra_50_java11
+            - integration_cassandra_trunk_java11
       - rpm_build_install:
           requires:
-            - java8
-            - java11
+            - unit_java8
+            - integration_cassandra_40_java8
+            - integration_cassandra_41_java8
+            - unit_java11
+            - integration_cassandra_40_java11
+            - integration_cassandra_50_java11
+            - integration_cassandra_trunk_java11
       - deb_build_install:
           requires:
-            - java8
-            - java11
+            - unit_java8
+            - integration_cassandra_40_java8
+            - integration_cassandra_41_java8
+            - unit_java11
+            - integration_cassandra_40_java11
+            - integration_cassandra_50_java11
+            - integration_cassandra_trunk_java11
       - docker_build:
           requires:
-            - java8
-            - java11
+            - unit_java8
+            - integration_cassandra_40_java8
+            - integration_cassandra_41_java8
+            - unit_java11
+            - integration_cassandra_40_java11
+            - integration_cassandra_50_java11
+            - integration_cassandra_trunk_java11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
      - checkout
      # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
-     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test=4.0 --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports
@@ -131,7 +131,7 @@ jobs:
       - checkout
       # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
       - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test=4.0 checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test=4.0 --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     steps:
      - checkout
      # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
-     - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
+     - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c 8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.0 cassandra-4.1" scripts/build-dtest-jars.sh
      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
@@ -126,11 +126,10 @@ jobs:
   integration_cassandra_40_java11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
-    resource_class: large
     steps:
       - checkout
       # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
-      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
+      - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c 8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.0 cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
       - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
@@ -143,7 +142,6 @@ jobs:
   integration_cassandra_50_java11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
-    resource_class: large
     steps:
       - checkout
       - run: CASSANDRA_SHAS="410018ab165b54c378648d52fb4ec815c557e80e" BRANCHES="cassandra-5.0" scripts/build-dtest-jars.sh
@@ -159,7 +157,6 @@ jobs:
   integration_cassandra_trunk_java11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
-    resource_class: large
     steps:
       - checkout
       - run: CASSANDRA_SHAS="cbaef9094e83364e6812c65b8411ff7dbffaf9c6" BRANCHES="trunk" scripts/build-dtest-jars.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,9 @@ jobs:
      - image: circleci/openjdk:8-jdk-stretch
     steps:
      - checkout
-
-     - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c" BRANCHES="cassandra-4.0" scripts/build-dtest-jars.sh
-     - run: ./gradlew -PdtestVersion=4.0.12 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+     # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
+     - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
+     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports
@@ -96,7 +96,6 @@ jobs:
      - image: circleci/openjdk:8-jdk-stretch
     steps:
      - checkout
-
      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
@@ -130,8 +129,9 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: CASSANDRA_SHAS="d13b3ef61b9afbd04878c988c7b722507674228c" BRANCHES="cassandra-4.0" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=4.0.12 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
+      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
+      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       skipIntegrationTest: true
     steps:
      - checkout
-     - run: ./gradlew --info check --stacktrace -Dcassandra.sidecar.versions_to_test="4.0,4.1"
+     - run: ./gradlew --info check -x integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,6 @@ jobs:
   integration_cassandra_40_java11:
     docker:
       - image: circleci/openjdk:11-jdk-stretch
-    environment:
-      M2_HOME: "/home/circleci/.m2/repository/"
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - checkout
       # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
-      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
+      - run: CASSANDRA_SHAS="8666265521c97a5e726c9d38762028a14325e4dc" BRANCHES="cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
       - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:

--- a/build.gradle
+++ b/build.gradle
@@ -426,9 +426,9 @@ rat {
     reportDir.set(file("build/reports/rat"))
 }
 
-//compileIntegrationTestJava.onlyIf { "true" != System.getenv("skipIntegrationTest") }
-//checkstyleIntegrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
-//spotbugsIntegrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
+compileIntegrationTestJava.onlyIf { "true" != System.getenv("skipIntegrationTest") }
+checkstyleIntegrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
+spotbugsIntegrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
 
 // copyDist gets called on every build
 copyDist.dependsOn installDist, copyJolokia

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,7 @@ plugins {
     id("org.nosphere.apache.rat") version "0.8.0"
 }
 
-
-ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-5.1.jar" // trunk is currently 5.1.jar - update when trunk moves
-println("Using DTest jar: ${ext.dtestJar}")
+println("Using DTest jar: ${dtestVersion}")
 
 // Force checkstyle, rat, and spotBugs to run before test tasks for faster feedback
 def codeCheckTasks = task("codeCheckTasks")
@@ -66,6 +64,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+
+        // for dtest jar
+        mavenLocal()
     }
 
     checkstyle {
@@ -213,8 +214,8 @@ dependencies {
     testFixturesImplementation("io.vertx:vertx-web:${project.vertxVersion}") {
         exclude group: 'junit', module: 'junit'
     }
-    integrationTestImplementation(files("dtest-jars/${dtestJar}"))
-    integrationTestImplementation("org.apache.cassandra:dtest-api:0.0.16")
+    integrationTestImplementation(group: 'org.apache.cassandra', name: "${dtestDependencyName}", version: "${dtestVersion}")
+    integrationTestImplementation(group: 'org.apache.cassandra', name: 'dtest-api', version: "${dtestApiVersion}")
     // Needed by the Cassandra dtest framework
     integrationTestImplementation("org.junit.vintage:junit-vintage-engine:${junitVersion}")
 }
@@ -425,8 +426,9 @@ rat {
     reportDir.set(file("build/reports/rat"))
 }
 
-integrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
-compileIntegrationTestJava.onlyIf { "true" != System.getenv("skipIntegrationTest") }
+//compileIntegrationTestJava.onlyIf { "true" != System.getenv("skipIntegrationTest") }
+//checkstyleIntegrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
+//spotbugsIntegrationTest.onlyIf { "true" != System.getenv("skipIntegrationTest") }
 
 // copyDist gets called on every build
 copyDist.dependsOn installDist, copyJolokia

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,7 @@ vertxVersion=4.2.1
 guavaVersion=27.0.1-jre
 slf4jVersion=1.7.36
 jacksonVersion=2.14.3
+dtestApiVersion=0.0.16
+# trunk is currently 5.1 - update when trunk moves
+dtestVersion=5.1
+dtestDependencyName="cassandra-dtest-local-all"

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ jacksonVersion=2.14.3
 dtestApiVersion=0.0.16
 # trunk is currently 5.1 - update when trunk moves
 dtestVersion=5.1
-dtestDependencyName="cassandra-dtest-local-all"
+dtestDependencyName=cassandra-dtest-local-all

--- a/scripts/build-dtest-jars.sh
+++ b/scripts/build-dtest-jars.sh
@@ -19,7 +19,7 @@
 
 set -xe
 BRANCHES=( ${BRANCHES:-cassandra-4.0 trunk} )
-CASSANDRA_SHAS_ARRAY=( ${CASSANDRA_SHAS} )
+CASSANDRA_SHAS_ARRAY=( ${CASSANDRA_SHAS:-d13b3ef61b9afbd04878c988c7b722507674228c cbaef9094e83364e6812c65b8411ff7dbffaf9c6} )
 REPO=${REPO:-"https://github.com/apache/cassandra.git"}
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
 DTEST_JAR_DIR="$(dirname "${SCRIPT_DIR}/")/dtest-jars"

--- a/scripts/build-shaded-dtest-jar-local.sh
+++ b/scripts/build-shaded-dtest-jar-local.sh
@@ -20,7 +20,7 @@
 set -xe
 
 ARTIFACT_NAME=cassandra-dtest
-REPO_DIR="$(pwd)/out"
+REPO_DIR="${M2_HOME:-${HOME}/.m2/repository}"
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
 CASSANDRA_VERSION=$(cat build.xml | grep 'property name="base.version"' | awk -F "\"" '{print $4}')
 GIT_HASH=$(git rev-parse --short HEAD)
@@ -53,5 +53,15 @@ ant dtest-jar -Dno-checkstyle=true
                      -DoutputFilePath="${DTEST_JAR_DIR}/dtest-${CASSANDRA_VERSION}.jar" \
                      -Drelocation.prefix="shaded-${GIT_HASH}"                           \
                      --no-snapshot-updates --update-snapshots
+
+# Install the shaded version
+"${SCRIPT_DIR}/mvnw" install:install-file                                     \
+                     -Dfile="${DTEST_JAR_DIR}/dtest-${CASSANDRA_VERSION}.jar" \
+                     -DgroupId=org.apache.cassandra                           \
+                     -DartifactId="${DTEST_ARTIFACT_ID}-all"                  \
+                     -Dversion="${CASSANDRA_VERSION}"                         \
+                     -Dpackaging=jar                                          \
+                     -DgeneratePom=true                                       \
+                     -DlocalRepositoryPath="${REPO_DIR}"
 
 set +xe

--- a/src/test/integration/org/apache/cassandra/testing/TestVersionSupplier.java
+++ b/src/test/integration/org/apache/cassandra/testing/TestVersionSupplier.java
@@ -21,6 +21,9 @@ package org.apache.cassandra.testing;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Generates the list of versions we're going to test against.
  * We will run the same module (trunk for example) against multiple versions of Cassandra.
@@ -32,10 +35,13 @@ import java.util.stream.Stream;
  */
 public class TestVersionSupplier
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestVersionSupplier.class);
+
     Stream<TestVersion> testVersions()
     {
         // By default, we test 2 versions that will exercise oldest and newest supported versions
         String versions = System.getProperty("cassandra.sidecar.versions_to_test", "4.0,5.1");
+        LOGGER.info("Testing with versions={}", versions);
         return Arrays.stream(versions.split(",")).map(String::trim).map(TestVersion::new);
     }
 }

--- a/src/test/java/org/apache/cassandra/sidecar/config/yaml/SSTableUploadConfigurationImplTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/config/yaml/SSTableUploadConfigurationImplTest.java
@@ -43,7 +43,7 @@ class SSTableUploadConfigurationImplTest
     {
         assertThatIllegalArgumentException()
         .isThrownBy(() -> new SSTableUploadConfigurationImpl(value))
-        .withMessage("Invalid filePermissions configuration=\"" + value + "\"");
+        .withMessage("Invalid file_permissions configuration=\"" + value + "\"");
     }
 
     @ParameterizedTest(name = "{index} => valid permission string \"{0}\"")


### PR DESCRIPTION
As the number of integration tests continues to grow, it is desirable to split unit tests and integration tests. It is also desirable to parallelize integration tests, each integration test should be its own job. The goals of this improvement are:

- Fail fast on checkstyle or minor errors
- Speed up test runtime by running integration tests in parallel
- Isolate failing tests to specific combinations of Cassandra

In this commit, we run unit tests individually for both java 8 and java 11. We split integration tests into its own jobs, split per java version and cassandra version combination.