### PR TITLE
CASSANDRA-19854 add .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+notifications:
+  commits:      commits@cassandra.apache.org
+  issues:       commits@cassandra.apache.org
+  pullrequests: pr@cassandra.apache.org
+  jira_options: link worklog
+
+github:
+  description: "Sidecar for Apache Cassandra®"
+  homepage: https://cassandra.apache.org/
+  enabled_merge_buttons:
+    squash:  false
+    merge:   false
+    rebase:  true
+  features:
+    wiki: false
+    issues: false
+    projects: false
+  autolink_jira:
+    - CASSANDRASC
+    - CASSANDRA


### PR DESCRIPTION
patch by Stefan Miklosovic; reviewed by TBD for CASSANDRA-19854

This is same as for cassandra-gocql-driver.

Notice autolink is CASSANDRASC which will make link to JIRA out of `CASSANDRA-123` in the commit message. This is already done in main Cassandra repository as well as in gocql driver. (It was done manually for Cassandra repository though before this was configurable by asf.yaml means).