### PR TITLE
CASSANDRASC-152: Fix restore job of coordinated write not proceeding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,6 @@ version: 2.1
 
 # need to reuse the same base environment for several tests
 aliases:
-  base_job: &base_job
-    machine:
-      image: ubuntu-2204:edge
-    working_directory: ~/repo
-    environment:
-      TERM: dumb
   centos: &centos
     docker:
       - image: centos:centos8
@@ -425,8 +419,10 @@ jobs:
       - run: test -f /opt/cassandra-sidecar/bin/cassandra-sidecar
 
   docker_build:
-    <<: *base_job
+    docker:
+      - image: cimg/openjdk:11.0
     steps:
+      - setup_remote_docker
       - checkout
       - run: ./gradlew --info clean :server:jibDockerBuild
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Fix restore job of coordinated write not proceeding (CASSANDRASC-152)
  * Add vert.x auth subproject for mTLS authentication support in Sidecar (CASSANDRASC-146)
  * Improve S3 download throttling with range-GetObject (CASSANDRASC-142)
  * Updating traffic shaping options throws IllegalStateException (CASSANDRASC-140)

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraAdapter.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraAdapter.java
@@ -143,9 +143,21 @@ public class CassandraAdapter implements ICassandraAdapter
     }
 
     @Override
-    public InetSocketAddress localNativeTransportPort()
+    public InetSocketAddress localNativeTransportAddress()
     {
         return localNativeTransportAddress;
+    }
+
+    @Override
+    public InetSocketAddress localStorageBroadcastAddress()
+    {
+        Metadata metadata = metadata();
+        if (metadata == null)
+        {
+            return null;
+        }
+
+        return getHost(metadata).getBroadcastSocketAddress();
     }
 
     /**

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/ConsistencyVerificationResult.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/ConsistencyVerificationResult.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.data;
+
+/**
+ * Verification result
+ */
+public enum ConsistencyVerificationResult
+{
+    SATISFIED,  // the passed replicas have satisfied the consistency level
+    PENDING,    // no conclusion can be made yet
+    FAILED,     // the failed replicas have failed the consistency level
+}

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/ConsistencyVerificationResult.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/ConsistencyVerificationResult.java
@@ -23,7 +23,16 @@ package org.apache.cassandra.sidecar.common.data;
  */
 public enum ConsistencyVerificationResult
 {
-    SATISFIED,  // the passed replicas have satisfied the consistency level
-    PENDING,    // no conclusion can be made yet
-    FAILED,     // the failed replicas have failed the consistency level
+    /**
+     * the passed replicas have satisfied the consistency level
+     */
+    SATISFIED,
+    /**
+     * no conclusion can be made yet
+     */
+    PENDING,
+    /**
+     * the failed replicas have failed the consistency level
+     */
+    FAILED,
 }

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobConstants.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobConstants.java
@@ -28,6 +28,7 @@ public class RestoreJobConstants
     public static final String JOB_STATUS = "status";
     public static final String JOB_SECRETS = "secrets";
     public static final String JOB_EXPIRE_AT = "expireAt";
+    public static final String JOB_SLICE_COUNT = "sliceCount";
     public static final String JOB_IMPORT_OPTIONS = "importOptions";
     public static final String JOB_CREATED_AT = "createdAt";
     public static final String JOB_KEYSPACE = "keyspace";
@@ -52,10 +53,11 @@ public class RestoreJobConstants
     public static final String CREDENTIALS_REGION = "region";
 
     // -- restore job status fields
-    public static final String JOB_STATUS_MESSAGE = "message";
-    public static final String JOB_STATUS_SUMMARY = "summary";
-    public static final String JOB_STATUS_FAILED_RANGES = "failedRanges";
-    public static final String JOB_STATUS_ABORTED_RANGES = "abortedRanges";
-    public static final String JOB_STATUS_PENDING_RANGES = "pendingRanges";
-    public static final String JOB_STATUS_SUCCEEDED_RANGES = "succeededRanges";
+    public static final String JOB_PROGRESS_MESSAGE = "message";
+    public static final String JOB_PROGRESS_STATUS = "status";
+    public static final String JOB_PROGRESS_SUMMARY = "summary";
+    public static final String JOB_PROGRESS_FAILED_RANGES = "failedRanges";
+    public static final String JOB_PROGRESS_ABORTED_RANGES = "abortedRanges";
+    public static final String JOB_PROGRESS_PENDING_RANGES = "pendingRanges";
+    public static final String JOB_PROGRESS_SUCCEEDED_RANGES = "succeededRanges";
 }

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/data/UpdateRestoreJobRequestPayload.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/data/UpdateRestoreJobRequestPayload.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.cassandra.sidecar.common.DataObjectBuilder;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.jetbrains.annotations.Nullable;
@@ -31,6 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_AGENT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_EXPIRE_AT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_SECRETS;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_SLICE_COUNT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS;
 
 /**
@@ -43,18 +45,35 @@ public class UpdateRestoreJobRequestPayload
     private final RestoreJobSecrets secrets;
     private final RestoreJobStatus status;
     private final Long expireAtInMillis; // timestamp; use Long because the field can be absent
+    private final Long sliceCount; // number of slices (s3 objects) produced by the job; use Long as the field can be absent
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
 
     // NOTE: if adding a new field, update isEmpty() and toString()
     @JsonCreator
     public UpdateRestoreJobRequestPayload(@JsonProperty(JOB_AGENT) String jobAgent,
                                           @JsonProperty(JOB_SECRETS) RestoreJobSecrets secrets,
                                           @JsonProperty(JOB_STATUS) RestoreJobStatus status,
-                                          @JsonProperty(JOB_EXPIRE_AT) Long expireAtInMillis)
+                                          @JsonProperty(JOB_EXPIRE_AT) Long expireAtInMillis,
+                                          @JsonProperty(JOB_SLICE_COUNT) Long sliceCount)
     {
         this.jobAgent = jobAgent;
         this.secrets = secrets;
         this.status = status;
         this.expireAtInMillis = expireAtInMillis;
+        this.sliceCount = sliceCount;
+    }
+
+    private UpdateRestoreJobRequestPayload(Builder builder)
+    {
+        this.jobAgent = builder.jobAgent;
+        this.secrets = builder.secrets;
+        this.status = builder.status;
+        this.expireAtInMillis = builder.expireAtInMillis;
+        this.sliceCount = builder.sliceCount;
     }
 
     /**
@@ -94,6 +113,15 @@ public class UpdateRestoreJobRequestPayload
     }
 
     /**
+     * @return number of total slices (s3 objects) produced. The field is only present when the restore job is managed by Sidecar
+     */
+    @Nullable @JsonProperty(JOB_SLICE_COUNT)
+    public Long sliceCount()
+    {
+        return sliceCount;
+    }
+
+    /**
      * Convert the expireAtInMillis timestamp as {@link Date}
      * @return date or null
      */
@@ -107,7 +135,7 @@ public class UpdateRestoreJobRequestPayload
     @JsonIgnore
     public boolean isEmpty()
     {
-        return jobAgent == null && secrets == null && status == null && expireAtInMillis == null;
+        return jobAgent == null && secrets == null && status == null && expireAtInMillis == null && sliceCount == null;
     }
 
     /**
@@ -119,6 +147,56 @@ public class UpdateRestoreJobRequestPayload
                JOB_AGENT + "='" + jobAgent + "', " +
                JOB_STATUS + "='" + status + "', " +
                JOB_SECRETS + "='" + secrets + "', " +
-               JOB_EXPIRE_AT + "='" + expireAtInMillis + "'}";
+               JOB_EXPIRE_AT + "='" + expireAtInMillis + "', " +
+               JOB_SLICE_COUNT + "='" + sliceCount + "'}";
+    }
+
+    /**
+     * Builder for {@link UpdateRestoreJobRequestPayload}
+     */
+    public static class Builder implements DataObjectBuilder<Builder, UpdateRestoreJobRequestPayload>
+    {
+        private String jobAgent;
+        private RestoreJobSecrets secrets;
+        private RestoreJobStatus status;
+        private Long expireAtInMillis; // timestamp; use Long because the field can be absent
+        private Long sliceCount; // number of slices (s3 objects) produced by the job; use Long as the field can be absent
+
+        public Builder withJobAgent(String jobAgent)
+        {
+            return update(b -> b.jobAgent = jobAgent);
+        }
+
+        public Builder withSecrets(RestoreJobSecrets secrets)
+        {
+            return update(b -> b.secrets = secrets);
+        }
+
+        public Builder withStatus(RestoreJobStatus status)
+        {
+            return update(b -> b.status = status);
+        }
+
+        public Builder withExpireAtInMillis(Long expireAtInMillis)
+        {
+            return update(b -> b.expireAtInMillis = expireAtInMillis);
+        }
+
+        public Builder withSliceCount(Long sliceCount)
+        {
+            return update(b -> b.sliceCount = sliceCount);
+        }
+
+        @Override
+        public Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        public UpdateRestoreJobRequestPayload build()
+        {
+            return new UpdateRestoreJobRequestPayload(this);
+        }
     }
 }

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/data/RestoreJobProgressResponsePayload.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/data/RestoreJobProgressResponsePayload.java
@@ -26,16 +26,18 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.sidecar.common.DataObjectBuilder;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.request.RestoreJobProgressRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS_ABORTED_RANGES;
-import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS_FAILED_RANGES;
-import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS_MESSAGE;
-import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS_PENDING_RANGES;
-import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS_SUCCEEDED_RANGES;
-import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_STATUS_SUMMARY;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_ABORTED_RANGES;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_FAILED_RANGES;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_MESSAGE;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_PENDING_RANGES;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_STATUS;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_SUCCEEDED_RANGES;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_PROGRESS_SUMMARY;
 
 /**
  * A class representing a response for the {@link RestoreJobProgressRequest}.
@@ -45,6 +47,7 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_S
 public class RestoreJobProgressResponsePayload
 {
     private final String message;
+    private final ConsistencyVerificationResult status;
     private final RestoreJobSummaryResponsePayload summary;
     // the ranges can be null/absent, if they are not required to be included in the response payload, depending on the fetch policy
     @Nullable // failed due to unrecoverable exceptions
@@ -68,14 +71,16 @@ public class RestoreJobProgressResponsePayload
      * Constructor for json deserialization
      */
     @JsonCreator
