### PR TITLE
CASSANDRASC-83 Require gossip to be enabled for ring and token ranges…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Require gossip to be enabled for ring and token ranges mapping endpoints (CASSANDRASC-83)
  * Improve TokenRangeReplicasResponse payload (CASSANDRASC-81)
  * HealthCheckPeriodicTask execute never completes the promise when instances are empty (CASSANDRASC-80)
  * Fix token-ranges endpoint to handle gossip-info responses without 'status' (CASSANDRASC-78)

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/GossipDependentStorageJmxOperations.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/GossipDependentStorageJmxOperations.java
@@ -144,6 +144,6 @@ public class GossipDependentStorageJmxOperations implements StorageJmxOperations
             return;
 
         LOGGER.warn("Gossip is disabled and unavailable for the operation");
-        throw new OperationUnavailableException(OperationUnavailableException.OperationType.GOSSIP_DISABLED);
+        throw OperationUnavailableException.GOSSIP_DISABLED;
     }
 }

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/GossipDependentStorageJmxOperations.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/GossipDependentStorageJmxOperations.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.base;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
+
+/**
+ * A wrapper class for {@link StorageJmxOperations} that ensures gossip is enabled during initialization.
+ */
+public class GossipDependentStorageJmxOperations implements StorageJmxOperations
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(GossipDependentStorageJmxOperations.class);
+
+    private final StorageJmxOperations delegate;
+
+    public GossipDependentStorageJmxOperations(StorageJmxOperations delegate)
+    {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must be not-null");
+        ensureGossipIsEnabled();
+    }
+
+    @Override
+    public List<String> getLiveNodesWithPort()
+    {
+        return delegate.getLiveNodesWithPort();
+    }
+
+    @Override
+    public List<String> getUnreachableNodesWithPort()
+    {
+        return delegate.getUnreachableNodesWithPort();
+    }
+
+    @Override
+    public List<String> getJoiningNodesWithPort()
+    {
+        return delegate.getJoiningNodesWithPort();
+    }
+
+    @Override
+    public List<String> getLeavingNodesWithPort()
+    {
+        return delegate.getLeavingNodesWithPort();
+    }
+
+    @Override
+    public List<String> getMovingNodesWithPort()
+    {
+        return delegate.getMovingNodesWithPort();
+    }
+
+    @Override
+    public Map<String, String> getLoadMapWithPort()
+    {
+        return delegate.getLoadMapWithPort();
+    }
+
+    @Override
+    public Map<String, String> getTokenToEndpointWithPortMap()
+    {
+        return delegate.getTokenToEndpointWithPortMap();
+    }
+
+    @Override
+    public Map<String, Float> effectiveOwnershipWithPort(String keyspace) throws IllegalStateException
+    {
+        return delegate.effectiveOwnershipWithPort(keyspace);
+    }
+
+    @Override
+    public Map<String, Float> getOwnershipWithPort()
+    {
+        return delegate.getOwnershipWithPort();
+    }
+
+    @Override
+    public Map<String, String> getEndpointWithPortToHostId()
+    {
+        return delegate.getEndpointWithPortToHostId();
+    }
+
+    @Override
+    public void takeSnapshot(String tag, Map<String, String> options, String... entities) throws IOException
+    {
+        delegate.takeSnapshot(tag, options, entities);
+    }
+
+    @Override
+    public void clearSnapshot(String tag, String... keyspaceNames)
+    {
+        delegate.clearSnapshot(tag, keyspaceNames);
+    }
+
+    @Override
+    public Map<List<String>, List<String>> getRangeToEndpointWithPortMap(String keyspace)
+    {
+        return delegate.getRangeToEndpointWithPortMap(keyspace);
+    }
+
+    @Override
+    public Map<List<String>, List<String>> getPendingRangeToEndpointWithPortMap(String keyspace)
+    {
+        return delegate.getPendingRangeToEndpointWithPortMap(keyspace);
+    }
+
+    @Override
+    public boolean isGossipRunning()
+    {
+        return delegate.isGossipRunning();
+    }
+
+    /**
+     * Ensures that gossip is running on the Cassandra instance
+     *
+     * @throws OperationUnavailableException when gossip is not running
+     */
+    public void ensureGossipIsEnabled()
+    {
+        if (delegate.isGossipRunning())
+            return;
+
+        LOGGER.warn("Gossip is disabled and unavailable for the operation");
+        throw new OperationUnavailableException(OperationUnavailableException.OperationType.GOSSIP_DISABLED);
+    }
+}

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/RingProvider.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/RingProvider.java
@@ -126,7 +126,8 @@ public class RingProvider
 
     protected StorageJmxOperations initializeStorageOps()
     {
-        return jmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME);
+        return new GossipDependentStorageJmxOperations(jmxClient.proxy(StorageJmxOperations.class,
+                                                                       STORAGE_SERVICE_OBJ_NAME));
     }
 
     /**

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/StorageJmxOperations.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/StorageJmxOperations.java
@@ -134,4 +134,9 @@ public interface StorageJmxOperations
      * a list of endpoints
      */
     Map<List<String>, List<String>> getPendingRangeToEndpointWithPortMap(String keyspace);
