### PR TITLE
CASSANDRASC-113 Fix flaky JmxClientTest

### DIFF
--- a/common/src/test/java/org/apache/cassandra/sidecar/common/JmxClientTest.java
+++ b/common/src/test/java/org/apache/cassandra/sidecar/common/JmxClientTest.java
@@ -47,7 +47,7 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.commons.util.Preconditions;
 
@@ -124,8 +124,7 @@ class JmxClientTest
         importMBean.shouldSucceed = true;
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testCanCallMethodWithoutEntireInterface() throws IOException
     {
         List<String> result;
@@ -143,8 +142,7 @@ class JmxClientTest
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testCanCallMethodWithoutEntireInterfaceGetResults() throws IOException
     {
         importMBean.shouldSucceed = false;
@@ -166,8 +164,7 @@ class JmxClientTest
         assertThat(failedDirs.toArray()).isEqualTo(srcPaths.toArray());
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testCallWithoutCredentialsFails() throws IOException
     {
         try (JmxClient client = JmxClient.builder().jmxServiceURL(serviceURL).build())
@@ -186,8 +183,7 @@ class JmxClientTest
         }
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testRoleSupplierThrows() throws IOException
     {
         String errorMessage = "bad role state!";
@@ -200,8 +196,7 @@ class JmxClientTest
                                                   .build());
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testPasswordSupplierThrows() throws IOException
     {
         String errorMessage = "bad password state!";
@@ -215,8 +210,7 @@ class JmxClientTest
                                                   .build());
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testEnableSslSupplierThrows() throws IOException
     {
         String errorMessage = "bad ssl supplier state!";
@@ -231,8 +225,7 @@ class JmxClientTest
                                                   .build());
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testRetryAfterAuthenticationFailureWithCorrectCredentials() throws IOException
     {
         AtomicInteger tryCount = new AtomicInteger(0);
@@ -273,8 +266,7 @@ class JmxClientTest
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testDisconnectReconnect() throws Exception
     {
         List<String> result;
@@ -305,8 +297,7 @@ class JmxClientTest
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @RepeatedTest(20)
-//    @Test
+    @Test
     void testLotsOfProxies() throws IOException
     {
         try (JmxClient client = JmxClient.builder()
@@ -327,8 +318,7 @@ class JmxClientTest
         }
     }
 
-    @RepeatedTest(100)
-//    @Test
+    @Test
     void testConstructorWithHostPort() throws IOException
     {
         try (JmxClient client = JmxClient.builder()

--- a/common/src/test/java/org/apache/cassandra/sidecar/common/JmxClientTest.java
+++ b/common/src/test/java/org/apache/cassandra/sidecar/common/JmxClientTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.platform.commons.util.Preconditions;
 

--- a/common/src/test/java/org/apache/cassandra/sidecar/common/JmxClientTest.java
+++ b/common/src/test/java/org/apache/cassandra/sidecar/common/JmxClientTest.java
@@ -124,7 +124,7 @@ class JmxClientTest
         importMBean.shouldSucceed = true;
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testCanCallMethodWithoutEntireInterface() throws IOException
     {
@@ -143,7 +143,7 @@ class JmxClientTest
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testCanCallMethodWithoutEntireInterfaceGetResults() throws IOException
     {
@@ -166,7 +166,7 @@ class JmxClientTest
         assertThat(failedDirs.toArray()).isEqualTo(srcPaths.toArray());
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testCallWithoutCredentialsFails() throws IOException
     {
@@ -186,7 +186,7 @@ class JmxClientTest
         }
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testRoleSupplierThrows() throws IOException
     {
@@ -200,7 +200,7 @@ class JmxClientTest
                                                   .build());
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testPasswordSupplierThrows() throws IOException
     {
@@ -215,7 +215,7 @@ class JmxClientTest
                                                   .build());
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testEnableSslSupplierThrows() throws IOException
     {
@@ -231,7 +231,7 @@ class JmxClientTest
                                                   .build());
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testRetryAfterAuthenticationFailureWithCorrectCredentials() throws IOException
     {
@@ -273,7 +273,7 @@ class JmxClientTest
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testDisconnectReconnect() throws Exception
     {
@@ -305,7 +305,7 @@ class JmxClientTest
         assertThat(result.size()).isEqualTo(0);
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(20)
 //    @Test
     void testLotsOfProxies() throws IOException
     {
@@ -327,7 +327,7 @@ class JmxClientTest
         }
     }
 
-    @RepeatedTest(1000)
+    @RepeatedTest(100)
 //    @Test
     void testConstructorWithHostPort() throws IOException
     {

--- a/src/test/integration/org/apache/cassandra/sidecar/common/JmxClientIntegrationTest.java
+++ b/src/test/integration/org/apache/cassandra/sidecar/common/JmxClientIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test to ensure connectivity with the JMX client
  */
-public class JmxClientTest
+public class JmxClientIntegrationTest
 {
     private static final String SS_OBJ_NAME = "org.apache.cassandra.db:type=StorageService";
 


### PR DESCRIPTION
In this PR, we fix the race condition that occurs when determining the port number to use for the registry. Currently, the port is determined in the `availablePort` method, where a socket is determined by using port 0. The OS will assign a port number for the socket, but we immediately close the socket, and use the determined port number to run the test. This PR brings a better approach by directly using port 0 while creating the registry, thus avoiding the intermediate step and directly using the port that originally was assigned to the registry without releasing it until the end of the test.

Additionally in this PR, we rename the integration test JmxClientTest which name is colliding with the unit test. This allows for a better IDE integration and debugging experience.

Patch by Francisco Guerrero; Reviewed by TBD for CASSANDRASC-113