### PR TITLE
CASSANDRASC-75: Shade Jackson completely to prevent incompatibility issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,13 +80,13 @@ jobs:
      - image: circleci/openjdk:8-jdk-stretch
     environment:
       INTEGRATION_MAX_PARALLEL_FORKS: 1
-      INTEGRATION_MAX_HEAP_SIZE: "6g"
+      INTEGRATION_MAX_HEAP_SIZE: "4G"
     resource_class: large
     steps:
      - checkout
      # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
      - run: BRANCHES="cassandra-4.0 cassandra-4.1" scripts/build-dtest-jars.sh
-     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+     - run: ./gradlew --no-daemon -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports
@@ -100,12 +100,12 @@ jobs:
      - image: circleci/openjdk:8-jdk-stretch
     environment:
       INTEGRATION_MAX_PARALLEL_FORKS: 1
-      INTEGRATION_MAX_HEAP_SIZE: "6g"
+      INTEGRATION_MAX_HEAP_SIZE: "4G"
     resource_class: large
     steps:
      - checkout
      - run: BRANCHES="cassandra-4.1" scripts/build-dtest-jars.sh
-     - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+     - run: ./gradlew --no-daemon -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
      - store_artifacts:
          path: build/reports
@@ -136,13 +136,13 @@ jobs:
       - image: circleci/openjdk:11-jdk-stretch
     environment:
       INTEGRATION_MAX_PARALLEL_FORKS: 1
-      INTEGRATION_MAX_HEAP_SIZE: "6g"
+      INTEGRATION_MAX_HEAP_SIZE: "4G"
     resource_class: large
     steps:
       - checkout
       # Cassandra 4.0 jar seems to be missing some dependencies, so we use 4.1 here (this is what we currently do)
       - run: BRANCHES="cassandra-4.0 cassandra-4.1" CASSANDRA_USE_JDK11=true scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew --no-daemon -PdtestVersion=4.1.4 -Dcassandra.sidecar.versions_to_test="4.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports
@@ -156,12 +156,12 @@ jobs:
       - image: circleci/openjdk:11-jdk-stretch
     environment:
       INTEGRATION_MAX_PARALLEL_FORKS: 1
-      INTEGRATION_MAX_HEAP_SIZE: "6g"
+      INTEGRATION_MAX_HEAP_SIZE: "4G"
     resource_class: large
     steps:
       - checkout
       - run: BRANCHES="cassandra-5.0" scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=5.0-alpha2 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew --no-daemon -PdtestVersion=5.0-alpha2 -Dcassandra.sidecar.versions_to_test="5.0" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports
@@ -175,12 +175,12 @@ jobs:
       - image: circleci/openjdk:11-jdk-stretch
     environment:
       INTEGRATION_MAX_PARALLEL_FORKS: 1
-      INTEGRATION_MAX_HEAP_SIZE: "6g"
+      INTEGRATION_MAX_HEAP_SIZE: "4G"
     resource_class: large
     steps:
       - checkout
       - run: BRANCHES="trunk" scripts/build-dtest-jars.sh
-      - run: ./gradlew -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
+      - run: ./gradlew --no-daemon -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" --info checkstyleIntegrationTest spotbugsIntegrationTest integrationTest --stacktrace
 
       - store_artifacts:
           path: build/reports

--- a/vertx-client-shaded/build.gradle
+++ b/vertx-client-shaded/build.gradle
@@ -46,7 +46,6 @@ configurations {
 
 dependencies {
     shadow(group: 'org.slf4j', name: 'slf4j-api', version: "${project.slf4jVersion}")
-    shadow(group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: "${project.jacksonVersion}")
     api(project(':vertx-client'))
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
@@ -68,8 +67,9 @@ tasks.named('test') {
 // Relocating a Package
 shadowJar {
     archiveClassifier.set('')
-    relocate 'com.fasterxml.jackson.core', 'o.a.c.sidecar.client.shaded.com.fasterxml.jackson.core'
-    relocate 'com.fasterxml.jackson.databind', 'o.a.c.sidecar.client.shaded.com.fasterxml.jackson.databind'
+    // Our use of Jackson should be an implementation detail - shade everything so no matter what
+    // version of Jackson is available in the classpath we don't break consumers of the client
+    relocate 'com.fasterxml.jackson', 'o.a.c.sidecar.client.shaded.com.fasterxml.jackson'
     relocate 'io.netty', 'o.a.c.sidecar.client.shaded.io.netty'
     relocate 'io.vertx', 'o.a.c.sidecar.client.shaded.io.vertx'
     relocate 'META-INF/native/libnetty', 'META-INF/native/libo_a_c_sidecar_client_shaded_netty'
@@ -79,10 +79,6 @@ shadowJar {
 
     dependencies {
         exclude(dependency('org.slf4j:.*:.*'))
-        // Exclude the jackson-annotations dependency so that extension clients can keep annotating POJOs
-        // without the need to use shadow annotations. For example, they can continue using
-        // com.fasterxml.jackson.annotation.JsonProperty.
-        exclude(dependency('com.fasterxml.jackson.core:jackson-annotations:.*'))
     }
 }
 


### PR DESCRIPTION
Before, we we shading almost all of Jackson but left the annotations unshaded/relocated. However, this causes problems in older Spark environments where the annotations in the class path don’t quite match what the other shaded parts of Jackson expect (missing classes being the most serious issue). This can cause the library to fail on certain Spark versions. This commit removes the exclusion of the annotations project from shading in the vertx-client-shaded project.