-    public RestoreJobProgressResponsePayload(@NotNull @JsonProperty(JOB_STATUS_MESSAGE) String message,
-                                             @NotNull @JsonProperty(JOB_STATUS_SUMMARY) RestoreJobSummaryResponsePayload summary,
-                                             @Nullable @JsonProperty(JOB_STATUS_FAILED_RANGES) List<RestoreRangeJson> failedRanges,
-                                             @Nullable @JsonProperty(JOB_STATUS_ABORTED_RANGES) List<RestoreRangeJson> abortedRanges,
-                                             @Nullable @JsonProperty(JOB_STATUS_PENDING_RANGES) List<RestoreRangeJson> pendingRanges,
-                                             @Nullable @JsonProperty(JOB_STATUS_SUCCEEDED_RANGES) List<RestoreRangeJson> succeededRanges)
+    public RestoreJobProgressResponsePayload(@NotNull @JsonProperty(JOB_PROGRESS_MESSAGE) String message,
+                                             @NotNull @JsonProperty(JOB_PROGRESS_STATUS) ConsistencyVerificationResult status,
+                                             @NotNull @JsonProperty(JOB_PROGRESS_SUMMARY) RestoreJobSummaryResponsePayload summary,
+                                             @Nullable @JsonProperty(JOB_PROGRESS_FAILED_RANGES) List<RestoreRangeJson> failedRanges,
+                                             @Nullable @JsonProperty(JOB_PROGRESS_ABORTED_RANGES) List<RestoreRangeJson> abortedRanges,
+                                             @Nullable @JsonProperty(JOB_PROGRESS_PENDING_RANGES) List<RestoreRangeJson> pendingRanges,
+                                             @Nullable @JsonProperty(JOB_PROGRESS_SUCCEEDED_RANGES) List<RestoreRangeJson> succeededRanges)
     {
         this.message = message;
+        this.status = status;
         this.summary = summary;
         this.failedRanges = failedRanges;
         this.abortedRanges = abortedRanges;
@@ -86,6 +91,7 @@ public class RestoreJobProgressResponsePayload
     private RestoreJobProgressResponsePayload(Builder builder)
     {
         this(builder.message,
+             builder.status,
              builder.summary,
              builder.failedRanges,
              builder.abortedRanges,
@@ -94,42 +100,49 @@ public class RestoreJobProgressResponsePayload
     }
 
     @NotNull
-    @JsonProperty(JOB_STATUS_MESSAGE)
+    @JsonProperty(JOB_PROGRESS_MESSAGE)
     public String message()
     {
         return this.message;
     }
 
     @NotNull
-    @JsonProperty(JOB_STATUS_SUMMARY)
+    @JsonProperty(JOB_PROGRESS_STATUS)
+    public ConsistencyVerificationResult status()
+    {
+        return this.status;
+    }
+
+    @NotNull
+    @JsonProperty(JOB_PROGRESS_SUMMARY)
     public RestoreJobSummaryResponsePayload summary()
     {
         return this.summary;
     }
 
     @Nullable
-    @JsonProperty(JOB_STATUS_FAILED_RANGES)
+    @JsonProperty(JOB_PROGRESS_FAILED_RANGES)
     public List<RestoreRangeJson> failedRanges()
     {
         return this.failedRanges;
     }
 
     @Nullable
-    @JsonProperty(JOB_STATUS_ABORTED_RANGES)
+    @JsonProperty(JOB_PROGRESS_ABORTED_RANGES)
     public List<RestoreRangeJson> abortedRanges()
     {
         return this.abortedRanges;
     }
 
     @Nullable
-    @JsonProperty(JOB_STATUS_PENDING_RANGES)
+    @JsonProperty(JOB_PROGRESS_PENDING_RANGES)
     public List<RestoreRangeJson> pendingRanges()
     {
         return this.pendingRanges;
     }
 
     @Nullable
-    @JsonProperty(JOB_STATUS_SUCCEEDED_RANGES)
+    @JsonProperty(JOB_PROGRESS_SUCCEEDED_RANGES)
     public List<RestoreRangeJson> succeededRanges()
     {
         return this.succeededRanges;
@@ -141,11 +154,17 @@ public class RestoreJobProgressResponsePayload
     public static class Builder implements DataObjectBuilder<Builder, RestoreJobProgressResponsePayload>
     {
         String message;
+        ConsistencyVerificationResult status;
         RestoreJobSummaryResponsePayload summary;
         List<RestoreRangeJson> failedRanges = null;
         List<RestoreRangeJson> abortedRanges = null;
         List<RestoreRangeJson> pendingRanges = null;
         List<RestoreRangeJson> succeededRanges = null;
+
+        public Builder withStatus(ConsistencyVerificationResult status)
+        {
+            return update(b -> b.status = status);
+        }
 
         public Builder withMessage(String message)
         {

--- a/client-common/src/test/java/org/apache/cassandra/sidecar/common/request/UpdateRestoreJobRequestPayloadTest.java
+++ b/client-common/src/test/java/org/apache/cassandra/sidecar/common/request/UpdateRestoreJobRequestPayloadTest.java
@@ -47,6 +47,7 @@ class UpdateRestoreJobRequestPayloadTest
         assertThat(req.status()).isNull();
         assertThat(req.expireAtInMillis()).isNull();
         assertThat(req.expireAtAsDate()).isNull();
+        assertThat(req.sliceCount()).isNull();
         assertThat(req.secrets()).isNull();
     }
 
@@ -60,6 +61,19 @@ class UpdateRestoreJobRequestPayloadTest
 
         assertThat(req.expireAtAsDate()).isEqualTo(date);
         assertThat(req.expireAtInMillis()).isEqualTo(time);
+
+        assertThat(mapper.writeValueAsString(req)).isEqualTo(json);
+    }
+
+    @Test
+    void testSliceCount() throws JsonProcessingException
+    {
+        long sliceCount = 123L;
+        String json = "{\"sliceCount\":" + sliceCount + "}";
+        UpdateRestoreJobRequestPayload req = mapper.readValue(json, UpdateRestoreJobRequestPayload.class);
+        assertThat(req.sliceCount()).isEqualTo(sliceCount);
+
+        assertThat(mapper.writeValueAsString(req)).isEqualTo(json);
     }
 
     @Test
@@ -67,12 +81,13 @@ class UpdateRestoreJobRequestPayloadTest
     {
         RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
         UpdateRestoreJobRequestPayload payload = new UpdateRestoreJobRequestPayload(null, secrets
-                                                                                    , null, null);
+                                                                                    , null, null, null);
         String json = mapper.writeValueAsString(payload);
         assertThat(json).contains(RestoreJobConstants.JOB_SECRETS)
                         .doesNotContain(RestoreJobConstants.JOB_AGENT,
                                         RestoreJobConstants.JOB_EXPIRE_AT,
-                                        RestoreJobConstants.JOB_STATUS)
+                                        RestoreJobConstants.JOB_STATUS,
+                                        RestoreJobConstants.JOB_SLICE_COUNT)
                         .doesNotContain("empty"); // ignored by @JsonIgnore
     }
 }

--- a/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/ICassandraAdapter.java
+++ b/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/ICassandraAdapter.java
@@ -25,6 +25,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.Statement;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Core Cassandra Adapter interface
@@ -63,10 +64,18 @@ public interface ICassandraAdapter
     ResultSet executeLocal(Statement statement);
 
     /**
-     * The address on which the local instance is listening for CQL connections
-     * @return the {@link InetSocketAddress} representing the local address and port.
+     * The address on which the local Cassandra instance is listening for CQL connections
+     * @return the {@link InetSocketAddress} representing the address and port.
      */
-    InetSocketAddress localNativeTransportPort();
+    InetSocketAddress localNativeTransportAddress();
+
+    /**
+     * The address on which the local Cassandra instance broadcasts the intra-cluster storage traffic
+     * @return the {@link InetSocketAddress} representing the address and port.
+     *         When CQL connection is not yet established, returns null
+     */
+    @Nullable
+    InetSocketAddress localStorageBroadcastAddress();
 
     /**
      * @return the {@link StorageOperations} implementation for the Cassandra cluster

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegate.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegate.java
@@ -384,9 +384,15 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
     }
 
     @Override
-    public InetSocketAddress localNativeTransportPort()
+    public InetSocketAddress localNativeTransportAddress()
     {
-        return fromAdapter(ICassandraAdapter::localNativeTransportPort);
+        return fromAdapter(ICassandraAdapter::localNativeTransportAddress);
+    }
+
+    @Override
+    public InetSocketAddress localStorageBroadcastAddress()
+    {
+        return fromAdapter(ICassandraAdapter::localStorageBroadcastAddress);
     }
 
     @Nullable

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/ConsistencyVerifier.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/ConsistencyVerifier.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.sidecar.cluster;
 import java.util.Set;
 
 import org.apache.cassandra.sidecar.cluster.locator.InstanceSetByDc;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -35,15 +36,5 @@ public interface ConsistencyVerifier
      *                  instances are grouped by dc
      * @return result
      */
-    Result verify(@NotNull Set<String> succeeded, @NotNull Set<String> failed, @NotNull InstanceSetByDc all);
-
-    /**
-     * Verification result
-     */
-    enum Result
-    {
-        SATISFIED,  // the passed replicas have satisfied the consistency level
-        PENDING,    // no conclusion can be made yet
-        FAILED,     // the failed replicas have failed the consistency level
-    }
+    ConsistencyVerificationResult verify(@NotNull Set<String> succeeded, @NotNull Set<String> failed, @NotNull InstanceSetByDc all);
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadata.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.cluster.instance;
 
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.metrics.instance.InstanceMetrics;
@@ -41,7 +42,7 @@ public interface InstanceMetadata
     String host();
 
     /**
-     * @return the port number of the Cassandra instance
+     * @return the native transport port number of the Cassandra instance
      */
     int port();
 
@@ -58,10 +59,24 @@ public interface InstanceMetadata
     /**
      * @return a {@link CassandraAdapterDelegate} specific for the instance
      */
-    @Nullable CassandraAdapterDelegate delegate();
+    @Nullable
+    CassandraAdapterDelegate delegate();
 
     /**
      * @return {@link InstanceMetrics} metrics specific for the Cassandra instance
      */
     @NotNull InstanceMetrics metrics();
+
+    /**
+     * Get value from {@link CassandraAdapterDelegate}
+     * @param mapper the function is evaluated only when delegate is not null
+     * @return value retrieved from {@link CassandraAdapterDelegate} or null
+     * @param <T> value type
+     */
+    @Nullable
+    default <T> T getFromDelegate(Function<CassandraAdapterDelegate, T> mapper)
+    {
+        CassandraAdapterDelegate delegate = delegate();
+        return delegate == null ? null : mapper.apply(delegate);
+    }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadata.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadata.java
@@ -74,7 +74,7 @@ public interface InstanceMetadata
      * @param <T> value type
      */
     @Nullable
-    default <T> T getFromDelegate(Function<CassandraAdapterDelegate, T> mapper)
+    default <T> T applyFromDelegate(Function<CassandraAdapterDelegate, T> mapper)
     {
         CassandraAdapterDelegate delegate = delegate();
         return delegate == null ? null : mapper.apply(delegate);

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJob.java
@@ -64,6 +64,7 @@ public class RestoreJob
     public final @Nullable ConsistencyLevel consistencyLevel;
     public final @Nullable String localDatacenter;
     public final Manager restoreJobManager;
+    public final Long sliceCount;
 
     private final String statusText;
 
@@ -92,7 +93,8 @@ public class RestoreJob
                .expireAt(row.getTimestamp("expire_at"))
                .sstableImportOptions(decodeSSTableImportOptions(row.getBytes("import_options")))
                .consistencyLevel(consistencyConfig.consistencyLevel)
-               .localDatacenter(consistencyConfig.localDatacenter);
+               .localDatacenter(consistencyConfig.localDatacenter)
+               .sliceCount(row.get("slice_count", Long.class));
 
         return builder.build();
     }