+
+    /**
+     * @return {@code true} if gossip is running, {@code false} otherwise
+     */
+    boolean isGossipRunning();
 }

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProvider.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProvider.java
@@ -177,9 +177,9 @@ public class TokenRangeReplicaProvider
 
     protected StorageJmxOperations initializeStorageOps()
     {
-        return jmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME);
+        return new GossipDependentStorageJmxOperations(jmxClient.proxy(StorageJmxOperations.class,
+                                                                       STORAGE_SERVICE_OBJ_NAME));
     }
-
 
     protected String getRawGossipInfo()
     {

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/exception/OperationUnavailableException.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/exception/OperationUnavailableException.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.base.exception;
+
+/**
+ * Indicates that the operation is unavailable because a requirement for the operation has not been met
+ */
+public class OperationUnavailableException extends RuntimeException
+{
+    private final OperationType operationType;
+
+    public OperationUnavailableException(OperationType operationType)
+    {
+        super(operationType.message);
+        this.operationType = operationType;
+    }
+
+    public OperationType operationType()
+    {
+        return operationType;
+    }
+
+    /**
+     * The requirement for the operation
+     */
+    public enum OperationType
+    {
+        /**
+         * Gossip is required for the operation, but gossip has been disabled
+         */
+        GOSSIP_DISABLED("Gossip is required for the operation but it is disabled"),
+        ;
+
+        private final String message;
+
+        OperationType(String message)
+        {
+            this.message = message;
+        }
+    }
+}

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/exception/OperationUnavailableException.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/exception/OperationUnavailableException.java
@@ -23,35 +23,11 @@ package org.apache.cassandra.sidecar.adapters.base.exception;
  */
 public class OperationUnavailableException extends RuntimeException
 {
-    private final OperationType operationType;
+    public static final OperationUnavailableException GOSSIP_DISABLED
+    = new OperationUnavailableException("Gossip is required for the operation but it is disabled");
 
-    public OperationUnavailableException(OperationType operationType)
+    public OperationUnavailableException(String errorMessage)
     {
-        super(operationType.message);
-        this.operationType = operationType;
-    }
-
-    public OperationType operationType()
-    {
-        return operationType;
-    }
-
-    /**
-     * The requirement for the operation
-     */
-    public enum OperationType
-    {
-        /**
-         * Gossip is required for the operation, but gossip has been disabled
-         */
-        GOSSIP_DISABLED("Gossip is required for the operation but it is disabled"),
-        ;
-
-        private final String message;
-
-        OperationType(String message)
-        {
-            this.message = message;
-        }
+        super(errorMessage);
     }
 }

--- a/adapters/base/src/test/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProviderTest.java
+++ b/adapters/base/src/test/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProviderTest.java
@@ -82,6 +82,7 @@ public class TokenRangeReplicaProviderTest
         dnsResolver = mock(DnsResolver.class);
         instance = new TokenRangeReplicaProvider(jmxClient, dnsResolver);
 
+        when(storageOperations.isGossipRunning()).thenReturn(true);
         when(jmxClient.proxy(StorageJmxOperations.class, "org.apache.cassandra.db:type=StorageService"))
         .thenReturn(storageOperations);
         when(jmxClient.proxy(EndpointSnitchJmxOperations.class, "org.apache.cassandra.db:type=EndpointSnitchInfo"))

--- a/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
+++ b/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
@@ -30,6 +30,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
+import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.data.QualifiedTableName;
 import org.apache.cassandra.sidecar.common.exceptions.JmxAuthenticationException;
@@ -192,6 +193,11 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
         if (cause instanceof JmxAuthenticationException)
         {
             return wrapHttpException(HttpResponseStatus.SERVICE_UNAVAILABLE, cause);
+        }
+
+        if (cause instanceof OperationUnavailableException)
+        {
+            return wrapHttpException(HttpResponseStatus.SERVICE_UNAVAILABLE, cause.getMessage(), cause);
         }
 
         return wrapHttpException(HttpResponseStatus.INTERNAL_SERVER_ERROR, cause);

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicMultiDCRf3Test.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicMultiDCRf3Test.java
@@ -39,9 +39,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * therefore limit the instance size required to run the tests from CircleCI as the in-jvm-dtests tests are memory bound
  */
 @ExtendWith(VertxExtension.class)
-class BasicTestMultiDCRf3 extends BaseTokenRangeIntegrationTest
+class BasicMultiDCRf3Test extends BaseTokenRangeIntegrationTest
 {
-    @CassandraIntegrationTest(nodesPerDc = 5, numDcs = 2)
+    @CassandraIntegrationTest(nodesPerDc = 5, numDcs = 2, gossip = true)
     void retrieveMappingMultiDcRf3(VertxTestContext context) throws Exception
     {
         int replicationFactor = 3;

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicMultiDCSingleReplicatedTest.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicMultiDCSingleReplicatedTest.java
@@ -18,15 +18,15 @@
 
 package org.apache.cassandra.sidecar.routes.tokenrange;
 
+import java.util.Collections;
+
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.data.TokenRangeReplicasResponse;
 import org.apache.cassandra.testing.CassandraIntegrationTest;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test the token range replica mapping endpoint with the in-jvm dtest framework.
@@ -35,18 +35,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * therefore limit the instance size required to run the tests from CircleCI as the in-jvm-dtests tests are memory bound
  */
 @ExtendWith(VertxExtension.class)
-class BasicTestUnknownKeyspace extends BaseTokenRangeIntegrationTest
+class BasicMultiDCSingleReplicatedTest extends BaseTokenRangeIntegrationTest
 {
-    @CassandraIntegrationTest
-    void retrieveMappingWithUnknownKeyspace(VertxTestContext context) throws Exception
+    @CassandraIntegrationTest(nodesPerDc = 5, numDcs = 2, gossip = true)
+    void retrieveMappingSingleDCReplicatedRf3(VertxTestContext context)
+    throws Exception
     {
-        retrieveMappingWithKeyspace(context, "unknown_ks", response -> {
-            int errorCode = HttpResponseStatus.NOT_FOUND.code();
-            assertThat(response.statusCode()).isEqualTo(errorCode);
-            JsonObject body = response.bodyAsJsonObject();
-            assertThat(body.getInteger("code")).isEqualTo(errorCode);
-            assertThat(body.getString("message")).contains("Unknown keyspace");
-
+        int replicationFactor = 3;
+        createTestKeyspace(ImmutableMap.of("datacenter1", replicationFactor));
+        retrieveMappingWithKeyspace(context, TEST_KEYSPACE, response -> {
+            TokenRangeReplicasResponse mappingResponse = response.bodyAsJson(TokenRangeReplicasResponse.class);
+            assertMappingResponseOK(mappingResponse, replicationFactor, Collections.singleton("datacenter1"));
             context.completeNow();
         });
     }

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicRf3Test.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicRf3Test.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.routes.tokenrange;
+
+import java.util.Collections;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.data.TokenRangeReplicasResponse;
+import org.apache.cassandra.testing.CassandraIntegrationTest;
+
+/**
+ * Test the token range replica mapping endpoint with the in-jvm dtest framework.
+ *
+ * Note: Some related test classes are broken down to have a single test case to parallelize test execution and
+ * therefore limit the instance size required to run the tests from CircleCI as the in-jvm-dtests tests are memory bound
+ */
+@ExtendWith(VertxExtension.class)
+class BasicRf3Test extends BaseTokenRangeIntegrationTest
+{
+    @CassandraIntegrationTest(nodesPerDc = 5, gossip = true)
+    void retrieveMappingRf3(VertxTestContext context) throws Exception
+    {
+        int replicationFactor = 3;
+        createTestKeyspace(ImmutableMap.of("datacenter1", replicationFactor));
+        retrieveMappingWithKeyspace(context, TEST_KEYSPACE, response -> {
+            TokenRangeReplicasResponse mappingResponse = response.bodyAsJson(TokenRangeReplicasResponse.class);
+            assertMappingResponseOK(mappingResponse, replicationFactor, Collections.singleton("datacenter1"));
+            context.completeNow();
+        });
+    }
+}

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicUnknownKeyspaceTest.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicUnknownKeyspaceTest.java
@@ -18,15 +18,15 @@
 
 package org.apache.cassandra.sidecar.routes.tokenrange;
 
-import java.util.Collections;
-
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import org.apache.cassandra.sidecar.common.data.TokenRangeReplicasResponse;
 import org.apache.cassandra.testing.CassandraIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test the token range replica mapping endpoint with the in-jvm dtest framework.
@@ -35,16 +35,18 @@ import org.apache.cassandra.testing.CassandraIntegrationTest;
  * therefore limit the instance size required to run the tests from CircleCI as the in-jvm-dtests tests are memory bound
  */
 @ExtendWith(VertxExtension.class)
-class BasicTestRf3 extends BaseTokenRangeIntegrationTest
+class BasicUnknownKeyspaceTest extends BaseTokenRangeIntegrationTest
 {
-    @CassandraIntegrationTest(nodesPerDc = 5)
-    void retrieveMappingRf3(VertxTestContext context) throws Exception
+    @CassandraIntegrationTest(gossip = true)
+    void retrieveMappingWithUnknownKeyspace(VertxTestContext context) throws Exception
     {
-        int replicationFactor = 3;
-        createTestKeyspace(ImmutableMap.of("datacenter1", replicationFactor));
-        retrieveMappingWithKeyspace(context, TEST_KEYSPACE, response -> {
-            TokenRangeReplicasResponse mappingResponse = response.bodyAsJson(TokenRangeReplicasResponse.class);
-            assertMappingResponseOK(mappingResponse, replicationFactor, Collections.singleton("datacenter1"));
+        retrieveMappingWithKeyspace(context, "unknown_ks", response -> {
+            int errorCode = HttpResponseStatus.NOT_FOUND.code();
+            assertThat(response.statusCode()).isEqualTo(errorCode);
+            JsonObject body = response.bodyAsJsonObject();
+            assertThat(body.getInteger("code")).isEqualTo(errorCode);
+            assertThat(body.getString("message")).contains("Unknown keyspace");
+
             context.completeNow();
         });
     }


### PR DESCRIPTION
… mapping endpoints

The ring and token ranges mapping endpoints leverage JMX to produce the payload. Ring and token ranges mapping information is derived from gossip information available to the Cassandra instance. If gossip has been disabled, the information might provide an inconsistent view of the cluster which is undesirable. We should instead return a 503 (Service Unavailable) to the client whenever the client tries to access these endpoints and gossip has been disabled.

In this commit, we ensure the endpoints return a 503 (Service Unavailable) when gossip is disabled.