### PR TITLE
CASSANDRASC-90 Token-ranges endpoint fix to unwrap token-ranges by th…

### DIFF
--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicas.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicas.java
@@ -216,10 +216,11 @@ public class TokenRangeReplicas implements Comparable<TokenRangeReplicas>
      */
     public static List<TokenRangeReplicas> normalize(List<TokenRangeReplicas> ranges)
     {
-
         if (ranges.stream().noneMatch(r -> r.partitioner.minToken.compareTo(r.start()) == 0))
         {
-            LOGGER.warn("Partitioner based minToken does not exist in the token ranges");
+            LOGGER.warn("{} based minToken does not exist in the token ranges", ranges.stream()
+                                                                                      .findFirst()
+                                                                                      .get().partitioner.name());
         }
 
         return deoverlap(ranges);

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicas.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicas.java
@@ -69,7 +69,7 @@ public class TokenRangeReplicas implements Comparable<TokenRangeReplicas>
                                                                       Partitioner partitioner,
                                                                       Set<String> replicaSet)
     {
-        if (start.compareTo(end) > 0)
+        if (start.compareTo(end) >= 0)
         {
             return unwrapRange(start, end, partitioner, replicaSet);
         }
@@ -219,7 +219,7 @@ public class TokenRangeReplicas implements Comparable<TokenRangeReplicas>
 
         if (ranges.stream().noneMatch(r -> r.partitioner.minToken.compareTo(r.start()) == 0))
         {
-            LOGGER.warn("{} based minToken does not exist in the token ranges", Partitioner.class.getName());
+            LOGGER.warn("Partitioner based minToken does not exist in the token ranges");
         }
 
         return deoverlap(ranges);

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BaseTokenRangeIntegrationTest.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BaseTokenRangeIntegrationTest.java
@@ -298,13 +298,13 @@ public class BaseTokenRangeIntegrationTest extends IntegrationTestBase
     private void validateRanges(List<TokenRangeReplicasResponse.ReplicaInfo> replicaRanges)
     {
         // Ranges should not be empty
-        replicaRanges.stream().forEach(r -> assertThat(r.start()).isNotEqualTo(r.end()));
+        replicaRanges.forEach(r -> assertThat(r.start()).isNotEqualTo(r.end()));
         // Ranges should include partitioner start and end
-        replicaRanges.stream()
-                     .map(TokenRangeReplicasResponse.ReplicaInfo::start)
-                     .anyMatch(s -> s.equals(Murmur3Partitioner.MINIMUM.toString()));
-        replicaRanges.stream()
-                     .map(TokenRangeReplicasResponse.ReplicaInfo::end)
-                     .anyMatch(s -> s.equals(Long.toString(Murmur3Partitioner.MAXIMUM)));
+        assertThat(replicaRanges.stream()
+                                .map(TokenRangeReplicasResponse.ReplicaInfo::start)
+                                .anyMatch(s -> s.equals(Murmur3Partitioner.MINIMUM.toString()))).isTrue();
+        assertThat(replicaRanges.stream()
+                                .map(TokenRangeReplicasResponse.ReplicaInfo::end)
+                                .anyMatch(s -> s.equals(Long.toString(Murmur3Partitioner.MAXIMUM)))).isTrue();
     }
 }

--- a/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicRf1Test.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/BasicRf1Test.java
@@ -50,4 +50,17 @@ class BasicRf1Test extends BaseTokenRangeIntegrationTest
             context.completeNow();
         });
     }
+
+    @CassandraIntegrationTest()
+    void retrieveMappingSingleNodeRf1(VertxTestContext context) throws Exception
+    {
+        createTestKeyspace();
+        retrieveMappingWithKeyspace(context, TEST_KEYSPACE, response -> {
+            assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.OK.code());
+            TokenRangeReplicasResponse mappingResponse = response.bodyAsJson(TokenRangeReplicasResponse.class);
+            assertMappingResponseOK(mappingResponse, 1, Collections.singleton("datacenter1"));
+            context.completeNow();
+        });
+    }
+
 }


### PR DESCRIPTION
…e partitioner's boundary for a single node clusters

For single node clusters, the natural token range returned by the token-ranges endpoint looks like this (seems like an invalid range, without the partitioner’s minToken) -  [9223372036854775807, 9223372036854775807] . 
Verified that this is what the storage-service range-endpoints JMX returns

The contract for the token-ranges API is to make sure ranges are unwrapped around the partitioner’s min-max tokens, which is not honored for the above case. As a result, this is the fix in sidecar for the logic used to unwrap ranges.

### Testing
- Added range validation checks for existing API response validation and additional test case to validate the fix.