@@ -155,6 +157,7 @@ public class RestoreJob
         this.consistencyLevel = builder.consistencyLevel;
         this.localDatacenter = builder.localDatacenter;
         this.restoreJobManager = builder.manager;
+        this.sliceCount = builder.sliceCount;
     }
 
     public Builder unbuild()
@@ -244,6 +247,7 @@ public class RestoreJob
         private ConsistencyLevel consistencyLevel;
         private String localDatacenter;
         private Manager manager;
+        private Long sliceCount;
 
         private Builder()
         {
@@ -265,6 +269,8 @@ public class RestoreJob
             this.bucketCount = restoreJob.bucketCount;
             this.consistencyLevel = restoreJob.consistencyLevel;
             this.localDatacenter = restoreJob.localDatacenter;
+            this.manager = restoreJob.restoreJobManager;
+            this.sliceCount = restoreJob.sliceCount;
         }
 
         public Builder createdAt(LocalDate createdAt)
@@ -326,6 +332,11 @@ public class RestoreJob
         public Builder expireAt(Date expireAt)
         {
             return update(b -> b.expireAt = expireAt);
+        }
+
+        public Builder sliceCount(Long sliceCount)
+        {
+            return update(b -> b.sliceCount = sliceCount);
         }
 
         public Builder bucketCount(short bucketCount)

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessor.java
@@ -124,6 +124,7 @@ public class RestoreJobDatabaseAccessor extends DatabaseAccessor<RestoreJobsSche
         RestoreJobStatus status = payload.status();
         String jobAgent = payload.jobAgent();
         Date expireAt = payload.expireAtAsDate();
+        Long sliceCount = payload.sliceCount();
         // all updates are going to the same partition. We use unlogged explicitly.
         // Cassandra internally combine those updates into the same mutation.
         BatchStatement batchStatement = new BatchStatement(BatchStatement.Type.UNLOGGED);
@@ -157,6 +158,11 @@ public class RestoreJobDatabaseAccessor extends DatabaseAccessor<RestoreJobsSche
         {
             batchStatement.add(tableSchema.updateExpireAt().bind(createdAt, jobId, expireAt));
             updateBuilder.expireAt(expireAt);
+        }
+        if (sliceCount != null)
+        {
+            batchStatement.add(tableSchema.updateSliceCount().bind(createdAt, jobId, sliceCount));
+            updateBuilder.sliceCount(sliceCount);
         }
 
         execute(batchStatement);

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreRange.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreRange.java
@@ -189,7 +189,6 @@ public class RestoreRange
                && Objects.equals(this.bucketId, that.bucketId)
                && Objects.equals(this.sliceId, that.sliceId);
     }
-
     // -- INTERNAL FLOW CONTROL METHODS --
 
     /**
@@ -381,7 +380,7 @@ public class RestoreRange
 
     public Map<String, RestoreRangeStatus> statusByReplica()
     {
-        return statusByReplica;
+        return Collections.unmodifiableMap(statusByReplica);
     }
 
     public Map<String, String> statusTextByReplica()
@@ -502,7 +501,7 @@ public class RestoreRange
     {
         try
         {
-            InetSocketAddress storageAddress = instance.getFromDelegate(CassandraAdapterDelegate::localStorageBroadcastAddress);
+            InetSocketAddress storageAddress = instance.applyFromDelegate(CassandraAdapterDelegate::localStorageBroadcastAddress);
             return storageAddress.getAddress().getHostAddress() + ':' + storageAddress.getPort();
         }
         catch (NullPointerException npe) // various places can throw NPE. Catch them all in one single place.

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreRange.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreRange.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.db;
 
 import java.math.BigInteger;
+import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import com.datastax.driver.core.Row;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.cluster.locator.LocalTokenRangesProvider;
 import org.apache.cassandra.sidecar.common.DataObjectBuilder;
@@ -50,14 +52,14 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * A {@link RestoreRange}, similar to {@link RestoreSlice}, represents the data of a narrower token range.
- *
+ * <p>
  * Conceptually, a {@link RestoreSlice} can be split into multiple {@link RestoreRange}s. A range only belongs to,
  * i.e. fully enclosed in, a slice. In other words, a range is derived from a lice.
  * As slices do not overlap, the ranges have no overlap too.
  * When no split is needed for a slice, its range is equivalent to itself, in terms of token range.
- *
+ * <p>
  * In additional, {@link RestoreRange} contains the control flow of applying/importing data to Cassandra.
- *
+ * <p>
  * Why is {@link RestoreRange} required?
  * Range is introduced to better align with the current Cassandra token topology.
  * Restore slice represents the client-side generated dataset and its token range,
@@ -65,13 +67,15 @@ import org.jetbrains.annotations.VisibleForTesting;
  * On the server side, especially the token topology of Cassandra has changed, there can be no exact match of the
  * token range of a slice and the Cassandra node's owning token range. The slice has to be split into ranges that fit
  * into the Cassandra nodes properly.
- *
- *
+ * <p>
  * How the staged files are organized on disk?
+ * <p>
  * For each slice,
- * - the S3 object is downloaded to the path at "stageDirectory/key". It is a zip file.
- * - the zip is then extracted to the directory at "stageDirectory/keyspace/table/".
- *   The extracted sstables are imported into Cassandra.
+ * <ul>
+ *     <li>the S3 object is downloaded to the path at "stageDirectory/key". It is a zip file.</li>
+ *     <li>the zip is then extracted to the directory at "stageDirectory/keyspace/table/".
+ *     The extracted sstables are imported into Cassandra.</li>
+ * </ul>
  */
 public class RestoreRange
 {
@@ -147,7 +151,7 @@ public class RestoreRange
         this.stagedObjectPath = builder.stagedObjectPath;
         this.uploadId = builder.uploadId;
         this.owner = builder.owner;
-        this.statusByReplica = builder.statusByReplica;
+        this.statusByReplica = new HashMap<>(builder.statusByReplica);
         this.tracker = builder.tracker;
     }
 
@@ -202,6 +206,7 @@ public class RestoreRange
     public void completeStagePhase()
     {
         this.hasStaged = true;
+        updateRangeStatusForInstance(owner(), RestoreRangeStatus.STAGED);
     }
 
     /**
@@ -210,11 +215,7 @@ public class RestoreRange
     public void completeImportPhase()
     {
         this.hasImported = true;
-    }
-
-    public void failAtInstance(int instanceId)
-    {
-        statusByReplica.put(String.valueOf(instanceId), RestoreRangeStatus.FAILED);
+        updateRangeStatusForInstance(owner(), RestoreRangeStatus.SUCCEEDED);
     }
 
     /**
@@ -223,7 +224,7 @@ public class RestoreRange
     public void fail(RestoreJobFatalException exception)
     {
         tracker.fail(exception);
-        failAtInstance(owner().id());
+        updateRangeStatusForInstance(owner(), RestoreRangeStatus.FAILED);
     }
 
     /**
@@ -484,6 +485,30 @@ public class RestoreRange
             return null;
         }
         return func.apply(source);
+    }
+
+    private void updateRangeStatusForInstance(InstanceMetadata instance, RestoreRangeStatus status)
+    {
+        // skip if the belong job is not managed by sidecar
+        if (!job().isManagedBySidecar())
+        {
+            return;
+        }
+
+        statusByReplica.put(storageAddressWithPort(instance), status);
+    }
+
+    private String storageAddressWithPort(InstanceMetadata instance)
+    {
+        try
+        {
+            InetSocketAddress storageAddress = instance.getFromDelegate(CassandraAdapterDelegate::localStorageBroadcastAddress);
+            return storageAddress.getAddress().getHostAddress() + ':' + storageAddress.getPort();
+        }
+        catch (NullPointerException npe) // various places can throw NPE. Catch them all in one single place.
+        {
+            throw new NullPointerException("Unexpected null storageBroadcastAddress from CassandraAdapter");
+        }
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/AbstractSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/AbstractSchema.java
@@ -21,6 +21,7 @@ package org.apache.cassandra.sidecar.db.schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
@@ -44,7 +45,7 @@ abstract class AbstractSchema
 
     protected PreparedStatement prepare(PreparedStatement cached, Session session, String cqlLiteral)
     {
-        return cached == null ? session.prepare(cqlLiteral) : cached;
+        return cached == null ? session.prepare(cqlLiteral).setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM) : cached;
     }
 
     protected boolean initializeInternal(@NotNull Session session)

--- a/server/src/main/java/org/apache/cassandra/sidecar/exceptions/RestoreJobExceptions.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/exceptions/RestoreJobExceptions.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.exceptions;
 
 import org.apache.cassandra.sidecar.db.RestoreRange;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility methods to create {@link RestoreJobException}
@@ -28,18 +29,31 @@ public class RestoreJobExceptions
     private RestoreJobExceptions() {}
 
     /**
+     * Create a {@link RestoreJobException} with cause.
+     * If the cause is already a {@link RestoreJobException}, the retryable property is preserved.
+     * @param cause
+     * @return a new {@link RestoreJobException}
+     */
+    public static RestoreJobException propagate(Throwable cause)
+    {
+        return propagate(null, cause);
+    }
+
+    /**
      * Create a {@link RestoreJobException} with message and cause.
      * If the cause is already a {@link RestoreJobException}, the retryable property is preserved.
      * @param message
      * @param cause
      * @return a new {@link RestoreJobException}
      */
