### PR TITLE
CASSANDRASC-78 Fix token-ranges endpoint to handle gossip-info respon…

### DIFF
--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProvider.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProvider.java
@@ -285,7 +285,9 @@ public class TokenRangeReplicaProvider
                 {
                     LOGGER.debug("Found gossipInfoEntry={}", gossipInfoEntry);
                     String hostStatus = gossipInfoEntry.status();
-                    if (hostStatus != null && hostStatus.startsWith("BOOT_REPLACE,"))
+                    String hostStatusWithPort = gossipInfoEntry.statusWithPort();
+                    if ((hostStatus != null && hostStatus.startsWith("BOOT_REPLACE,")) ||
+                        (hostStatusWithPort != null && hostStatusWithPort.startsWith("BOOT_REPLACE,")))
                     {
                         return NodeState.REPLACING.displayName();
                     }

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/ReplacementBaseTest.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/ReplacementBaseTest.java
@@ -127,7 +127,7 @@ class ReplacementBaseTest extends BaseTokenRangeIntegrationTest
                 List<Integer> nodeNums = newNodes.stream().map(i -> i.config().num()).collect(Collectors.toList());
                 validateNodeStates(mappingResponse,
                                    dcReplication,
-                                   nodeNumber -> nodeNums.contains(nodeNumber) ? "Joining" : "Normal");
+                                   nodeNumber -> nodeNums.contains(nodeNumber) ? "Replacing" : "Normal");
 
                 int nodeCount = annotation.nodesPerDc() * annotation.numDcs();
                 validateTokenRanges(mappingResponse, generateExpectedRanges(nodeCount));


### PR DESCRIPTION
…ses without 'status'

### Details
This is a fix to look for the host status in ‘Status’ and ‘StatusWithPort’ attributes in GossipInfo response  to determine the ‘state’ of the node.

Currently, we only check for ‘status’ which can be missing from gossipInfo in some cases, which will result in a replacement node status to be reported as `Joining` instead of `Replacing`.

### Testing
- Added related unit tests to reproduce and validate fix
