### PR TITLE
CASSANDRASC-80 HealthCheckPeriodicTask execute never completes the pr…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,8 @@ configurations {
 
 dependencies {
     compileOnly('org.jetbrains:annotations:23.0.0')
+    testCompileOnly('org.jetbrains:annotations:23.0.0')
+    integrationTestCompileOnly('org.jetbrains:annotations:23.0.0')
 
     implementation("io.vertx:vertx-web:${project.vertxVersion}") {
         exclude group: 'junit', module: 'junit'

--- a/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesConfig.java
+++ b/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Maintains metadata of instances maintained by Sidecar.
@@ -29,8 +30,12 @@ import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 public interface InstancesConfig
 {
     /**
+     * Returns metadata associated with the Cassandra instances managed by this Sidecar. The implementer
+     * must return a non-null value. When no Cassandra instances are configured, an empty list can be returned.
+     *
      * @return metadata of instances owned by the sidecar
      */
+    @NotNull
     List<InstanceMetadata> instances();
 
     /**

--- a/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesConfigImpl.java
+++ b/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesConfigImpl.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.dns.DnsResolver;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Local implementation of InstancesConfig.
@@ -57,7 +58,7 @@ public class InstancesConfigImpl implements InstancesConfig
     }
 
     @Override
-    public List<InstanceMetadata> instances()
+    public @NotNull List<InstanceMetadata> instances()
     {
         return instanceMetadataList;
     }

--- a/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
+++ b/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
@@ -83,6 +83,11 @@ public class HealthCheckPeriodicTask implements PeriodicTask
     public void execute(Promise<Void> promise)
     {
         List<InstanceMetadata> instances = instancesConfig.instances();
+        if (instances == null || instances.isEmpty())
+        {
+            promise.complete();
+            return;
+        }
         AtomicInteger counter = new AtomicInteger(instances.size());
         instances.forEach(instanceMetadata -> internalPool.executeBlocking(p -> {
             try

--- a/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
+++ b/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
@@ -101,7 +101,7 @@ public class HealthCheckPeriodicTask implements PeriodicTask
                                           }, false))
                                           .collect(Collectors.toList());
 
-        // join always wait until all its futures are completed and will not fail as soon as one of the future fails
+        // join always waits until all its futures are completed and will not fail as soon as one of the future fails
         Future.join(futures)
               .onSuccess(v -> promise.complete())
               .onFailure(promise::fail);

--- a/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
+++ b/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
@@ -18,9 +18,7 @@
 
 package org.apache.cassandra.sidecar.tasks;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -84,22 +82,22 @@ public class HealthCheckPeriodicTask implements PeriodicTask
     @Override
     public void execute(Promise<Void> promise)
     {
-        List<Future<?>> futures = Optional.ofNullable(instancesConfig.instances()).orElse(Collections.emptyList())
-                                          .stream()
-                                          .map(instanceMetadata -> internalPool.executeBlocking(p -> {
-                                              try
-                                              {
-                                                  instanceMetadata.delegate().healthCheck();
-                                                  p.complete();
-                                              }
-                                              catch (Throwable cause)
-                                              {
-                                                  p.fail(cause);
-                                                  LOGGER.error("Unable to complete health check on instance={}",
-                                                               instanceMetadata.id(), cause);
-                                              }
-                                          }, false))
-                                          .collect(Collectors.toList());
+        List<Future<?>> futures = instancesConfig.instances()
+                                                 .stream()
+                                                 .map(instanceMetadata -> internalPool.executeBlocking(p -> {
+                                                     try
+                                                     {
+                                                         instanceMetadata.delegate().healthCheck();
+                                                         p.complete();
+                                                     }
+                                                     catch (Throwable cause)
+                                                     {
+                                                         p.fail(cause);
+                                                         LOGGER.error("Unable to complete health check on instance={}",
+                                                                      instanceMetadata.id(), cause);
+                                                     }
+                                                 }, false))
+                                                 .collect(Collectors.toList());
 
         // join always waits until all its futures are completed and will not fail as soon as one of the future fails
         Future.join(futures)

--- a/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTask.java
+++ b/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTask.java
@@ -60,9 +60,8 @@ public interface PeriodicTask
      * Defines the task body.
      * The method can be considered as executing in a single thread.
      *
-     * <br><b>NOTE:</b> It is very important that the promise is completed (as either succeeded or failed), when the
-     * execution is considered complete. Otherwise, the {@link PeriodicTaskExecutor} will not be able to execute
-     * the task since the executor only allows for the task to be run if it's not already running.
+     * <br><b>NOTE:</b> the {@code promise} must be completed (as either succeeded or failed) at the end of the run.
+     * Failing to do so, the {@link PeriodicTaskExecutor} will not be able to schedule a new run.
      * {@see PeriodicTaskExecutor#executeInternal} for details.
      *
      * @param promise a promise when the execution completes

--- a/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTask.java
+++ b/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTask.java
@@ -60,6 +60,11 @@ public interface PeriodicTask
      * Defines the task body.
      * The method can be considered as executing in a single thread.
      *
+     * <br><b>NOTE:</b> It is very important that the promise is completed (as either succeeded or failed), when the
+     * execution is considered complete. Otherwise, the {@link PeriodicTaskExecutor} will not be able to execute
+     * the task since the executor only allows for the task to be run if it's not already running.
+     * {@see PeriodicTaskExecutor#executeInternal} for details.
+     *
      * @param promise a promise when the execution completes
      */
     void execute(Promise<Void> promise);

--- a/src/test/integration/org/apache/cassandra/sidecar/IntegrationTestModule.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/IntegrationTestModule.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.sidecar.config.yaml.HealthCheckConfigurationImpl;
 import org.apache.cassandra.sidecar.config.yaml.ServiceConfigurationImpl;
 import org.apache.cassandra.sidecar.config.yaml.SidecarConfigurationImpl;
 import org.apache.cassandra.sidecar.test.CassandraSidecarTestContext;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Provides the basic dependencies for integration tests
@@ -59,6 +60,7 @@ public class IntegrationTestModule extends AbstractModule
         /**
          * @return metadata of instances owned by the sidecar
          */
+        @NotNull
         public List<InstanceMetadata> instances()
         {
             if (cassandraTestContext != null && cassandraTestContext.isClusterBuilt())

--- a/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
@@ -83,15 +83,6 @@ class HealthCheckPeriodicTaskTest
     }
 
     @Test
-    void testHealthCheckPromiseCompletesWhenInstancesAreNull(VertxTestContext context)
-    {
-        when(mockInstancesConfig.instances()).thenReturn(null);
-        Promise<Void> promise = Promise.promise();
-        healthCheck.execute(promise);
-        promise.future().onComplete(context.succeedingThenComplete());
-    }
-
-    @Test
     void testHealthCheckPromiseCompletesWhenNoInstancesAreConfigured(VertxTestContext context)
     {
         List<InstanceMetadata> mockInstanceMetadata = Collections.emptyList();

--- a/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
@@ -127,7 +127,7 @@ class HealthCheckPeriodicTaskTest
         when(mockInstancesConfig.instances()).thenReturn(mockInstanceMetadata);
         Promise<Void> promise = Promise.promise();
         healthCheck.execute(promise);
-        promise.future().onComplete(context.succeedingThenComplete());
+        promise.future().onComplete(context.failingThenComplete());
     }
 
     @Test

--- a/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
+++ b/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.sidecar.tasks;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -79,6 +80,25 @@ class HealthCheckPeriodicTaskTest
         assertThat(healthCheck.initialDelay()).isEqualTo(10);
         assertThat(healthCheck.delay()).isEqualTo(1000);
         assertThat(healthCheck.name()).isEqualTo("Health Check");
+    }
+
+    @Test
+    void testHealthCheckPromiseCompletesWhenInstancesAreNull(VertxTestContext context)
+    {
+        when(mockInstancesConfig.instances()).thenReturn(null);
+        Promise<Void> promise = Promise.promise();
+        healthCheck.execute(promise);
+        promise.future().onComplete(context.succeedingThenComplete());
+    }
+
+    @Test
+    void testHealthCheckPromiseCompletesWhenNoInstancesAreConfigured(VertxTestContext context)
+    {
+        List<InstanceMetadata> mockInstanceMetadata = Collections.emptyList();
+        when(mockInstancesConfig.instances()).thenReturn(mockInstanceMetadata);
+        Promise<Void> promise = Promise.promise();
+        healthCheck.execute(promise);
+        promise.future().onComplete(context.succeedingThenComplete());
     }
 
     @Test


### PR DESCRIPTION
…omise when instances are empty

When the HealthCheckPeriodicTask executes, and the instances are null or empty, the promise never completes. This prevents subsequent scheduled health checks to take place because the PeriodicTaskExecutor will only schedule the new task only if no other tasks are active. This makes the HealthCheckPeriodicTask to never perform health checks when this condition is encountered.

In this commit, we fix the issue by completing the promise when this condition is encountered.

[CASSANDRASC-80](https://issues.apache.org/jira/browse/CASSANDRASC-80)