-    public static RestoreJobException propagate(String message, Throwable cause)
+    public static RestoreJobException propagate(@Nullable String message, Throwable cause)
     {
         String concatMessage = message;
         if (cause.getMessage() != null)
         {
-            concatMessage = concatMessage + ':' + cause.getMessage();
+            concatMessage = concatMessage == null
+                            ? cause.getMessage()
+                            : concatMessage + ':' + cause.getMessage();
         }
         if (cause instanceof RestoreJobException)
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelChecker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelChecker.java
@@ -109,7 +109,7 @@ public class RestoreJobConsistencyLevelChecker
                    if (shouldForceRestoreJobDiscoverRun(restoreJob, ranges))
                    {
                        // schedule the adhoc restore job discovery in a background thread.
-                       taskExecutorPool.runBlocking(restoreJobDiscoverer::tryExecute, false);
+                       taskExecutorPool.runBlocking(restoreJobDiscoverer::tryExecuteDiscovery, false);
                        return RestoreJobProgress.pending(restoreJob);
                    }
                    concludeRanges(ranges, topology, verifier, successCriteria, collector);

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelChecker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelChecker.java
@@ -34,7 +34,9 @@ import io.vertx.core.Future;
 import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
 import org.apache.cassandra.sidecar.cluster.ConsistencyVerifiers;
 import org.apache.cassandra.sidecar.cluster.locator.InstanceSetByDc;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.data.RestoreJobProgressFetchPolicy;
+import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.Token;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.TokenRange;
@@ -62,15 +64,19 @@ public class RestoreJobConsistencyLevelChecker
     private static final Logger LOGGER = LoggerFactory.getLogger(RestoreJobConsistencyLevelChecker.class);
 
     private final RingTopologyRefresher ringTopologyRefresher;
+    private final RestoreJobDiscoverer restoreJobDiscoverer;
     private final RestoreRangeDatabaseAccessor rangeDatabaseAccessor;
     private final TaskExecutorPool taskExecutorPool;
+    private volatile boolean firstTimeSinceImportReady = true;
 
     @Inject
     public RestoreJobConsistencyLevelChecker(RingTopologyRefresher ringTopologyRefresher,
+                                             RestoreJobDiscoverer restoreJobDiscoverer,
                                              RestoreRangeDatabaseAccessor rangeDatabaseAccessor,
                                              ExecutorPools executorPools)
     {
         this.ringTopologyRefresher = ringTopologyRefresher;
+        this.restoreJobDiscoverer = restoreJobDiscoverer;
         this.rangeDatabaseAccessor = rangeDatabaseAccessor;
         this.taskExecutorPool = executorPools.internal();
     }
@@ -100,14 +106,35 @@ public class RestoreJobConsistencyLevelChecker
                    return rangeDatabaseAccessor.findAll(restoreJob.jobId, bucketId);
                })
                .map(ranges -> {
-                   if (ranges.isEmpty())
+                   if (shouldForceRestoreJobDiscoverRun(restoreJob, ranges))
                    {
-                       LOGGER.error("No restore ranges found. jobId={}", restoreJob.jobId);
-                       throw new IllegalStateException("No restore ranges found for job: " + restoreJob.jobId);
+                       // schedule the adhoc restore job discovery in a background thread.
+                       taskExecutorPool.runBlocking(restoreJobDiscoverer::executeBlocking, false);
+                       return RestoreJobProgress.pending(restoreJob);
                    }
                    concludeRanges(ranges, topology, verifier, successCriteria, collector);
                    return collector.toRestoreJobProgress();
                });
+    }
+
+    private boolean shouldForceRestoreJobDiscoverRun(RestoreJob restoreJob, List<RestoreRange> ranges)
+    {
+        long foundSliceCount = sliceCountFromRanges(ranges);
+        if (foundSliceCount < restoreJob.sliceCount)
+        {
+            LOGGER.warn("Not all restore ranges are found. Mark the progress as pending and force restore job discover run. " +
+                        "jobId={} expectedSliceCount={} foundSliceCount={}", restoreJob.jobId, restoreJob.sliceCount, foundSliceCount);
+            return true;
+        }
+
+        if (restoreJob.status == RestoreJobStatus.IMPORT_READY && firstTimeSinceImportReady)
+        {
+            firstTimeSinceImportReady = false;
+            LOGGER.info("First time checking consistency of the restore job after import_ready. " +
+                        "Mark the progress as pending and force restore job discover run. jobId={}", restoreJob.jobId);
+            return true;
+        }
+        return false;
     }
 
     private static void concludeRanges(List<RestoreRange> ranges,
@@ -123,7 +150,7 @@ public class RestoreJobConsistencyLevelChecker
                 return;
             }
 
-            ConsistencyVerifier.Result res = concludeOneRange(topology, verifier, successCriteria, range);
+            ConsistencyVerificationResult res = concludeOneRange(topology, verifier, successCriteria, range);
             collector.collect(range, res);
         }
     }
@@ -140,10 +167,10 @@ public class RestoreJobConsistencyLevelChecker
      * @param range range to check
      * @return result of the consistency verification
      */
-    private static ConsistencyVerifier.Result concludeOneRange(TokenRangeReplicasResponse topology,
-                                                               ConsistencyVerifier verifier,
-                                                               RestoreRangeStatus successCriteria,
-                                                               RestoreRange range)
+    private static ConsistencyVerificationResult concludeOneRange(TokenRangeReplicasResponse topology,
+                                                                  ConsistencyVerifier verifier,
+                                                                  RestoreRangeStatus successCriteria,
+                                                                  RestoreRange range)
     {
         Map<RestoreRangeStatus, Set<String>> groupByStatus = groupReplicaByStatus(range.statusByReplica());
         Set<String> succeeded = groupByStatus.getOrDefault(successCriteria, Collections.emptySet());
@@ -151,18 +178,18 @@ public class RestoreJobConsistencyLevelChecker
         InstanceSetByDc replicaSet = replicaSetForRange(range, topology);
         if (replicaSet == null) // cannot proceed to verify yet. Return pending
         {
-            return ConsistencyVerifier.Result.PENDING;
+            return ConsistencyVerificationResult.PENDING;
         }
 
-        ConsistencyVerifier.Result result = verifier.verify(succeeded, failed, replicaSet);
+        ConsistencyVerificationResult result = verifier.verify(succeeded, failed, replicaSet);
         switch (result)
         {
             case FAILED:
-                return ConsistencyVerifier.Result.FAILED;
+                return ConsistencyVerificationResult.FAILED;
             case PENDING:
-                return ConsistencyVerifier.Result.PENDING;
+                return ConsistencyVerificationResult.PENDING;
             default:
-                return ConsistencyVerifier.Result.SATISFIED;
+                return ConsistencyVerificationResult.SATISFIED;
         }
     }
 
@@ -208,11 +235,16 @@ public class RestoreJobConsistencyLevelChecker
         return null;
     }
 
+    private static long sliceCountFromRanges(List<RestoreRange> ranges)
+    {
+        return ranges.stream().map(RestoreRange::sliceId).distinct().count();
+    }
+
     @VisibleForTesting
