### PR TITLE
CASSSIDECAR-173: Endpoint to retrieve C* gossip status

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Add sidecar endpoint to retrieve cassandra gossip health (CASSSIDECAR-173)
  * Fix SidecarSchema stuck at initialization due to ClusterLeaseTask scheduling (CASSSIDECAR-189)
  * Add RBAC Authorization support in Sidecar (CASSSIDECAR-161)
  * Standardize configuration for duration units (CASSSIDECAR-186)

--- a/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraStorageOperations.java
+++ b/adapters/base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraStorageOperations.java
@@ -233,4 +233,13 @@ public class CassandraStorageOperations implements StorageOperations
         StorageJmxOperations ssProxy = jmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME);
         ssProxy.decommission(force);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isGossipRunning()
+    {
+        return jmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME).isGossipRunning();
+    }
 }

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV1.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV1.java
@@ -97,6 +97,7 @@ public final class ApiEndpointsV1
     public static final String SSTABLE_CLEANUP_ROUTE = API_V1 + PER_UPLOAD;
 
     public static final String GOSSIP_INFO_ROUTE = API_V1 + CASSANDRA + "/gossip";
+    public static final String GOSSIP_HEALTH_ROUTE = GOSSIP_INFO_ROUTE + HEALTH;
     public static final String TIME_SKEW_ROUTE = API_V1 + "/time-skew";
 
     public static final String KEYSPACE_TOKEN_MAPPING_ROUTE = API_V1 + PER_KEYSPACE + "/token-range-replicas";

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/GossipHealthRequest.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/GossipHealthRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.request;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.response.HealthResponse;
+
+/**
+ * Request to get gossip health
+ */
+public class GossipHealthRequest extends JsonRequest<HealthResponse>
+{
+    /**
+     * Constructs a request to GET gossip health
+     */
+    public GossipHealthRequest()
+    {
+        super(ApiEndpointsV1.GOSSIP_HEALTH_ROUTE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethod method()
+    {
+        return HttpMethod.GET;
+    }
+}

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/RequestContext.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/RequestContext.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.sidecar.common.request.CleanSSTableUploadSessionRequ
 import org.apache.cassandra.sidecar.common.request.ClearSnapshotRequest;
 import org.apache.cassandra.sidecar.common.request.ConnectedClientStatsRequest;
 import org.apache.cassandra.sidecar.common.request.CreateSnapshotRequest;
+import org.apache.cassandra.sidecar.common.request.GossipHealthRequest;
 import org.apache.cassandra.sidecar.common.request.GossipInfoRequest;
 import org.apache.cassandra.sidecar.common.request.ImportSSTableRequest;
 import org.apache.cassandra.sidecar.common.request.ListOperationalJobsRequest;
@@ -334,6 +335,17 @@ public class RequestContext
         public Builder gossipInfoRequest()
         {
             return request(GOSSIP_INFO_REQUEST);
+        }
+
+        /**
+         * Sets the {@code request} to be a {@link GossipHealthRequest} and returns a reference to this Builder enabling
+         * method chaining.
+         *
+         * @return a reference to this Builder
+         */
+        public Builder gossipHealthRequest()
+        {
+            return request(new GossipHealthRequest());
         }
 
         /**

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
@@ -220,6 +220,20 @@ public class SidecarClient implements AutoCloseable, SidecarClientBlobRestoreExt
         return executor.executeRequestAsync(requestBuilder().gossipInfoRequest().build());
     }
 
+
+    /**
+     * Executes the GET gossip health request using the default retry policy and configured selection policy
+     * @param instance the instance where the request will be executed
+     * @return a completable future with gossip health response
+     */
+    public CompletableFuture<HealthResponse> gossipHealth(SidecarInstance instance)
+    {
+        return executor.executeRequestAsync(requestBuilder()
+                                            .singleInstanceSelectionPolicy(instance)
+                                            .gossipHealthRequest()
+                                            .build());
+    }
+
     /**
      * Executes the time skew request using the default retry policy and configured selection policy
      *

--- a/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
+++ b/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
@@ -392,6 +392,36 @@ abstract class SidecarClientTest
     }
 
     @Test
+    public void testGossipHealthOK() throws InterruptedException, ExecutionException, TimeoutException
+    {
+        SidecarInstanceImpl sidecarInstance = instances.get(3);
+        String gossipHealthAsString = "{\"status\":\"OK\"}";
+        MockResponse response = new MockResponse().setResponseCode(OK.code()).setBody(gossipHealthAsString);
+        enqueue(response);
+
+        HealthResponse result = client.gossipHealth(sidecarInstance).get(30, TimeUnit.SECONDS);
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo("OK");
+
+        validateResponseServed(ApiEndpointsV1.GOSSIP_HEALTH_ROUTE);
+    }
+
+    @Test
+    public void testGossipHealthNotOK() throws InterruptedException, ExecutionException, TimeoutException
+    {
+        SidecarInstanceImpl sidecarInstance = instances.get(3);
+        String gossipHealthAsString = "{\"status\":\"NOT_OK\"}";
+        MockResponse response = new MockResponse().setResponseCode(OK.code()).setBody(gossipHealthAsString);
+        enqueue(response);
+
+        HealthResponse result = client.gossipHealth(sidecarInstance).get(30, TimeUnit.SECONDS);
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo("NOT_OK");
+
+        validateResponseServed(ApiEndpointsV1.GOSSIP_HEALTH_ROUTE);
+    }
+
+    @Test
     public void testTimeSkew() throws Exception
     {
         String timeSkewAsString = "{\"currentTime\":\"123456789\",\"allowableSkewInMinutes\":\"122\"}}";

--- a/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/StorageOperations.java
+++ b/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/StorageOperations.java
@@ -114,4 +114,9 @@ public interface StorageOperations
      * @param force force decommission, bypassing RF checks, when this flag is set
      */
     void decommission(boolean force);
+
+    /**
+     * @return returns true if gossip is running, false otherwise
+     */
+    boolean isGossipRunning();
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
@@ -58,9 +58,9 @@ public class GossipHealthHandler extends AbstractHandler<Void>
     {
         StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
         executorPools.service()
-                         .executeBlocking(operations::isGossipRunning)
-                         .onSuccess(isGossipRunning -> context.json(isGossipRunning ? OK_STATUS : NOT_OK_STATUS))
-                         .onFailure(cause -> processFailure(cause, context, host, remoteAddress, request));
+                     .executeBlocking(operations::isGossipRunning)
+                     .onSuccess(isGossipRunning -> context.json(isGossipRunning ? OK_STATUS : NOT_OK_STATUS))
+                     .onFailure(cause -> processFailure(cause, context, host, remoteAddress, request));
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.routes;
+
+import com.google.inject.Inject;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+
+import static org.apache.cassandra.sidecar.server.MainModule.NOT_OK_STATUS;
+import static org.apache.cassandra.sidecar.server.MainModule.OK_STATUS;
+
+
+/**
+ * Handler to retrieve gossip health
+ */
+public class GossipHealthHandler extends AbstractHandler<Void>
+{
+    /**
+     * Constructs a handler with the provided {@code metadataFetcher}
+     * @param metadataFetcher the metadata fetcher
+     * @param executorPools   executor pools for blocking executions
+     */
+    @Inject
+    protected GossipHealthHandler(InstanceMetadataFetcher metadataFetcher, ExecutorPools executorPools)
+    {
+        super(metadataFetcher, executorPools, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleInternal(RoutingContext context,
+                               HttpServerRequest httpRequest,
+                               String host,
+                               SocketAddress remoteAddress,
+                               Void request)
+    {
+        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
+        executorPools.service()
+                         .executeBlocking(operations::isGossipRunning)
+                         .onSuccess(isGossipRunning -> context.json(isGossipRunning ? OK_STATUS : NOT_OK_STATUS))
+                         .onFailure(cause -> processFailure(cause, context, host, remoteAddress, request));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Void extractParamsOrThrow(RoutingContext context)
+    {
+        return null;
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -113,6 +113,7 @@ import org.apache.cassandra.sidecar.routes.CassandraHealthHandler;
 import org.apache.cassandra.sidecar.routes.ConnectedClientStatsHandler;
 import org.apache.cassandra.sidecar.routes.DiskSpaceProtectionHandler;
 import org.apache.cassandra.sidecar.routes.FileStreamHandler;
+import org.apache.cassandra.sidecar.routes.GossipHealthHandler;
 import org.apache.cassandra.sidecar.routes.GossipInfoHandler;
 import org.apache.cassandra.sidecar.routes.JsonErrorHandler;
 import org.apache.cassandra.sidecar.routes.KeyspaceRingHandler;
@@ -319,6 +320,7 @@ public class MainModule extends AbstractModule
                               TokenRangeReplicaMapHandler tokenRangeHandler,
                               LoggerHandler loggerHandler,
                               GossipInfoHandler gossipInfoHandler,
+                              GossipHealthHandler gossipHealthHandler,
                               TimeSkewHandler timeSkewHandler,
                               NodeSettingsHandler nodeSettingsHandler,
                               SSTableUploadHandler ssTableUploadHandler,
@@ -387,6 +389,9 @@ public class MainModule extends AbstractModule
         // authenticated users can also read node settings information.
         router.get(ApiEndpointsV1.NODE_SETTINGS_ROUTE)
               .handler(nodeSettingsHandler);
+
+        router.get(ApiEndpointsV1.GOSSIP_HEALTH_ROUTE)
+              .handler(gossipHealthHandler);
 
         router.get(ApiEndpointsV1.TIME_SKEW_ROUTE)
               .handler(timeSkewHandler);

--- a/server/src/test/integration/org/apache/cassandra/sidecar/routes/GossipHealthHandlerIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/routes/GossipHealthHandlerIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.routes;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Future;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.response.HealthResponse;
+import org.apache.cassandra.sidecar.testing.IntegrationTestBase;
+import org.apache.cassandra.testing.CassandraIntegrationTest;
+import org.apache.cassandra.testing.CassandraTestContext;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test GET gossip health endpoint with C* container
+ */
+@ExtendWith(VertxExtension.class)
+public class GossipHealthHandlerIntegrationTest extends IntegrationTestBase
+{
+    private static final String testRoute = "/api/v1/cassandra/gossip/__health";
+
+    private Future<HealthResponse> getGossipHealth()
+    {
+        return client.get(server.actualPort(), "127.0.0.1", testRoute)
+                     .expect(ResponsePredicate.SC_OK)
+                     .send()
+                     .compose(response -> {
+                         assertThat(response.statusCode()).isEqualTo(OK.code());
+                         return Future.succeededFuture(response.bodyAsJson(HealthResponse.class));
+                     });
+    }
+
+    @CassandraIntegrationTest()
+    void testGossipHealth(CassandraTestContext context, VertxTestContext testContext)
+    {
+        int disableGossip = context.cluster().getFirstRunningInstance().nodetool("disablegossip");
+        assertThat(disableGossip).isEqualTo(0);
+
+        getGossipHealth()
+        .compose(response -> {
+            assertThat(response.status()).isEqualTo("NOT_OK");
+            assertThat(context.cluster().getFirstRunningInstance().nodetool("enablegossip"))
+            .isEqualTo(0);
+            return getGossipHealth();
+        })
+        .compose(response -> {
+            assertThat(response.status()).isEqualTo("OK");
+            return Future.succeededFuture();
+        })
+        .onSuccess(response -> testContext.completeNow())
+        .onFailure(testContext::failNow);
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/CommonTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/CommonTest.java
@@ -90,9 +90,9 @@ public class CommonTest
         @Singleton
         public InstancesMetadata instanceConfig()
         {
-            final int instanceId = 100;
-            final String host = "127.0.0.1";
-            final InstanceMetadata instanceMetadata = mock(InstanceMetadata.class);
+            int instanceId = 100;
+            String host = "127.0.0.1";
+            InstanceMetadata instanceMetadata = mock(InstanceMetadata.class);
             when(instanceMetadata.host()).thenReturn(host);
             when(instanceMetadata.port()).thenReturn(9042);
             when(instanceMetadata.id()).thenReturn(instanceId);

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/CommonTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/CommonTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.routes;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.util.Modules;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.TestModule;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.apache.cassandra.sidecar.server.MainModule;
+import org.apache.cassandra.sidecar.server.Server;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Common test code to setup/teardown the server and populate test instances metadata
+ */
+public class CommonTest
+{
+    static final Logger LOGGER = LoggerFactory.getLogger(CommonTest.class);
+    Vertx vertx;
+    Server server;
+    CassandraAdapterDelegate delegate = mock(CassandraAdapterDelegate.class);
+
+    @BeforeEach
+    void before() throws InterruptedException
+    {
+        Injector injector;
+        Module testOverride = Modules.override(new TestModule())
+                                     .with(new CommonTestModule());
+        injector = Guice.createInjector(Modules.override(new MainModule())
+                                               .with(testOverride));
+        vertx = injector.getInstance(Vertx.class);
+        server = injector.getInstance(Server.class);
+        VertxTestContext context = new VertxTestContext();
+        server.start()
+              .onSuccess(s -> context.completeNow())
+              .onFailure(context::failNow);
+        context.awaitCompletion(5, TimeUnit.SECONDS);
+    }
+
+    @AfterEach
+    void after() throws InterruptedException
+    {
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        server.close().onSuccess(res -> closeLatch.countDown());
+        if (closeLatch.await(60, TimeUnit.SECONDS))
+            LOGGER.info("Close event received before timeout.");
+        else
+            LOGGER.error("Close event timed out.");
+    }
+
+    class CommonTestModule extends AbstractModule
+    {
+        @Provides
+        @Singleton
+        public InstancesMetadata instanceConfig()
+        {
+            final int instanceId = 100;
+            final String host = "127.0.0.1";
+            final InstanceMetadata instanceMetadata = mock(InstanceMetadata.class);
+            when(instanceMetadata.host()).thenReturn(host);
+            when(instanceMetadata.port()).thenReturn(9042);
+            when(instanceMetadata.id()).thenReturn(instanceId);
+            when(instanceMetadata.stagingDir()).thenReturn("");
+            when(instanceMetadata.delegate()).thenReturn(delegate);
+
+            InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+            when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+            when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
+
+            return mockInstancesMetadata;
+        }
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/GossipHealthHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/GossipHealthHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.routes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Failure tests for {@link GossipHealthHandler}
+ * Success cases are already covered by corresponding in-jvm test
+ */
+@ExtendWith(VertxExtension.class)
+public class GossipHealthHandlerTest extends CommonTest
+{
+    StorageOperations storageOperations = mock(StorageOperations.class);
+
+    @Test
+    void testFailure(VertxTestContext context)
+    {
+        doThrow(new RuntimeException()).when(storageOperations).isGossipRunning();
+
+        WebClient client = WebClient.create(vertx);
+        client.get(server.actualPort(), "127.0.0.1", "/api/v1/cassandra/gossip/__health")
+              .expect(ResponsePredicate.SC_INTERNAL_SERVER_ERROR)
+              .send(context.succeeding(response -> {
+                  assertThat(response.statusCode()).isEqualTo(INTERNAL_SERVER_ERROR.code());
+                  context.completeNow();
+              }));
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSSIDECAR-173
Developing a new Sidecar endpoint to retrieve gossip running status of Cassandra, so the end user can use this endpoint without having to invoke C* JMX call. This endpoint will have authorization checks enabled once authorization feature is added to the Sidecar.

Circle CI run: https://app.circleci.com/pipelines/github/skoppu22/cassandra-sidecar?branch=gossips2