### PR TITLE
CASSSIDECAR-171: Fixed cdc dir path in InstanceMetadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * CDC directory not initialized properly in InstanceMetadata (CASSSIDECAR-171)
  * yaml configuration defaults to a file that doesn't exist (CASSSIDECAR-122)
  * Add advanced driver settings to allow taking in password or certificates for Cassandra connection (CASSSIDECAR-159)
  * Add metric to report consistency check duration (CASSSIDECAR-165)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadataImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadataImpl.java
@@ -56,7 +56,7 @@ public class InstanceMetadataImpl implements InstanceMetadata
                                    .map(FileUtils::maybeResolveHomeDirectory)
                                    .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
         stagingDir = FileUtils.maybeResolveHomeDirectory(builder.stagingDir);
-        cdcDir = builder().cdcDir;
+        cdcDir = FileUtils.maybeResolveHomeDirectory(builder.cdcDir);
         delegate = builder.delegate;
         metrics = builder.metrics;
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadataImplTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadataImplTest.java
@@ -27,80 +27,64 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.codahale.metrics.MetricRegistry;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class InstanceMetadataImplTest
 {
 
+    private static final int ID = 123;
+    private static final String HOST = "testhost";
+    private static final int PORT = 12345;
+    private static final String DATA_DIR_1 = "test/data/data1";
+    private static final String DATA_DIR_2 = "test/data/data2";
+    private static final String CDC_DIR = "cdc_dir";
+    private static final String STAGING_DIR = "staging_dir";
+    private static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+
     @TempDir
     Path tempDir;
-
 
     @Test
     void testConstructor()
     {
-        int id = 123;
-        String host = "testhost";
-        int port = 12345;
         String rootDir = tempDir.toString();
-        List<String> dataDirs = new ArrayList<>();
-        dataDirs.add(rootDir + "/test/data/data1");
-        dataDirs.add(rootDir + "/test/data/data2");
-        String cdcDir = rootDir + "/cdc_dir";
-        String stagingDir = rootDir + "/staging_dir";
-        MetricRegistry metricRegistry = new MetricRegistry();
 
-        InstanceMetadataImpl metadata = InstanceMetadataImpl.builder()
-                                                            .id(id)
-                                                            .host(host)
-                                                            .port(port)
-                                                            .dataDirs(dataDirs)
-                                                            .cdcDir(cdcDir)
-                                                            .stagingDir(stagingDir)
-                                                            .metricRegistry(metricRegistry)
-                                                            .build();
+        InstanceMetadataImpl metadata = getInstanceMetadataBuilder(rootDir).build();
 
-        assertEquals(id, metadata.id());
-        assertEquals(host, metadata.host());
-        assertEquals(port, metadata.port());
-        assertEquals(dataDirs, metadata.dataDirs());
-        assertEquals(cdcDir, metadata.cdcDir());
-        assertEquals(stagingDir, metadata.stagingDir());
+        assertThat(metadata.id()).isEqualTo(ID);
+        assertThat(metadata.host()).isEqualTo(HOST);
+        assertThat(metadata.port()).isEqualTo(PORT);
+        assertThat(metadata.dataDirs()).contains(rootDir + "/" + DATA_DIR_1, rootDir + "/" + DATA_DIR_2);
+        assertThat(metadata.cdcDir()).isEqualTo(rootDir + "/" + CDC_DIR);
+        assertThat(metadata.stagingDir()).isEqualTo(rootDir + "/" + STAGING_DIR);
     }
 
     @Test
     void testConstructorWithHomeDirPaths()
     {
-        int id = 123;
-        String host = "testhost";
-        int port = 12345;
         String rootDir = "~";
-        String dataDir1 = "test/data/data1";
-        String dataDir2 = "test/data/data2";
-        List<String> dataDirs = new ArrayList<>();
-        dataDirs.add(rootDir + "/" + dataDir1);
-        dataDirs.add(rootDir + "/" + dataDir2);
-        String cdcDir = "cdc_dir";
-        String stagingDir = "staging_dir";
-        MetricRegistry metricRegistry = new MetricRegistry();
-
         String homeDir = System.getProperty("user.home");
 
-        InstanceMetadataImpl metadata = InstanceMetadataImpl.builder()
-                                                            .id(id)
-                                                            .host(host)
-                                                            .port(port)
-                                                            .dataDirs(dataDirs)
-                                                            .cdcDir(rootDir + "/" + cdcDir)
-                                                            .stagingDir(rootDir + "/" + stagingDir)
-                                                            .metricRegistry(metricRegistry)
-                                                            .build();
+        InstanceMetadataImpl metadata = getInstanceMetadataBuilder(rootDir).build();
 
-        List<String> expectedDataDirs = new ArrayList<>();
-        expectedDataDirs.add(homeDir + "/" + dataDir1);
-        expectedDataDirs.add(homeDir + "/" + dataDir2);
-        assertEquals(expectedDataDirs, metadata.dataDirs());
-        assertEquals(homeDir + "/" + cdcDir, metadata.cdcDir());
-        assertEquals(homeDir + "/" + stagingDir, metadata.stagingDir());
+        assertThat(metadata.dataDirs()).contains(homeDir + "/" + DATA_DIR_1, homeDir + "/" + DATA_DIR_2);
+        assertThat(metadata.cdcDir()).isEqualTo(homeDir + "/" + CDC_DIR);
+        assertThat(metadata.stagingDir()).isEqualTo(homeDir + "/" + STAGING_DIR);
+    }
+
+    InstanceMetadataImpl.Builder getInstanceMetadataBuilder(String rootDir)
+    {
+        List<String> dataDirs = new ArrayList<>();
+        dataDirs.add(rootDir + "/" + DATA_DIR_1);
+        dataDirs.add(rootDir + "/" + DATA_DIR_2);
+
+        return InstanceMetadataImpl.builder()
+                                   .id(ID)
+                                   .host(HOST)
+                                   .port(PORT)
+                                   .dataDirs(dataDirs)
+                                   .cdcDir(rootDir + "/" + CDC_DIR)
+                                   .stagingDir(rootDir + "/" + STAGING_DIR)
+                                   .metricRegistry(METRIC_REGISTRY);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadataImplTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cluster/instance/InstanceMetadataImplTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.cluster.instance;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.codahale.metrics.MetricRegistry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InstanceMetadataImplTest
+{
+
+    @TempDir
+    Path tempDir;
+
+
+    @Test
+    void testConstructor()
+    {
+        int id = 123;
+        String host = "testhost";
+        int port = 12345;
+        String rootDir = tempDir.toString();
+        List<String> dataDirs = new ArrayList<>();
+        dataDirs.add(rootDir + "/test/data/data1");
+        dataDirs.add(rootDir + "/test/data/data2");
+        String cdcDir = rootDir + "/cdc_dir";
+        String stagingDir = rootDir + "/staging_dir";
+        MetricRegistry metricRegistry = new MetricRegistry();
+
+        InstanceMetadataImpl metadata = InstanceMetadataImpl.builder()
+                                                            .id(id)
+                                                            .host(host)
+                                                            .port(port)
+                                                            .dataDirs(dataDirs)
+                                                            .cdcDir(cdcDir)
+                                                            .stagingDir(stagingDir)
+                                                            .metricRegistry(metricRegistry)
+                                                            .build();
+
+        assertEquals(id, metadata.id());
+        assertEquals(host, metadata.host());
+        assertEquals(port, metadata.port());
+        assertEquals(dataDirs, metadata.dataDirs());
+        assertEquals(cdcDir, metadata.cdcDir());
+        assertEquals(stagingDir, metadata.stagingDir());
+    }
+
+    @Test
+    void testConstructorWithHomeDirPaths()
+    {
+        int id = 123;
+        String host = "testhost";
+        int port = 12345;
+        String rootDir = "~";
+        String dataDir1 = "test/data/data1";
+        String dataDir2 = "test/data/data2";
+        List<String> dataDirs = new ArrayList<>();
+        dataDirs.add(rootDir + "/" + dataDir1);
+        dataDirs.add(rootDir + "/" + dataDir2);
+        String cdcDir = "cdc_dir";
+        String stagingDir = "staging_dir";
+        MetricRegistry metricRegistry = new MetricRegistry();
+
+        String homeDir = System.getProperty("user.home");
+
+        InstanceMetadataImpl metadata = InstanceMetadataImpl.builder()
+                                                            .id(id)
+                                                            .host(host)
+                                                            .port(port)
+                                                            .dataDirs(dataDirs)
+                                                            .cdcDir(rootDir + "/" + cdcDir)
+                                                            .stagingDir(rootDir + "/" + stagingDir)
+                                                            .metricRegistry(metricRegistry)
+                                                            .build();
+
+        List<String> expectedDataDirs = new ArrayList<>();
+        expectedDataDirs.add(homeDir + "/" + dataDir1);
+        expectedDataDirs.add(homeDir + "/" + dataDir2);
+        assertEquals(expectedDataDirs, metadata.dataDirs());
+        assertEquals(homeDir + "/" + cdcDir, metadata.cdcDir());
+        assertEquals(homeDir + "/" + stagingDir, metadata.stagingDir());
+    }
+}


### PR DESCRIPTION
CDC directory in InstanceMetadata constructor initialized with new builder instance value instead of the value from builder passed to constructor.

For [CASSANDRASC-171](https://issues.apache.org/jira/browse/CASSSIDECAR-171)