-    static ConsistencyVerifier.Result concludeOneRangeUnsafe(TokenRangeReplicasResponse topology,
-                                                             ConsistencyVerifier verifier,
-                                                             RestoreRangeStatus successCriteria,
-                                                             RestoreRange range)
+    static ConsistencyVerificationResult concludeOneRangeUnsafe(TokenRangeReplicasResponse topology,
+                                                                ConsistencyVerifier verifier,
+                                                                RestoreRangeStatus successCriteria,
+                                                                RestoreRange range)
     {
         return concludeOneRange(topology, verifier, successCriteria, range);
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelChecker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelChecker.java
@@ -109,7 +109,7 @@ public class RestoreJobConsistencyLevelChecker
                    if (shouldForceRestoreJobDiscoverRun(restoreJob, ranges))
                    {
                        // schedule the adhoc restore job discovery in a background thread.
-                       taskExecutorPool.runBlocking(restoreJobDiscoverer::executeBlocking, false);
+                       taskExecutorPool.runBlocking(restoreJobDiscoverer::tryExecute, false);
                        return RestoreJobProgress.pending(restoreJob);
                    }
                    concludeRanges(ranges, topology, verifier, successCriteria, collector);

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobDiscoverer.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobDiscoverer.java
@@ -163,7 +163,7 @@ public class RestoreJobDiscoverer implements PeriodicTask
     @Override
     public void execute(Promise<Void> promise)
     {
-        tryExecute();
+        tryExecuteDiscovery();
         promise.tryComplete();
     }
 
@@ -171,7 +171,7 @@ public class RestoreJobDiscoverer implements PeriodicTask
      * Try to execute the job discovery task in the blocking way. It returns immediately, if another thread is executing already.
      * The method can be invoked by external call-sites.
      */
-    public void tryExecute()
+    public void tryExecuteDiscovery()
     {
         if (!isExecuting.compareAndSet(false, true))
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobProgress.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobProgress.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
 import org.apache.cassandra.sidecar.common.DataObjectBuilder;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.response.data.RestoreJobProgressResponsePayload;
 import org.apache.cassandra.sidecar.common.response.data.RestoreRangeJson;
@@ -35,10 +35,17 @@ import org.jetbrains.annotations.Nullable;
 public class RestoreJobProgress
 {
     private final RestoreJob restoreJob;
-    private final ConsistencyVerifier.Result overallStatus;
+    private final ConsistencyVerificationResult overallStatus;
     private final List<RestoreRange> failedRanges;
     private final List<RestoreRange> pendingRanges;
     private final List<RestoreRange> succeededRanges;
+
+    public static RestoreJobProgress pending(RestoreJob restoreJob)
+    {
+        Builder builder = new Builder(restoreJob)
+                          .withOverallStatus(ConsistencyVerificationResult.PENDING);
+        return new RestoreJobProgress(builder);
+    }
 
     private RestoreJobProgress(Builder builder)
     {
@@ -52,6 +59,7 @@ public class RestoreJobProgress
     public RestoreJobProgressResponsePayload toResponsePayload()
     {
         return RestoreJobProgressResponsePayload.builder()
+                                                .withStatus(overallStatus)
                                                 .withSucceededRanges(toJson(succeededRanges))
                                                 .withFailedRanges(toJson(failedRanges))
                                                 .withPendingRanges(toJson(pendingRanges))
@@ -101,7 +109,7 @@ public class RestoreJobProgress
     static class Builder implements DataObjectBuilder<Builder, RestoreJobProgress>
     {
         private final RestoreJob restoreJob;
-        private ConsistencyVerifier.Result overallStatus;
+        private ConsistencyVerificationResult overallStatus;
         private List<RestoreRange> failedRanges;
         private List<RestoreRange> pendingRanges;
         private List<RestoreRange> succeededRanges;
@@ -111,7 +119,7 @@ public class RestoreJobProgress
             this.restoreJob = restoreJob;
         }
 
-        public Builder withOverallStatus(ConsistencyVerifier.Result overallStatus)
+        public Builder withOverallStatus(ConsistencyVerificationResult overallStatus)
         {
             return update(b -> b.overallStatus = overallStatus);
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollector.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollector.java
@@ -16,7 +16,7 @@
 
 package org.apache.cassandra.sidecar.restore;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.db.RestoreRange;
 
 /**
@@ -35,7 +35,7 @@ public interface RestoreJobProgressCollector
      * @param range a range to be restored
      * @param checkResult result of the consistency check
      */
-    void collect(RestoreRange range, ConsistencyVerifier.Result checkResult);
+    void collect(RestoreRange range, ConsistencyVerificationResult checkResult);
 
     /**
      * Produce the {@link RestoreJobProgress} from the collected per range progress

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectors.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectors.java
@@ -18,7 +18,7 @@
 
 package org.apache.cassandra.sidecar.restore;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier.Result;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.data.RestoreJobProgressFetchPolicy;
 import org.apache.cassandra.sidecar.db.RestoreJob;
 import org.apache.cassandra.sidecar.db.RestoreRange;
@@ -65,19 +65,19 @@ public class RestoreJobProgressCollectors
             progressBuilder = new RestoreJobProgress.Builder(restoreJob);
         }
 
-        protected boolean shouldSkip(Result checkResult)
+        protected boolean shouldSkip(ConsistencyVerificationResult checkResult)
         {
             return false;
         }
 
         @Override
-        public void collect(RestoreRange range, Result checkResult)
+        public void collect(RestoreRange range, ConsistencyVerificationResult checkResult)
         {
-            if (checkResult == Result.FAILED)
+            if (checkResult == ConsistencyVerificationResult.FAILED)
             {
                 seenFailed = true;
             }
-            else if (checkResult == Result.PENDING)
+            else if (checkResult == ConsistencyVerificationResult.PENDING)
             {
                 seenPending = true;
             }
@@ -104,24 +104,24 @@ public class RestoreJobProgressCollectors
         @Override
         public RestoreJobProgress toRestoreJobProgress()
         {
-            Result overallStatus = determineOverallStatus();
+            ConsistencyVerificationResult overallStatus = determineOverallStatus();
             return progressBuilder.withOverallStatus(overallStatus)
                                   .build();
         }
 
-        private Result determineOverallStatus()
+        private ConsistencyVerificationResult determineOverallStatus()
         {
             if (seenFailed)
             {
-                return Result.FAILED;
+                return ConsistencyVerificationResult.FAILED;
             }
             else if (seenPending)
             {
-                return Result.PENDING;
+                return ConsistencyVerificationResult.PENDING;
             }
             else
             {
-                return Result.SATISFIED;
+                return ConsistencyVerificationResult.SATISFIED;
             }
         }
     }
@@ -156,10 +156,10 @@ public class RestoreJobProgressCollectors
         }
 
         @Override
-        protected boolean shouldSkip(Result checkResult)
+        protected boolean shouldSkip(ConsistencyVerificationResult checkResult)
         {
             // do not collect the ranges that have satisfied
-            return checkResult == Result.SATISFIED || checkResult == Result.PENDING;
+            return checkResult == ConsistencyVerificationResult.SATISFIED || checkResult == ConsistencyVerificationResult.PENDING;
         }
     }
 
@@ -178,10 +178,10 @@ public class RestoreJobProgressCollectors
         }
 
         @Override
-        protected boolean shouldSkip(Result checkResult)
+        protected boolean shouldSkip(ConsistencyVerificationResult checkResult)
         {
             // do not collect the ranges that have satisfied
-            return checkResult == Result.SATISFIED;
+            return checkResult == ConsistencyVerificationResult.SATISFIED;
         }
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreRangeTask.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreRangeTask.java
@@ -150,7 +150,7 @@ public class RestoreRangeTask implements RestoreRangeHandler
                 {
                     if (Files.exists(range.stagedObjectPath()))
                     {
-                        LOGGER.info("The slice has been staged already. sliceKey={} stagedFilePath={}",
+                        LOGGER.debug("The slice has been staged already. sliceKey={} stagedFilePath={}",
                                      range.sliceKey(), range.stagedObjectPath());
                         range.completeStagePhase(); // update the flag if missed
                         rangeDatabaseAccessor.updateStatus(range);

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreRangeTask.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreRangeTask.java
@@ -146,11 +146,11 @@ public class RestoreRangeTask implements RestoreRangeHandler
             RestoreJob job = range.job();
             if (job.isManagedBySidecar())
             {
-                if (job.status == RestoreJobStatus.CREATED)
+                if (job.status == RestoreJobStatus.STAGE_READY)
                 {
                     if (Files.exists(range.stagedObjectPath()))
                     {
-                        LOGGER.debug("The slice has been staged already. sliceKey={} stagedFilePath={}",
+                        LOGGER.info("The slice has been staged already. sliceKey={} stagedFilePath={}",
                                      range.sliceKey(), range.stagedObjectPath());
                         range.completeStagePhase(); // update the flag if missed
                         rangeDatabaseAccessor.updateStatus(range);
@@ -170,7 +170,7 @@ public class RestoreRangeTask implements RestoreRangeHandler
                                return Future.succeededFuture();
                            });
                 }
-                else if (job.status == RestoreJobStatus.STAGED)
+                else if (job.status == RestoreJobStatus.IMPORT_READY)
                 {
                     return unzipAndImport(range.stagedObjectPath().toFile(),
                                           // persist status
@@ -178,7 +178,7 @@ public class RestoreRangeTask implements RestoreRangeHandler
                 }
                 else
                 {
-                    String msg = "Unexpected restore job status. Expected only CREATED or STAGED when " +
+                    String msg = "Unexpected restore job status. Expected only STAGE_READY or IMPORT_READY when " +
                                  "processing active slices. Found status: " + job.statusWithOptionalDescription();
                     Exception unexpectedState = new IllegalStateException(msg);
                     return Future.failedFuture(RestoreJobExceptions.ofFatal("Unexpected restore job status",
@@ -191,7 +191,7 @@ public class RestoreRangeTask implements RestoreRangeHandler
             }
         })
         .onSuccess(v -> event.tryComplete(range))
-        .onFailure(cause -> event.tryFail(RestoreJobExceptions.propagate(cause.getMessage(), cause)));
+        .onFailure(cause -> event.tryFail(RestoreJobExceptions.propagate(cause)));
     }
 
     private Future<Void> downloadSliceAndImport()
@@ -295,6 +295,7 @@ public class RestoreRangeTask implements RestoreRangeHandler
             {
                 LOGGER.warn("Downloading restore slice times out. sliceKey={}", range.sliceKey());
                 instanceMetrics.restore().sliceDownloadTimeouts.metric.update(1);
+                return Future.failedFuture(RestoreJobExceptions.of("Download object times out. Retry later", range, cause));
             }
             return Future.failedFuture(RestoreJobExceptions.ofFatal("Unrecoverable error when downloading object", range, cause));
         });
@@ -331,13 +332,12 @@ public class RestoreRangeTask implements RestoreRangeHandler
                success -> { // successMapper
                    if (onSuccessCommit == null)
                    {
-                       range.completeImportPhase();
                        return Future.succeededFuture();
                    }
 
                    return executorPool.runBlocking(() -> {
-                       onSuccessCommit.run();
                        range.completeImportPhase();
+                       onSuccessCommit.run();
                    });
                },
                failure -> { // failureMapper

--- a/server/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTask.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTask.java
@@ -80,7 +80,7 @@ public interface PeriodicTask
 
     /**
      * Specify whether the task should be skipped.
-     *
+     * // TODO: consider returning the reason to skip, instead of just a boolean value
      * @return {@code true} to skip; otherwise, return {@code false}
      */
     default boolean shouldSkip()

--- a/server/src/test/integration/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessorIntTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessorIntTest.java
@@ -54,8 +54,15 @@ class RestoreJobDatabaseAccessorIntTest extends IntegrationTestBase
         assertThat(foundJobs).hasSize(1);
         assertJob(foundJobs.get(0), jobId, RestoreJobStatus.CREATED, expiresAtMillis, secrets);
         assertJob(accessor.find(jobId), jobId, RestoreJobStatus.CREATED, expiresAtMillis, secrets);
+
+        // update the slice count field and verify the correct value is read back
+        UpdateRestoreJobRequestPayload setSliceCount
+        = new UpdateRestoreJobRequestPayload(null, null, null, null, 100L);
+        accessor.update(setSliceCount, jobId);
+        assertThat(accessor.find(jobId).sliceCount).isEqualTo(100L);
+
         UpdateRestoreJobRequestPayload markSucceeded
-        = new UpdateRestoreJobRequestPayload(null, null, RestoreJobStatus.SUCCEEDED, null);
+        = new UpdateRestoreJobRequestPayload(null, null, RestoreJobStatus.SUCCEEDED, null, null);
         accessor.update(markSucceeded, jobId);
         assertJob(accessor.find(jobId), jobId, RestoreJobStatus.SUCCEEDED, expiresAtMillis, secrets);
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/cluster/ConsistencyVerifiersTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cluster/ConsistencyVerifiersTest.java
@@ -27,9 +27,9 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier.Result;
 import org.apache.cassandra.sidecar.cluster.locator.InstanceSetByDc;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,17 +46,17 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(Collections.emptySet(), // no passed instances
                                    replicas(1, 4),  // 4 instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         assertThat(verifier.verify(Collections.emptySet(),
                                    replicas(1, 6), // all instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 6), // the rest fail
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
     }
 
     @Test
@@ -66,17 +66,17 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 4), // 3 instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(1, 5), // 5 out of 6 instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(1, 2), // 2 instances pass
                                    replicas(3, 6), // the rest fail
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
     }
 
     @Test
@@ -86,17 +86,17 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 4), // 3 instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 5), // 4 out of 6 instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(1, 4), // 1 instance passed
                                    replicas(5, 6), // the rest fail
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
     }
 
     @Test
@@ -106,17 +106,17 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(Collections.emptySet(),
                                    replicas(2, 3), // 2 out of 3 local instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         assertThat(verifier.verify(Collections.emptySet(),
                                    replicas(1, 3), // 3 out of 3 local instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passed
                                    replicas(2, 3), // the rest of local instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
 
         ConsistencyVerifier dc2LocalVerifier = ConsistencyVerifiers.forConsistencyLevel(ConsistencyLevel.LOCAL_ONE, "dc-2");
         Set<String> set = Collections.emptySet();
@@ -132,17 +132,17 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 2), // 1 instance fails
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 3), // 2 out of 3 local instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(1, 2), // 2 instances pass
                                    replicas(3, 3), // the rest fail
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
 
         ConsistencyVerifier dc2LocalVerifier = ConsistencyVerifiers.forConsistencyLevel(ConsistencyLevel.LOCAL_ONE, "dc-2");
         Set<String> set = Collections.emptySet();
@@ -158,17 +158,17 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(3, 4), // 1 instance in each dc fails
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 5), // 4 out of 6 instances fail
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(2, 5), // 1 instance passes
                                    replicas(1, 1), // the rest fail
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
     }
 
     @Test
@@ -178,18 +178,18 @@ class ConsistencyVerifiersTest
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    Collections.emptySet(),
                                    allReplicasByDc))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
 
         assertThat(verifier.verify(replicas(1, 1), // 1 instance passes
                                    replicas(2, 2), // any instance fails
                                    allReplicasByDc))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
 
         assertThat(verifier.verify(replicas(1, 6), // all instances pass
                                    Collections.emptySet(),
                                    allReplicasByDc))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
     }
 
     private Set<String> replicas(int start, int end)

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/RestoreJobTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/RestoreJobTest.java
@@ -78,7 +78,8 @@ public class RestoreJobTest
                .jobStatus(status)
                .consistencyLevel(consistencyLevel)
                .localDatacenter(dcName)
-               .expireAt(new Date(System.currentTimeMillis() + 10000L));
+               .expireAt(new Date(System.currentTimeMillis() + 10000L))
+               .sliceCount(100L);
         return builder.build();
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -136,7 +136,7 @@ public class SidecarSchemaTest
             assertTrue(interceptedExecStmts.get(0).contains("CREATE KEYSPACE IF NOT EXISTS sidecar_internal"),
                        "Create keyspace should be executed the first");
             assertTrue(hasElementContains(interceptedExecStmts,
-                                          "CREATE TABLE IF NOT EXISTS sidecar_internal.restore_job_v3"),
+                                          "CREATE TABLE IF NOT EXISTS sidecar_internal.restore_job_v4"),
                        "Create table should be executed for job table");
             assertTrue(hasElementContains(interceptedExecStmts,
                                           "CREATE TABLE IF NOT EXISTS sidecar_internal.restore_slice_v3"),
@@ -146,23 +146,25 @@ public class SidecarSchemaTest
                        "Create table should be executed for range table");
 
             List<String> expectedPrepStatements = Arrays.asList(
-            "INSERT INTO sidecar_internal.restore_job_v3 (  created_at,  job_id,  keyspace_name,  table_name,  " +
+            "INSERT INTO sidecar_internal.restore_job_v4 (  created_at,  job_id,  keyspace_name,  table_name,  " +
             "job_agent,  status,  blob_secrets,  import_options,  consistency_level,  local_datacenter,  expire_at) " +
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v3 (  created_at,  job_id,  blob_secrets) VALUES (?, ? ,?)",
+            "INSERT INTO sidecar_internal.restore_job_v4 (  created_at,  job_id,  blob_secrets) VALUES (?, ? ,?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v3 (  created_at,  job_id,  status) VALUES (?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v4 (  created_at,  job_id,  status) VALUES (?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v3 (  created_at,  job_id,  job_agent) VALUES (?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v4 (  created_at,  job_id,  job_agent) VALUES (?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v3 (  created_at,  job_id,  expire_at) VALUES (?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v4 (  created_at,  job_id,  expire_at) VALUES (?, ?, ?)",
+
+            "INSERT INTO sidecar_internal.restore_job_v4 (  created_at,  job_id,  slice_count) VALUES (?, ?, ?)",
 
             "SELECT created_at, job_id, keyspace_name, table_name, job_agent, status, blob_secrets, import_options, " +
-            "consistency_level, local_datacenter, expire_at FROM sidecar_internal.restore_job_v3 WHERE created_at = ? AND job_id = ?",
+            "consistency_level, local_datacenter, expire_at, slice_count FROM sidecar_internal.restore_job_v4 WHERE created_at = ? AND job_id = ?",
 
             "SELECT created_at, job_id, keyspace_name, table_name, job_agent, status, blob_secrets, import_options, " +
-            "consistency_level, local_datacenter, expire_at FROM sidecar_internal.restore_job_v3 WHERE created_at = ?",
+            "consistency_level, local_datacenter, expire_at, slice_count FROM sidecar_internal.restore_job_v4 WHERE created_at = ?",
 
             "INSERT INTO sidecar_internal.restore_slice_v3 (  job_id,  bucket_id,  slice_id,  bucket,  key,  " +
             "checksum,  start_token,  end_token,  compressed_size,  uncompressed_size) " +

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/BaseRestoreJobProgressCollectorTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/BaseRestoreJobProgressCollectorTest.java
@@ -23,7 +23,7 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 import com.datastax.driver.core.utils.UUIDs;
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.response.data.RestoreJobProgressResponsePayload;
 import org.apache.cassandra.sidecar.common.response.data.RestoreJobSummaryResponsePayload;
 import org.apache.cassandra.sidecar.db.RestoreJob;
@@ -50,7 +50,7 @@ abstract class BaseRestoreJobProgressCollectorTest
         assertThat(payload.succeededRanges()).isNull();
     }
 
-    protected void createRangesAndCollect(int count, ConsistencyVerifier.Result result)
+    protected void createRangesAndCollect(int count, ConsistencyVerificationResult result)
     {
         for (int i = 0; i < count; i++)
         {

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelCheckerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobConsistencyLevelCheckerTest.java
@@ -28,10 +28,10 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier.Result;
 import org.apache.cassandra.sidecar.cluster.ConsistencyVerifiers;
 import org.apache.cassandra.sidecar.cluster.locator.InstanceSetByDc;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse.ReplicaInfo;
 import org.apache.cassandra.sidecar.common.server.data.RestoreRangeStatus;
@@ -57,7 +57,7 @@ class RestoreJobConsistencyLevelCheckerTest
 
         assertThat(concludeOneRangeUnsafe(topology, ConsistencyVerifiers.ForOne.INSTANCE, RestoreRangeStatus.STAGED, range))
         .describedAs("When unable to find replica set for the range, pending should be returned")
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
     }
 
     @Test
@@ -74,7 +74,7 @@ class RestoreJobConsistencyLevelCheckerTest
 
         assertThat(concludeOneRangeUnsafe(topology, ConsistencyVerifiers.ForOne.INSTANCE, RestoreRangeStatus.STAGED, range))
         .describedAs("When unable to find replica set for the range, pending should be returned")
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
     }
 
     @Test
@@ -104,14 +104,14 @@ class RestoreJobConsistencyLevelCheckerTest
         Map<String, RestoreRangeStatus> replicaStatus = new HashMap<>();
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, ConsistencyVerifiers.ForOne.INSTANCE, RestoreRangeStatus.STAGED, range))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         replicaStatus.put("i-1", RestoreRangeStatus.FAILED);
         replicaStatus.put("i-2", RestoreRangeStatus.FAILED);
         replicaStatus.put("i-3", RestoreRangeStatus.CREATED);
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, ConsistencyVerifiers.ForOne.INSTANCE, RestoreRangeStatus.STAGED, range))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         replicaStatus.put("i-1", RestoreRangeStatus.STAGED);
         replicaStatus.put("i-2", RestoreRangeStatus.CREATED);
@@ -119,7 +119,7 @@ class RestoreJobConsistencyLevelCheckerTest
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, ConsistencyVerifiers.ForOne.INSTANCE, RestoreRangeStatus.STAGED, range))
         .describedAs("As long as one replica reports STAGED, it is good for CL_ONE")
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
 
         replicaStatus.put("i-1", RestoreRangeStatus.FAILED);
         replicaStatus.put("i-2", RestoreRangeStatus.FAILED);
@@ -127,7 +127,7 @@ class RestoreJobConsistencyLevelCheckerTest
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, ConsistencyVerifiers.ForOne.INSTANCE, RestoreRangeStatus.STAGED, range))
         .describedAs("When all replicas fail, it fails for CL_ONE")
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
     }
 
     @Test
@@ -144,28 +144,28 @@ class RestoreJobConsistencyLevelCheckerTest
         Map<String, RestoreRangeStatus> replicaStatus = new HashMap<>();
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, localQuorumVerifier, RestoreRangeStatus.STAGED, range))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         replicaStatus.put("i-1", RestoreRangeStatus.FAILED);
         replicaStatus.put("i-2", RestoreRangeStatus.STAGED);
         replicaStatus.put("i-3", RestoreRangeStatus.CREATED);
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, localQuorumVerifier, RestoreRangeStatus.STAGED, range))
-        .isEqualTo(Result.PENDING);
+        .isEqualTo(ConsistencyVerificationResult.PENDING);
 
         replicaStatus.put("i-1", RestoreRangeStatus.STAGED);
         replicaStatus.put("i-2", RestoreRangeStatus.STAGED);
         replicaStatus.put("i-3", RestoreRangeStatus.FAILED);
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, localQuorumVerifier, RestoreRangeStatus.STAGED, range))
-        .isEqualTo(Result.SATISFIED);
+        .isEqualTo(ConsistencyVerificationResult.SATISFIED);
 
         replicaStatus.put("i-1", RestoreRangeStatus.STAGED);
         replicaStatus.put("i-2", RestoreRangeStatus.FAILED);
         replicaStatus.put("i-3", RestoreRangeStatus.FAILED);
         range = range.unbuild().replicaStatus(replicaStatus).build();
         assertThat(concludeOneRangeUnsafe(topology, localQuorumVerifier, RestoreRangeStatus.STAGED, range))
-        .isEqualTo(Result.FAILED);
+        .isEqualTo(ConsistencyVerificationResult.FAILED);
     }
 
     private Map<String, List<String>> replicaByDc(int dcCount, int replicasPerDc)

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectAllFailedAndPendingTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectAllFailedAndPendingTest.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.sidecar.restore;
 
 import org.junit.jupiter.api.Test;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.data.RestoreJobProgressFetchPolicy;
 import org.apache.cassandra.sidecar.common.response.data.RestoreJobProgressResponsePayload;
 import org.apache.cassandra.sidecar.db.RestoreJob;
@@ -33,7 +33,7 @@ class RestoreJobProgressCollectAllFailedAndPendingTest extends BaseRestoreJobPro
     void testAlwaysCollectMore()
     {
         assertThat(collector.canCollectMore()).isTrue();
-        for (ConsistencyVerifier.Result result : ConsistencyVerifier.Result.values())
+        for (ConsistencyVerificationResult result : ConsistencyVerificationResult.values())
         {
             createRangesAndCollect(1, result);
             assertThat(collector.canCollectMore()).isTrue();
@@ -43,9 +43,9 @@ class RestoreJobProgressCollectAllFailedAndPendingTest extends BaseRestoreJobPro
     @Test
     void testNotCollectSatisfied()
     {
-        createRangesAndCollect(5, ConsistencyVerifier.Result.SATISFIED);
-        createRangesAndCollect(1, ConsistencyVerifier.Result.PENDING);
-        createRangesAndCollect(1, ConsistencyVerifier.Result.FAILED);
+        createRangesAndCollect(5, ConsistencyVerificationResult.SATISFIED);
+        createRangesAndCollect(1, ConsistencyVerificationResult.PENDING);
+        createRangesAndCollect(1, ConsistencyVerificationResult.FAILED);
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("One or more ranges have failed. Current job status: CREATED");
         assertJobSummary(payload.summary());

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectAllTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectAllTest.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.sidecar.restore;
 
 import org.junit.jupiter.api.Test;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.data.RestoreJobProgressFetchPolicy;
 import org.apache.cassandra.sidecar.common.response.data.RestoreJobProgressResponsePayload;
 import org.apache.cassandra.sidecar.db.RestoreJob;
@@ -33,7 +33,7 @@ class RestoreJobProgressCollectAllTest extends BaseRestoreJobProgressCollectorTe
     void testAlwaysCollectMore()
     {
         assertThat(collector.canCollectMore()).isTrue();
-        for (ConsistencyVerifier.Result result : ConsistencyVerifier.Result.values())
+        for (ConsistencyVerificationResult result : ConsistencyVerificationResult.values())
         {
             createRangesAndCollect(1, result);
             assertThat(collector.canCollectMore()).isTrue();
@@ -44,7 +44,7 @@ class RestoreJobProgressCollectAllTest extends BaseRestoreJobProgressCollectorTe
     void testCollectAllSatisfiedRanges()
     {
         int succeededRanges = 10;
-        createRangesAndCollect(succeededRanges, ConsistencyVerifier.Result.SATISFIED);
+        createRangesAndCollect(succeededRanges, ConsistencyVerificationResult.SATISFIED);
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("All ranges have succeeded. Current job status: CREATED");
         assertJobSummary(payload.summary());
@@ -58,7 +58,7 @@ class RestoreJobProgressCollectAllTest extends BaseRestoreJobProgressCollectorTe
     void testCollectAllFailed()
     {
         int failedRanges = 10;
-        createRangesAndCollect(failedRanges, ConsistencyVerifier.Result.FAILED);
+        createRangesAndCollect(failedRanges, ConsistencyVerificationResult.FAILED);
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("One or more ranges have failed. Current job status: CREATED");
         assertJobSummary(payload.summary());
@@ -72,7 +72,7 @@ class RestoreJobProgressCollectAllTest extends BaseRestoreJobProgressCollectorTe
     void testCollectAllPending()
     {
         int pendingRanges = 10;
-        createRangesAndCollect(pendingRanges, ConsistencyVerifier.Result.PENDING);
+        createRangesAndCollect(pendingRanges, ConsistencyVerificationResult.PENDING);
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("One or more ranges are in progress. None of the ranges fail. Current job status: CREATED");
         assertJobSummary(payload.summary());
@@ -88,9 +88,9 @@ class RestoreJobProgressCollectAllTest extends BaseRestoreJobProgressCollectorTe
         int pendingRanges = 3;
         int failedRanges = 1;
         int satisfiedRanges = 2;
-        createRangesAndCollect(pendingRanges, ConsistencyVerifier.Result.PENDING);
-        createRangesAndCollect(failedRanges, ConsistencyVerifier.Result.FAILED);
-        createRangesAndCollect(satisfiedRanges, ConsistencyVerifier.Result.SATISFIED);
+        createRangesAndCollect(pendingRanges, ConsistencyVerificationResult.PENDING);
+        createRangesAndCollect(failedRanges, ConsistencyVerificationResult.FAILED);
+        createRangesAndCollect(satisfiedRanges, ConsistencyVerificationResult.SATISFIED);
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("One or more ranges have failed. Current job status: CREATED");
         assertJobSummary(payload.summary());
@@ -105,8 +105,8 @@ class RestoreJobProgressCollectAllTest extends BaseRestoreJobProgressCollectorTe
     {
         int pendingRanges = 3;
         int satisfiedRanges = 2;
-        createRangesAndCollect(pendingRanges, ConsistencyVerifier.Result.PENDING);
-        createRangesAndCollect(satisfiedRanges, ConsistencyVerifier.Result.SATISFIED);
+        createRangesAndCollect(pendingRanges, ConsistencyVerificationResult.PENDING);
+        createRangesAndCollect(satisfiedRanges, ConsistencyVerificationResult.SATISFIED);
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("One or more ranges are in progress. None of the ranges fail. Current job status: CREATED");
         assertJobSummary(payload.summary());

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectFirstFailedTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreJobProgressCollectFirstFailedTest.java
@@ -20,7 +20,7 @@ package org.apache.cassandra.sidecar.restore;
 
 import org.junit.jupiter.api.Test;
 
-import org.apache.cassandra.sidecar.cluster.ConsistencyVerifier;
+import org.apache.cassandra.sidecar.common.data.ConsistencyVerificationResult;
 import org.apache.cassandra.sidecar.common.data.RestoreJobProgressFetchPolicy;
 import org.apache.cassandra.sidecar.common.response.data.RestoreJobProgressResponsePayload;
 import org.apache.cassandra.sidecar.db.RestoreJob;
@@ -33,7 +33,7 @@ class RestoreJobProgressCollectFirstFailedTest extends BaseRestoreJobProgressCol
     void testContinueCollectOnSatisfied()
     {
         assertThat(collector.canCollectMore()).isTrue();
-        createRangesAndCollect(1, ConsistencyVerifier.Result.SATISFIED);
+        createRangesAndCollect(1, ConsistencyVerificationResult.SATISFIED);
         assertThat(collector.canCollectMore()).isTrue();
     }
 
@@ -41,11 +41,11 @@ class RestoreJobProgressCollectFirstFailedTest extends BaseRestoreJobProgressCol
     void testStopCollectionOnFirstFailed()
     {
         assertThat(collector.canCollectMore()).isTrue();
-        createRangesAndCollect(1, ConsistencyVerifier.Result.PENDING);
+        createRangesAndCollect(1, ConsistencyVerificationResult.PENDING);
         assertThat(collector.canCollectMore()).isTrue();
-        createRangesAndCollect(1, ConsistencyVerifier.Result.FAILED);
+        createRangesAndCollect(1, ConsistencyVerificationResult.FAILED);
         assertThat(collector.canCollectMore()).isFalse();
-        createRangesAndCollect(1, ConsistencyVerifier.Result.PENDING);
+        createRangesAndCollect(1, ConsistencyVerificationResult.PENDING);
         assertThat(collector.canCollectMore()).isFalse();
     }
 
@@ -53,11 +53,11 @@ class RestoreJobProgressCollectFirstFailedTest extends BaseRestoreJobProgressCol
     void testCollectMixed()
     {
         // The collector with FIRST_FAILED policy skips SATISFIED and PENDING ranges and stops after seeing the first FAILED
-        createRangesAndCollect(3, ConsistencyVerifier.Result.SATISFIED);
-        createRangesAndCollect(1, ConsistencyVerifier.Result.PENDING);
-        createRangesAndCollect(1, ConsistencyVerifier.Result.FAILED);
+        createRangesAndCollect(3, ConsistencyVerificationResult.SATISFIED);
+        createRangesAndCollect(1, ConsistencyVerificationResult.PENDING);
+        createRangesAndCollect(1, ConsistencyVerificationResult.FAILED);
         // collector should stop from collecting
-        createRangesAndCollect(5, ConsistencyVerifier.Result.PENDING); // not being collected
+        createRangesAndCollect(5, ConsistencyVerificationResult.PENDING); // not being collected
         RestoreJobProgressResponsePayload payload = collector.toRestoreJobProgress().toResponsePayload();
         assertThat(payload.message()).isEqualTo("One or more ranges have failed. Current job status: CREATED");
         assertJobSummary(payload.summary());

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreRangeTaskTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/RestoreRangeTaskTest.java
@@ -219,7 +219,7 @@ class RestoreRangeTaskTest
     void testStaging()
     {
         // test specific setup
-        RestoreJob job = spy(RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.CREATED));
+        RestoreJob job = spy(RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.STAGE_READY));
         doReturn(true).when(job).isManagedBySidecar();
         when(mockRange.job()).thenReturn(job);
         when(mockRange.stagedObjectPath()).thenReturn(Paths.get("nonexist"));
@@ -243,7 +243,7 @@ class RestoreRangeTaskTest
     void testStagingWithExistingObject(@TempDir Path testFolder) throws IOException
     {
         // test specific setup
-        RestoreJob job = spy(RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.CREATED));
+        RestoreJob job = spy(RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.STAGE_READY));
         doReturn(true).when(job).isManagedBySidecar();
         when(mockRange.job()).thenReturn(job);
         Path stagedPath = testFolder.resolve("slice.zip");
@@ -268,7 +268,7 @@ class RestoreRangeTaskTest
     void testImportPhase()
     {
         // test specific setup
-        RestoreJob job = spy(RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.STAGED));
+        RestoreJob job = spy(RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.IMPORT_READY));
         doReturn(true).when(job).isManagedBySidecar();
         when(mockRange.job()).thenReturn(job);
         RestoreRangeTask task = createTask(mockRange, job);
@@ -287,7 +287,7 @@ class RestoreRangeTaskTest
     {
         // import is successful
         when(mockSSTableImporter.scheduleImport(any())).thenReturn(Future.succeededFuture());
-        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.CREATED, ConsistencyLevel.QUORUM);
+        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.IMPORT_READY, ConsistencyLevel.QUORUM);
         RestoreRangeTask task = createTask(mockRange, job);
         Future<?> success = task.commit(testFolder.toFile());
         assertThat(success.failed()).isFalse();
@@ -302,7 +302,7 @@ class RestoreRangeTaskTest
     @Test
     void testHandlingUnexpectedExceptionInObjectExistsCheck(@TempDir Path testFolder)
     {
-        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.CREATED, ConsistencyLevel.QUORUM);
+        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.STAGE_READY, ConsistencyLevel.QUORUM);
         when(mockStorageClient.objectExists(mockRange)).thenThrow(new RuntimeException("Random exception"));
         Path stagedPath = testFolder.resolve("slice.zip");
         when(mockRange.stagedObjectPath()).thenReturn(stagedPath);
@@ -320,7 +320,7 @@ class RestoreRangeTaskTest
     @Test
     void testHandlingUnexpectedExceptionDuringDownloadSliceCheck(@TempDir Path testFolder)
     {
-        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.CREATED, ConsistencyLevel.QUORUM);
+        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.STAGE_READY, ConsistencyLevel.QUORUM);
         Path stagedPath = testFolder.resolve("slice.zip");
         when(mockRange.stagedObjectPath()).thenReturn(stagedPath);
         when(mockRange.isCancelled()).thenReturn(false);
@@ -343,8 +343,7 @@ class RestoreRangeTaskTest
     @Test
     void testHandlingUnexpectedExceptionDuringUnzip(@TempDir Path testFolder) throws IOException
     {
-
-        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.STAGED, ConsistencyLevel.QUORUM);
+        RestoreJob job = RestoreJobTest.createTestingJob(UUIDs.timeBased(), RestoreJobStatus.IMPORT_READY, ConsistencyLevel.QUORUM);
         Path stagedPath = testFolder.resolve("slice.zip");
         Files.createFile(stagedPath);
         when(mockRange.stagedObjectPath()).thenReturn(stagedPath);

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/restore/RestoreJobProgressHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/restore/RestoreJobProgressHandlerTest.java
@@ -61,9 +61,9 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
     {
         mockLookupRestoreJob(jobId -> createTestingJob(jobId, RestoreJobStatus.CREATED));
         getThenComplete(context, TEST_PROGRESS_ROUTE,
-                     asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
-                                                                "Only Sidecar-managed restore jobs are allowed. " +
-                                                                "jobId=8e5799a4-d277-11ed-8d85-6916bb9b8056 jobManager=SPARK"));
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
+                                                                   "Only Sidecar-managed restore jobs are allowed. " +
+                                                                   "jobId=8e5799a4-d277-11ed-8d85-6916bb9b8056 jobManager=SPARK"));
     }
 
     @Test
@@ -71,9 +71,9 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
     {
         mockLookupRestoreJob(jobId -> createTestingJob(jobId, RestoreJobStatus.CREATED, ConsistencyLevel.QUORUM));
         getThenComplete(context, TEST_PROGRESS_ROUTE,
-                     asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
-                                                                "Cannot check progress for restore job in CREATED status. " +
-                                                                "jobId: 8e5799a4-d277-11ed-8d85-6916bb9b8056"));
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
+                                                                   "Cannot check progress for restore job in CREATED status. " +
+                                                                   "jobId: " + TEST_JOB_ID));
     }
 
     @Test
@@ -83,8 +83,8 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
         mockTopologyInRefresher(() -> generateTestTopology(3));
         mockFindAllRestoreRanges(jobId -> Collections.emptyList()); // there are no ranges found for the job
         getThenComplete(context, TEST_PROGRESS_ROUTE,
-                     asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                                                "No restore ranges found for job: 8e5799a4-d277-11ed-8d85-6916bb9b8056"));
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                                                   "No restore ranges found for job: " + TEST_JOB_ID));
     }
 
     @Test
@@ -96,9 +96,9 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
             throw new RuntimeException("Failed to read from Cassandra");
         });
         getThenComplete(context, TEST_PROGRESS_ROUTE,
-                     asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                                                // todo: should we expose the actual cause to client?
-                                                                "Unexpected error encountered in handler"));
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                                                   // todo: should we expose the actual cause to client?
+                                                                   "Unexpected error encountered in handler"));
     }
 
     @Test
@@ -109,8 +109,8 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
             throw new IllegalStateException("Fails to load topology");
         });
         getThenComplete(context, TEST_PROGRESS_ROUTE,
-                     asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                                                                "Fails to load topology"));
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                                                                   "Fails to load topology"));
     }
 
     @Test
@@ -118,8 +118,21 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
     {
         mockLookupRestoreJob(jobId -> createTestingJob(jobId, RestoreJobStatus.STAGE_READY, ConsistencyLevel.QUORUM));
         getThenComplete(context, TEST_PROGRESS_ROUTE + "?fetch-policy=unknown_policy",
-                     asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
                                                                 "No RestoreJobProgressFetchPolicy found for unknown_policy"));
+    }
+
+    @Test
+    void testRetrieveProgressFailsWhenSliceCountIsNotSet(VertxTestContext context)
+    {
+        mockLookupRestoreJob(jobId -> createTestingJob(jobId, RestoreJobStatus.STAGE_READY, ConsistencyLevel.QUORUM)
+                                      .unbuild()
+                                      .sliceCount(null) // unset sliceCount
+                                      .build());
+        getThenComplete(context, TEST_PROGRESS_ROUTE + "?fetch-policy=first_failed",
+                        asyncResult -> assertStatusAndErrorMessage(asyncResult, HttpResponseStatus.BAD_REQUEST,
+                                                                   "Controller must set the sliceCount for Sidecar-managed restore job. " +
+                                                                   "jobId=" + TEST_JOB_ID));
     }
 
     @Test
@@ -134,23 +147,23 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
         List<RestoreRange> ranges = Arrays.asList(failedRange, RestoreRangeTest.createTestRange(10, 15));
         mockFindAllRestoreRanges(jobId -> ranges);
         getThenComplete(context, TEST_PROGRESS_ROUTE + "?fetch-policy=all",
-                     asyncResult -> {
-                         int rangesRetrieved = 0;
-                         RestoreJobProgressResponsePayload respBody = assertOKResponseAndExtractBody(asyncResult);
-                         assertFailedProgressRespBody(respBody);
-                         List<RestoreRangeJson> failedRanges = respBody.failedRanges();
-                         assertThat(failedRanges).hasSize(1);
-                         rangesRetrieved += failedRanges.size();
-                         assertRange(failedRanges.get(0), 0, 10);
-                         assertThat(respBody.succeededRanges()).isNull();
-                         List<RestoreRangeJson> pendingRanges = respBody.pendingRanges();
-                         assertThat(pendingRanges).hasSize(1);
-                         rangesRetrieved += pendingRanges.size();
-                         assertRange(pendingRanges.get(0), 10, 15);
-                         assertThat(respBody.abortedRanges()).isNull();
-                         // retrieving all 2 ranges back
-                         assertThat(rangesRetrieved).isEqualTo(2);
-                     });
+                        asyncResult -> {
+                            int rangesRetrieved = 0;
+                            RestoreJobProgressResponsePayload respBody = assertOKResponseAndExtractBody(asyncResult);
+                            assertFailedProgressRespBody(respBody);
+                            List<RestoreRangeJson> failedRanges = respBody.failedRanges();
+                            assertThat(failedRanges).hasSize(1);
+                            rangesRetrieved += failedRanges.size();
+                            assertRange(failedRanges.get(0), 0, 10);
+                            assertThat(respBody.succeededRanges()).isNull();
+                            List<RestoreRangeJson> pendingRanges = respBody.pendingRanges();
+                            assertThat(pendingRanges).hasSize(1);
+                            rangesRetrieved += pendingRanges.size();
+                            assertRange(pendingRanges.get(0), 10, 15);
+                            assertThat(respBody.abortedRanges()).isNull();
+                            // retrieving all 2 ranges back
+                            assertThat(rangesRetrieved).isEqualTo(2);
+                        });
     }
 
     @Test
@@ -169,23 +182,23 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
         List<RestoreRange> ranges = Arrays.asList(failedRange, RestoreRangeTest.createTestRange(10, 15), satisfiedRange);
         mockFindAllRestoreRanges(jobId -> ranges);
         getThenComplete(context, TEST_PROGRESS_ROUTE + "?fetch-policy=all_failed_and_pending",
-                     asyncResult -> {
-                         int rangesRetrieved = 0;
-                         RestoreJobProgressResponsePayload respBody = assertOKResponseAndExtractBody(asyncResult);
-                         assertFailedProgressRespBody(respBody);
-                         List<RestoreRangeJson> failedRanges = respBody.failedRanges();
-                         assertThat(failedRanges).hasSize(1);
-                         rangesRetrieved += failedRanges.size();
-                         assertRange(failedRanges.get(0), 0, 10);
-                         assertThat(respBody.succeededRanges()).isNull();
-                         List<RestoreRangeJson> pendingRanges = respBody.pendingRanges();
-                         assertThat(pendingRanges).hasSize(1);
-                         rangesRetrieved += pendingRanges.size();
-                         assertRange(pendingRanges.get(0), 10, 15);
-                         assertThat(respBody.abortedRanges()).isNull();
-                         // retrieving all 2 ranges back, while there are 3 ranges in total. One range is satisfied
-                         assertThat(rangesRetrieved).isEqualTo(2);
-                     });
+                        asyncResult -> {
+                            int rangesRetrieved = 0;
+                            RestoreJobProgressResponsePayload respBody = assertOKResponseAndExtractBody(asyncResult);
+                            assertFailedProgressRespBody(respBody);
+                            List<RestoreRangeJson> failedRanges = respBody.failedRanges();
+                            assertThat(failedRanges).hasSize(1);
+                            rangesRetrieved += failedRanges.size();
+                            assertRange(failedRanges.get(0), 0, 10);
+                            assertThat(respBody.succeededRanges()).isNull();
+                            List<RestoreRangeJson> pendingRanges = respBody.pendingRanges();
+                            assertThat(pendingRanges).hasSize(1);
+                            rangesRetrieved += pendingRanges.size();
+                            assertRange(pendingRanges.get(0), 10, 15);
+                            assertThat(respBody.abortedRanges()).isNull();
+                            // retrieving all 2 ranges back, while there are 3 ranges in total. One range is satisfied
+                            assertThat(rangesRetrieved).isEqualTo(2);
+                        });
     }
 
     @Test
@@ -212,17 +225,17 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
         List<RestoreRange> ranges = Arrays.asList(failedRange, RestoreRangeTest.createTestRange(10, 15));
         mockFindAllRestoreRanges(jobId -> ranges);
         getThenComplete(context, TEST_PROGRESS_ROUTE + (withQueryParam ? "?fetch-policy=first_failed" : ""),
-                     asyncResult -> {
-                         RestoreJobProgressResponsePayload respBody = assertOKResponseAndExtractBody(asyncResult);
-                         assertFailedProgressRespBody(respBody);
-                         List<RestoreRangeJson> failedRanges = respBody.failedRanges();
-                         assertThat(failedRanges).hasSize(1);
-                         assertRange(failedRanges.get(0), 0, 10);
-                         // no ranges in other status are included in the response body when using FIRST_FAILED fetch policy
-                         assertThat(respBody.succeededRanges()).isNull();
-                         assertThat(respBody.pendingRanges()).isNull();
-                         assertThat(respBody.abortedRanges()).isNull();
-                     });
+                        asyncResult -> {
+                            RestoreJobProgressResponsePayload respBody = assertOKResponseAndExtractBody(asyncResult);
+                            assertFailedProgressRespBody(respBody);
+                            List<RestoreRangeJson> failedRanges = respBody.failedRanges();
+                            assertThat(failedRanges).hasSize(1);
+                            assertRange(failedRanges.get(0), 0, 10);
+                            // no ranges in other status are included in the response body when using FIRST_FAILED fetch policy
+                            assertThat(respBody.succeededRanges()).isNull();
+                            assertThat(respBody.pendingRanges()).isNull();
+                            assertThat(respBody.abortedRanges()).isNull();
+                        });
     }
 
     // generate the artificial topology with fixed range length of 10 for each.
@@ -247,8 +260,7 @@ class RestoreJobProgressHandlerTest extends BaseRestoreJobTests
         HttpResponse<?> response = asyncResult.result();
         assertThat(response).isNotNull();
         assertThat(response.statusCode()).isEqualTo(status.code());
-        assertThat(response.bodyAsJsonObject().getString("message"))
-        .isEqualTo(message);
+        assertThat(response.bodyAsJsonObject().getString("message")).isEqualTo(message);
     }
 
     private RestoreJobProgressResponsePayload assertOKResponseAndExtractBody(AsyncResult<HttpResponse<Buffer>> asyncResult)

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/restore/UpdateRestoreJobHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/restore/UpdateRestoreJobHandlerTest.java
@@ -141,6 +141,22 @@ class UpdateRestoreJobHandlerTest extends BaseRestoreJobTests
                                              payload, context, HttpResponseStatus.OK.code());
     }
 
+    @Test
+    void testUpdateSliceCount(VertxTestContext context) throws Throwable
+    {
+        String jobId = "8e5799a4-d277-11ed-8d85-6916bb9b8056";
+        long sliceCount = 100;
+        mockLookupRestoreJob(RestoreJobTest::createNewTestingJob);
+        mockUpdateRestoreJob(payload -> {
+            assertThat(payload.sliceCount()).isEqualTo(sliceCount);
+            return createTestNewJob(jobId);
+        });
+        JsonObject payload = new JsonObject();
+        payload.put("sliceCount", sliceCount);
+        sendUpdateRestoreJobRequestAndVerify("ks", "table", jobId,
+                                             payload, context, HttpResponseStatus.OK.code());
+    }
+
     private RestoreJob createTestNewJob(String jobId)
     {
         return RestoreJob.builder()


### PR DESCRIPTION
- Extends the restore_job table to persist the total slice_count in order to known the complete data to restore
- Allows external to trigger restore job discover to be more responsive
- Fix restore job & range status update
- Fix two phase import implementation in RestoreProcessor
- Expose overall restore progress status in API response

Patch by Yifan Cai; Reviewed by TBD for CASSANDRASC-152