### PR TITLE
CASSSIDECAR-175: Renamed InstancesConfig to InstancesMetadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Renaming InstancesConfig to InstancesMetadata (CASSSIDECAR-175)
  * Mechanism to have a reduced number of Sidecar instances run operations (CASSSIDECAR-174)
  * Adding support for CDC APIs into sidecar client (CASSSIDECAR-172)
  * Stopping Sidecar can take a long time (CASSSIDECAR-178)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcLogCache.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcLogCache.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
@@ -67,10 +67,10 @@ public class CdcLogCache
 
     @Inject
     public CdcLogCache(ExecutorPools executorPools,
-                       InstancesConfig instancesConfig,
+                       InstancesMetadata instancesMetadata,
                        SidecarConfiguration sidecarConfig)
     {
-        this(executorPools, instancesConfig,
+        this(executorPools, instancesMetadata,
              TimeUnit.SECONDS.toMillis(sidecarConfig.serviceConfiguration()
                                                     .cdcConfiguration()
                                                     .segmentHardlinkCacheExpiryInSecs()));
@@ -78,7 +78,7 @@ public class CdcLogCache
 
     @VisibleForTesting
     CdcLogCache(ExecutorPools executorPools,
-                InstancesConfig instancesConfig,
+                InstancesMetadata instancesMetadata,
                 long cacheExpiryInMillis)
     {
         this.cacheExpiryInMillis = cacheExpiryInMillis;
@@ -88,7 +88,7 @@ public class CdcLogCache
                                          .removalListener(hardlinkRemover)
                                          .build();
         // Run cleanup in the internal pool to mute any exceptions. The cleanup is best-effort.
-        internalExecutorPool.runBlocking(() -> cleanupLinkedFilesOnStartup(instancesConfig));
+        internalExecutorPool.runBlocking(() -> cleanupLinkedFilesOnStartup(instancesMetadata));
     }
 
     public void initMaybe()
@@ -150,7 +150,7 @@ public class CdcLogCache
      * @param config instances config
      */
     @VisibleForTesting
-    public void cleanupLinkedFilesOnStartup(InstancesConfig config)
+    public void cleanupLinkedFilesOnStartup(InstancesMetadata config)
     {
         for (InstanceMetadata instance : config.instances())
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesMetadata.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesMetadata.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Maintains metadata of instances maintained by Sidecar.
  */
-public interface InstancesConfig
+public interface InstancesMetadata
 {
     /**
      * Returns metadata associated with the Cassandra instances managed by this Sidecar. The implementer

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesMetadataImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesMetadataImpl.java
@@ -33,19 +33,19 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Local implementation of InstancesConfig.
  */
-public class InstancesConfigImpl implements InstancesConfig
+public class InstancesMetadataImpl implements InstancesMetadata
 {
     private final Map<Integer, InstanceMetadata> idToInstanceMetadata;
     private final Map<String, InstanceMetadata> hostToInstanceMetadata;
     private final List<InstanceMetadata> instanceMetadataList;
     private final DnsResolver dnsResolver;
 
-    public InstancesConfigImpl(InstanceMetadata instanceMetadata, DnsResolver dnsResolver)
+    public InstancesMetadataImpl(InstanceMetadata instanceMetadata, DnsResolver dnsResolver)
     {
         this(Collections.singletonList(instanceMetadata), dnsResolver);
     }
 
-    public InstancesConfigImpl(List<InstanceMetadata> instanceMetadataList, DnsResolver dnsResolver)
+    public InstancesMetadataImpl(List<InstanceMetadata> instanceMetadataList, DnsResolver dnsResolver)
     {
         this.idToInstanceMetadata = instanceMetadataList.stream()
                                                         .collect(Collectors.toMap(InstanceMetadata::id,

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesMetadataImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/InstancesMetadataImpl.java
@@ -31,7 +31,7 @@ import org.apache.cassandra.sidecar.exceptions.NoSuchSidecarInstanceException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Local implementation of InstancesConfig.
+ * Local implementation of InstancesMetadata.
  */
 public class InstancesMetadataImpl implements InstancesMetadata
 {

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/locator/CachedLocalTokenRanges.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/locator/CachedLocalTokenRanges.java
@@ -42,7 +42,7 @@ import com.datastax.driver.core.Host;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Metadata;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.TokenRange;
 import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
@@ -55,7 +55,7 @@ import org.jetbrains.annotations.NotNull;
 public class CachedLocalTokenRanges implements LocalTokenRangesProvider
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CachedLocalTokenRanges.class);
-    private final InstancesConfig instancesConfig;
+    private final InstancesMetadata instancesMetadata;
     private final DnsResolver dnsResolver;
 
     @GuardedBy("this")
@@ -67,9 +67,9 @@ public class CachedLocalTokenRanges implements LocalTokenRangesProvider
     @GuardedBy("this")
     private ImmutableMap<String, Map<Integer, Set<TokenRange>>> localTokenRangesCache;
 
-    public CachedLocalTokenRanges(InstancesConfig instancesConfig, DnsResolver dnsResolver)
+    public CachedLocalTokenRanges(InstancesMetadata instancesMetadata, DnsResolver dnsResolver)
     {
-        this.instancesConfig = instancesConfig;
+        this.instancesMetadata = instancesMetadata;
         this.dnsResolver = dnsResolver;
         this.localTokenRangesCache = null;
         this.localInstanceIdsCache = null;
@@ -80,7 +80,7 @@ public class CachedLocalTokenRanges implements LocalTokenRangesProvider
     @Override
     public Map<Integer, Set<TokenRange>> localTokenRanges(String keyspace)
     {
-        List<InstanceMetadata> localInstances = instancesConfig.instances();
+        List<InstanceMetadata> localInstances = instancesMetadata.instances();
 
         if (localInstances.isEmpty())
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembership.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembership.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
@@ -54,15 +54,15 @@ import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements ElectorateMembership
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MostReplicatedKeyspaceTokenZeroElectorateMembership.class);
-    private final InstancesConfig instancesConfig;
+    private final InstancesMetadata instancesMetadata;
     private final CQLSessionProvider cqlSessionProvider;
     private final SidecarConfiguration configuration;
 
-    public MostReplicatedKeyspaceTokenZeroElectorateMembership(InstancesConfig instancesConfig,
+    public MostReplicatedKeyspaceTokenZeroElectorateMembership(InstancesMetadata instancesMetadata,
                                                                CQLSessionProvider cqlSessionProvider,
                                                                SidecarConfiguration sidecarConfiguration)
     {
-        this.instancesConfig = instancesConfig;
+        this.instancesMetadata = instancesMetadata;
         this.cqlSessionProvider = cqlSessionProvider;
         this.configuration = sidecarConfiguration;
     }
@@ -103,7 +103,7 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
     Set<String> collectLocalInstancesHostsAndPorts()
     {
         Set<String> result = new HashSet<>();
-        for (InstanceMetadata instance : instancesConfig.instances())
+        for (InstanceMetadata instance : instancesMetadata.instances())
         {
             CassandraAdapterDelegate delegate = instance.delegate();
             if (delegate == null)
@@ -126,7 +126,7 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
 
     <O> O firstAvailableOperationFromDelegate(Function<CassandraAdapterDelegate, O> mapper)
     {
-        for (InstanceMetadata instance : instancesConfig.instances())
+        for (InstanceMetadata instance : instancesMetadata.instances())
         {
             CassandraAdapterDelegate delegate = instance.delegate();
             O applied = delegate == null ? null : mapper.apply(delegate);
@@ -148,7 +148,7 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
      */
     String highestReplicationFactorKeyspace()
     {
-        if (instancesConfig.instances().isEmpty())
+        if (instancesMetadata.instances().isEmpty())
         {
             LOGGER.warn("There are no local Cassandra instances managed by this Sidecar");
             return null;

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobManagerGroup.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobManagerGroup.java
@@ -127,7 +127,7 @@ public class RestoreJobManagerGroup
     // Create RestoreJobManager instances eagerly
     private void initializeManagers(InstancesMetadata instancesMetadata)
     {
-        // todo: allow register listener for instances list changes in the instancesConfig?
+        // todo: allow register listener for instances list changes in the instancesMetadata?
         instancesMetadata.instances().forEach(this::getManager);
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobManagerGroup.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RestoreJobManagerGroup.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
@@ -48,7 +48,7 @@ public class RestoreJobManagerGroup
 
     @Inject
     public RestoreJobManagerGroup(SidecarConfiguration configuration,
-                                  InstancesConfig instancesConfig,
+                                  InstancesMetadata instancesMetadata,
                                   ExecutorPools executorPools,
                                   PeriodicTaskExecutor periodicTaskExecutor,
                                   RestoreProcessor restoreProcessor,
@@ -58,7 +58,7 @@ public class RestoreJobManagerGroup
         this.restoreJobConfig = configuration.restoreJobConfiguration();
         this.restoreProcessor = restoreProcessor;
         this.executorPools = executorPools;
-        initializeManagers(instancesConfig);
+        initializeManagers(instancesMetadata);
         periodicTaskExecutor.schedule(jobDiscoverer);
         periodicTaskExecutor.schedule(restoreProcessor);
         periodicTaskExecutor.schedule(ringTopologyRefresher);
@@ -125,9 +125,9 @@ public class RestoreJobManagerGroup
     }
 
     // Create RestoreJobManager instances eagerly
-    private void initializeManagers(InstancesConfig instancesConfig)
+    private void initializeManagers(InstancesMetadata instancesMetadata)
     {
         // todo: allow register listener for instances list changes in the instancesConfig?
-        instancesConfig.instances().forEach(this::getManager);
+        instancesMetadata.instances().forEach(this::getManager);
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -56,8 +56,8 @@ import org.apache.cassandra.sidecar.adapters.base.CassandraFactory;
 import org.apache.cassandra.sidecar.adapters.cassandra41.Cassandra41Factory;
 import org.apache.cassandra.sidecar.cluster.CQLSessionProviderImpl;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
-import org.apache.cassandra.sidecar.cluster.InstancesConfigImpl;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadataImpl;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadataImpl;
 import org.apache.cassandra.sidecar.cluster.locator.CachedLocalTokenRanges;
@@ -494,14 +494,14 @@ public class MainModule extends AbstractModule
 
     @Provides
     @Singleton
-    public InstancesConfig instancesConfig(Vertx vertx,
-                                           SidecarConfiguration configuration,
-                                           CassandraVersionProvider cassandraVersionProvider,
-                                           SidecarVersionProvider sidecarVersionProvider,
-                                           DnsResolver dnsResolver,
-                                           CQLSessionProvider cqlSessionProvider,
-                                           DriverUtils driverUtils,
-                                           MetricRegistryFactory registryProvider)
+    public InstancesMetadata instancesConfig(Vertx vertx,
+                                             SidecarConfiguration configuration,
+                                             CassandraVersionProvider cassandraVersionProvider,
+                                             SidecarVersionProvider sidecarVersionProvider,
+                                             DnsResolver dnsResolver,
+                                             CQLSessionProvider cqlSessionProvider,
+                                             DriverUtils driverUtils,
+                                             MetricRegistryFactory registryProvider)
     {
         List<InstanceMetadata> instanceMetadataList =
         configuration.cassandraInstances()
@@ -519,7 +519,7 @@ public class MainModule extends AbstractModule
                      })
                      .collect(Collectors.toList());
 
-        return new InstancesConfigImpl(instanceMetadataList, dnsResolver);
+        return new InstancesMetadataImpl(instanceMetadataList, dnsResolver);
     }
 
     @Provides
@@ -675,9 +675,9 @@ public class MainModule extends AbstractModule
 
     @Provides
     @Singleton
-    public LocalTokenRangesProvider localTokenRangesProvider(InstancesConfig instancesConfig, DnsResolver dnsResolver)
+    public LocalTokenRangesProvider localTokenRangesProvider(InstancesMetadata instancesMetadata, DnsResolver dnsResolver)
     {
-        return new CachedLocalTokenRanges(instancesConfig, dnsResolver);
+        return new CachedLocalTokenRanges(instancesMetadata, dnsResolver);
     }
 
     @Provides

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -682,11 +682,11 @@ public class MainModule extends AbstractModule
 
     @Provides
     @Singleton
-    public ElectorateMembership electorateMembership(InstancesConfig instancesConfig,
+    public ElectorateMembership electorateMembership(InstancesMetadata instancesMetadata,
                                                      CQLSessionProvider cqlSessionProvider,
                                                      SidecarConfiguration configuration)
     {
-        return new MostReplicatedKeyspaceTokenZeroElectorateMembership(instancesConfig, cqlSessionProvider, configuration);
+        return new MostReplicatedKeyspaceTokenZeroElectorateMembership(instancesMetadata, cqlSessionProvider, configuration);
     }
 
     @Provides

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -494,14 +494,14 @@ public class MainModule extends AbstractModule
 
     @Provides
     @Singleton
-    public InstancesMetadata instancesConfig(Vertx vertx,
-                                             SidecarConfiguration configuration,
-                                             CassandraVersionProvider cassandraVersionProvider,
-                                             SidecarVersionProvider sidecarVersionProvider,
-                                             DnsResolver dnsResolver,
-                                             CQLSessionProvider cqlSessionProvider,
-                                             DriverUtils driverUtils,
-                                             MetricRegistryFactory registryProvider)
+    public InstancesMetadata instancesMetadata(Vertx vertx,
+                                               SidecarConfiguration configuration,
+                                               CassandraVersionProvider cassandraVersionProvider,
+                                               SidecarVersionProvider sidecarVersionProvider,
+                                               DnsResolver dnsResolver,
+                                               CQLSessionProvider cqlSessionProvider,
+                                               DriverUtils driverUtils,
+                                               MetricRegistryFactory registryProvider)
     {
         List<InstanceMetadata> instanceMetadataList =
         configuration.cassandraInstances()

--- a/server/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
@@ -55,7 +55,7 @@ public class SnapshotPathBuilder extends BaseFileSystem
 
     /**
      * Creates a new SnapshotPathBuilder for snapshots of an instance with the given {@code vertx} instance and
-     * {@code instancesConfig Cassandra configuration}.
+     * {@code instancesMetadata Cassandra configuration}.
      *
      * @param vertx           the vertx instance
      * @param instancesMetadata the configuration for Cassandra

--- a/server/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilder.java
@@ -36,7 +36,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.common.utils.Preconditions;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.routes.data.StreamSSTableComponentRequestParam;
@@ -58,17 +58,17 @@ public class SnapshotPathBuilder extends BaseFileSystem
      * {@code instancesConfig Cassandra configuration}.
      *
      * @param vertx           the vertx instance
-     * @param instancesConfig the configuration for Cassandra
+     * @param instancesMetadata the configuration for Cassandra
      * @param validator       a validator instance to validate Cassandra-specific input
      * @param executorPools   executor pools for blocking executions
      */
     @Inject
     public SnapshotPathBuilder(Vertx vertx,
-                               InstancesConfig instancesConfig,
+                               InstancesMetadata instancesMetadata,
                                CassandraInputValidator validator,
                                ExecutorPools executorPools)
     {
-        super(vertx.fileSystem(), instancesConfig, validator, executorPools);
+        super(vertx.fileSystem(), instancesMetadata, validator, executorPools);
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/BaseFileSystem.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/BaseFileSystem.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.file.FileProps;
 import io.vertx.core.file.FileSystem;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 
 /**
@@ -39,24 +39,24 @@ public class BaseFileSystem
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     protected final ExecutorPools executorPools;
     protected final FileSystem fs;
-    protected final InstancesConfig instancesConfig;
+    protected final InstancesMetadata instancesMetadata;
     protected final CassandraInputValidator validator;
 
     /**
      * Creates a new FileSystemUtils with the given {@code vertx} instance.
      *
      * @param fileSystem      async file system abstraction from vertx
-     * @param instancesConfig the configuration for Cassandra
+     * @param instancesMetadata the configuration for Cassandra
      * @param validator       validates cassandra related inputs
      * @param executorPools   executor pools for blocking executions
      */
     public BaseFileSystem(FileSystem fileSystem,
-                          InstancesConfig instancesConfig,
+                          InstancesMetadata instancesMetadata,
                           CassandraInputValidator validator,
                           ExecutorPools executorPools)
     {
         this.fs = fileSystem;
-        this.instancesConfig = instancesConfig;
+        this.instancesMetadata = instancesMetadata;
         this.validator = validator;
         this.executorPools = executorPools;
     }
@@ -67,7 +67,7 @@ public class BaseFileSystem
      */
     protected Future<List<String>> dataDirectories(String host)
     {
-        List<String> dataDirs = instancesConfig.instanceFromHost(host).dataDirs();
+        List<String> dataDirs = instancesMetadata.instanceFromHost(host).dataDirs();
         if (dataDirs == null || dataDirs.isEmpty())
         {
             String errMsg = String.format("No data directories are available for host '%s'", host);

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,12 +34,12 @@ import org.jetbrains.annotations.Nullable;
 @Singleton
 public class InstanceMetadataFetcher
 {
-    private final InstancesConfig instancesConfig;
+    private final InstancesMetadata instancesMetadata;
 
     @Inject
-    public InstanceMetadataFetcher(InstancesConfig instancesConfig)
+    public InstanceMetadataFetcher(InstancesMetadata instancesMetadata)
     {
-        this.instancesConfig = instancesConfig;
+        this.instancesMetadata = instancesMetadata;
     }
 
     /**
@@ -54,7 +54,7 @@ public class InstanceMetadataFetcher
     {
         return host == null
                ? firstInstance()
-               : instancesConfig.instanceFromHost(host);
+               : instancesMetadata.instanceFromHost(host);
     }
 
     /**
@@ -67,7 +67,7 @@ public class InstanceMetadataFetcher
      */
     public InstanceMetadata instance(int instanceId)
     {
-        return instancesConfig.instanceFromId(instanceId);
+        return instancesMetadata.instanceFromId(instanceId);
     }
 
     /**
@@ -103,7 +103,7 @@ public class InstanceMetadataFetcher
     public InstanceMetadata firstInstance()
     {
         ensureInstancesConfigured();
-        return instancesConfig.instances().get(0);
+        return instancesMetadata.instances().get(0);
     }
 
     /**
@@ -113,7 +113,7 @@ public class InstanceMetadataFetcher
     public InstanceMetadata anyInstance()
     {
         ensureInstancesConfigured();
-        List<InstanceMetadata> instances = instancesConfig.instances();
+        List<InstanceMetadata> instances = instancesMetadata.instances();
         if (instances.size() == 1)
         {
             return instances.get(0);
@@ -125,7 +125,7 @@ public class InstanceMetadataFetcher
 
     private void ensureInstancesConfigured()
     {
-        if (instancesConfig.instances().isEmpty())
+        if (instancesMetadata.instances().isEmpty())
         {
             throw new IllegalStateException("There are no instances configured!");
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
@@ -102,7 +102,7 @@ public class InstanceMetadataFetcher
      */
     public InstanceMetadata firstInstance()
     {
-        ensureInstancesConfigured();
+        ensureInstancesMetadataConfigured();
         return instancesMetadata.instances().get(0);
     }
 
@@ -112,7 +112,7 @@ public class InstanceMetadataFetcher
      */
     public InstanceMetadata anyInstance()
     {
-        ensureInstancesConfigured();
+        ensureInstancesMetadataConfigured();
         List<InstanceMetadata> instances = instancesMetadata.instances();
         if (instances.size() == 1)
         {
@@ -123,7 +123,7 @@ public class InstanceMetadataFetcher
         return instances.get(randomPick);
     }
 
-    private void ensureInstancesConfigured()
+    private void ensureInstancesMetadataConfigured()
     {
         if (instancesMetadata.instances().isEmpty())
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/SSTableUploadsPathBuilder.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/SSTableUploadsPathBuilder.java
@@ -28,7 +28,7 @@ import com.google.inject.Singleton;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.handler.HttpException;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.routes.data.SSTableUploadRequestParam;
@@ -48,17 +48,17 @@ public class SSTableUploadsPathBuilder extends BaseFileSystem
      * Creates a new SSTableUploadsPathBuilder object with the given {@code vertx} instance.
      *
      * @param vertx           the vertx instance
-     * @param instancesConfig the configuration for Cassandra
+     * @param instancesMetadata the configuration for Cassandra
      * @param validator       a validator instance to validate Cassandra-specific input
      * @param executorPools   executor pools for blocking executions
      */
     @Inject
     public SSTableUploadsPathBuilder(Vertx vertx,
-                                     InstancesConfig instancesConfig,
+                                     InstancesMetadata instancesMetadata,
                                      CassandraInputValidator validator,
                                      ExecutorPools executorPools)
     {
-        super(vertx.fileSystem(), instancesConfig, validator, executorPools);
+        super(vertx.fileSystem(), instancesMetadata, validator, executorPools);
     }
 
     /**
@@ -89,7 +89,7 @@ public class SSTableUploadsPathBuilder extends BaseFileSystem
      */
     public Future<String> resolveStagingDirectory(String host)
     {
-        InstanceMetadata instanceMeta = instancesConfig.instanceFromHost(host);
+        InstanceMetadata instanceMeta = instancesMetadata.instanceFromHost(host);
         return ensureDirectoryExists(StringUtils.removeEnd(instanceMeta.stagingDir(), File.separator));
     }
 

--- a/server/src/test/integration/org/apache/cassandra/sidecar/cluster/driver/SidecarLoadBalancingPolicyTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/cluster/driver/SidecarLoadBalancingPolicyTest.java
@@ -71,7 +71,7 @@ public class SidecarLoadBalancingPolicyTest extends IntegrationTestBase
         assertThat(connectedHosts.size()).isEqualTo(expectedConnections);
         // Now, shut down one of the hosts and make sure that we connect to a different node
         UpgradeableCluster cluster = sidecarTestContext.cluster();
-        IUpgradeableInstance inst = shutDownNonLocalInstance(cluster, sidecarTestContext.instancesConfig().instances());
+        IUpgradeableInstance inst = shutDownNonLocalInstance(cluster, sidecarTestContext.instancesMetadata().instances());
         assertThat(inst.isShutdown()).isTrue();
         InetSocketAddress downInstanceAddress = new InetSocketAddress(inst.broadcastAddress().getAddress(),
                                                                       inst.config().getInt("native_transport_port"));

--- a/server/src/test/integration/org/apache/cassandra/sidecar/cluster/locator/CqlSessionProviderIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/cluster/locator/CqlSessionProviderIntegrationTest.java
@@ -55,7 +55,7 @@ class CqlSessionProviderIntegrationTest extends IntegrationTestBase
         cassandraContext.configureAndStartCluster(builder -> {
             builder.appendConfig(config -> config.set("authenticator", "org.apache.cassandra.auth.PasswordAuthenticator"));
         });
-        sidecarTestContext.refreshInstancesConfig();
+        sidecarTestContext.refreshInstancesMetadata();
         waitForSchemaReady(30, TimeUnit.SECONDS);
         retrieveClientStats(context, "cassandra", false);
     }

--- a/server/src/test/integration/org/apache/cassandra/sidecar/common/DelegateIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/common/DelegateIntegrationTest.java
@@ -69,7 +69,7 @@ class DelegateIntegrationTest extends IntegrationTestBase
     @CassandraIntegrationTest()
     void testCorrectVersionIsEnabled()
     {
-        CassandraAdapterDelegate delegate = sidecarTestContext.instancesConfig()
+        CassandraAdapterDelegate delegate = sidecarTestContext.instancesMetadata()
                                                               .instanceFromId(1)
                                                               .delegate();
         assertThat(delegate).isNotNull();
@@ -87,7 +87,7 @@ class DelegateIntegrationTest extends IntegrationTestBase
         Checkpoint cqlReady = context.checkpoint();
         Checkpoint cqlDisconnected = context.checkpoint();
 
-        CassandraAdapterDelegate adapterDelegate = sidecarTestContext.instancesConfig()
+        CassandraAdapterDelegate adapterDelegate = sidecarTestContext.instancesMetadata()
                                                                      .instanceFromId(1)
                                                                      .delegate();
         assertThat(adapterDelegate).isNotNull();
@@ -98,7 +98,7 @@ class DelegateIntegrationTest extends IntegrationTestBase
         // where the event happens before the consumer is registered.
         eventBus.localConsumer(ON_CASSANDRA_CQL_DISCONNECTED.address(), (Message<JsonObject> message) -> {
             int instanceId = message.body().getInteger("cassandraInstanceId");
-            CassandraAdapterDelegate delegate = sidecarTestContext.instancesConfig()
+            CassandraAdapterDelegate delegate = sidecarTestContext.instancesMetadata()
                                                                   .instanceFromId(instanceId)
                                                                   .delegate();
 
@@ -110,7 +110,7 @@ class DelegateIntegrationTest extends IntegrationTestBase
 
         eventBus.localConsumer(ON_CASSANDRA_CQL_READY.address(), (Message<JsonObject> reconnectMessage) -> {
             int instanceId = reconnectMessage.body().getInteger("cassandraInstanceId");
-            CassandraAdapterDelegate delegate = sidecarTestContext.instancesConfig()
+            CassandraAdapterDelegate delegate = sidecarTestContext.instancesMetadata()
                                                                   .instanceFromId(instanceId)
                                                                   .delegate();
             assertThat(delegate).isNotNull();

--- a/server/src/test/integration/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest.java
@@ -43,8 +43,8 @@ import org.apache.cassandra.distributed.shared.JMXUtil;
 import org.apache.cassandra.distributed.shared.Versions;
 import org.apache.cassandra.sidecar.cluster.CQLSessionProviderImpl;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
-import org.apache.cassandra.sidecar.cluster.InstancesConfigImpl;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadataImpl;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadataImpl;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
@@ -168,15 +168,15 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest
             List<InetSocketAddress> address = buildContactList(instance);
             CQLSessionProvider sessionProvider =
             new CQLSessionProviderImpl(address, address, 500, instance.config().localDatacenter(), 0, SharedExecutorNettyOptions.INSTANCE);
-            InstancesConfig instancesConfig = buildInstancesConfig(instance, sessionProvider, metricRegistryProvider);
-            result.add(new MostReplicatedKeyspaceTokenZeroElectorateMembership(instancesConfig, sessionProvider, CONFIG));
+            InstancesMetadata instancesMetadata = buildInstancesMetadata(instance, sessionProvider, metricRegistryProvider);
+            result.add(new MostReplicatedKeyspaceTokenZeroElectorateMembership(instancesMetadata, sessionProvider, CONFIG));
         }
         return result;
     }
 
-    private InstancesConfig buildInstancesConfig(IInstance instance,
-                                                 CQLSessionProvider sessionProvider,
-                                                 MetricRegistryFactory metricRegistryProvider)
+    private InstancesMetadata buildInstancesMetadata(IInstance instance,
+                                                     CQLSessionProvider sessionProvider,
+                                                     MetricRegistryFactory metricRegistryProvider)
     {
         IInstanceConfig config = instance.config();
         MetricRegistry instanceSpecificRegistry = metricRegistryProvider.getOrCreate(config.num());
@@ -216,7 +216,7 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest
                                                       .delegate(delegate)
                                                       .metricRegistry(instanceSpecificRegistry)
                                                       .build());
-        return new InstancesConfigImpl(metadata, DnsResolver.DEFAULT);
+        return new InstancesMetadataImpl(metadata, DnsResolver.DEFAULT);
     }
 
     void initializeSchema(AbstractCluster<?> cluster)

--- a/server/src/test/integration/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandlerIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandlerIntegrationTest.java
@@ -100,7 +100,7 @@ public class SSTableImportHandlerIntegrationTest extends IntegrationTestBase
         // verification happens in the host system. When calling import we use the same directory, but the
         // directory does not exist inside the cluster. For that reason we need to do the following to
         // ensure "import" finds the path inside the cluster
-        String uploadStagingDir = sidecarTestContext.instancesConfig()
+        String uploadStagingDir = sidecarTestContext.instancesMetadata()
                                                     .instanceFromHost("127.0.0.1").stagingDir();
         final String stagingPathInContainer = uploadStagingDir + File.separator + uploadId
                                               + File.separator + tableName.keyspace()

--- a/server/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/ReplacementBaseTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/routes/tokenrange/ReplacementBaseTest.java
@@ -99,7 +99,7 @@ class ReplacementBaseTest extends BaseTokenRangeIntegrationTest
 
             stopNodes(seed, nodesToRemove);
             List<IUpgradeableInstance> newNodes = startReplacementNodes(nodeStart, cluster, nodesToRemove);
-            sidecarTestContext.refreshInstancesConfig();
+            sidecarTestContext.refreshInstancesMetadata();
             // Wait until replacement nodes are in JOINING state
             awaitLatchOrThrow(transientStateStart, 2, TimeUnit.MINUTES, "transientStateStart");
 
@@ -214,7 +214,7 @@ class ReplacementBaseTest extends BaseTokenRangeIntegrationTest
             ClusterUtils.stopUnchecked(nodeToRemove);
             ClusterUtils.awaitRingStatus(seed, nodeToRemove, "Down");
         }
-        sidecarTestContext.refreshInstancesConfig();
+        sidecarTestContext.refreshInstancesMetadata();
     }
 
     private void validateReplicaMapping(TokenRangeReplicasResponse mappingResponse,

--- a/server/src/test/integration/org/apache/cassandra/sidecar/testing/CassandraSidecarTestContext.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/testing/CassandraSidecarTestContext.java
@@ -71,7 +71,7 @@ public class CassandraSidecarTestContext implements AutoCloseable
     private final DnsResolver dnsResolver;
     private final AbstractCassandraTestContext abstractCassandraTestContext;
     private final Vertx vertx;
-    private final List<InstanceConfigListener> instanceConfigListeners;
+    private final List<InstancesMetadataListener> instancesMetadataListeners;
     private int numInstancesToManage;
     public InstancesMetadata instancesMetadata;
     private List<JmxClient> jmxClients;
@@ -90,7 +90,7 @@ public class CassandraSidecarTestContext implements AutoCloseable
     {
         this.vertx = vertx;
         this.numInstancesToManage = numInstancesToManage;
-        this.instanceConfigListeners = new ArrayList<>();
+        this.instancesMetadataListeners = new ArrayList<>();
         this.abstractCassandraTestContext = abstractCassandraTestContext;
         this.version = version;
         this.versionProvider = versionProvider;
@@ -139,9 +139,9 @@ public class CassandraSidecarTestContext implements AutoCloseable
         }
     }
 
-    public void registerInstanceConfigListener(InstanceConfigListener listener)
+    public void registerInstanceConfigListener(InstancesMetadataListener listener)
     {
-        this.instanceConfigListeners.add(listener);
+        this.instancesMetadataListeners.add(listener);
     }
 
     public AbstractCassandraTestContext cassandraTestContext()
@@ -167,36 +167,36 @@ public class CassandraSidecarTestContext implements AutoCloseable
     public void setNumInstancesToManage(int numInstancesToManage)
     {
         this.numInstancesToManage = numInstancesToManage;
-        refreshInstancesConfig();
+        refreshInstancesMetadata();
     }
 
     public void setUsernamePassword(String username, String password)
     {
         this.username = username;
         this.password = password;
-        refreshInstancesConfig();
+        refreshInstancesMetadata();
     }
 
     public void setSslConfiguration(SslConfiguration sslConfiguration)
     {
         this.sslConfiguration = sslConfiguration;
-        refreshInstancesConfig();
+        refreshInstancesMetadata();
     }
 
-    public InstancesMetadata instancesConfig()
+    public InstancesMetadata instancesMetadata()
     {
         if (instancesMetadata == null)
         {
-            refreshInstancesConfig();
+            refreshInstancesMetadata();
         }
         return this.instancesMetadata;
     }
 
-    public InstancesMetadata refreshInstancesConfig()
+    public InstancesMetadata refreshInstancesMetadata()
     {
         // clean-up any open sessions or client resources
         close();
-        setInstancesConfig();
+        setInstancesMetadata();
         return this.instancesMetadata;
     }
 
@@ -233,17 +233,17 @@ public class CassandraSidecarTestContext implements AutoCloseable
         }
     }
 
-    private void setInstancesConfig()
+    private void setInstancesMetadata()
     {
-        this.instancesMetadata = buildInstancesConfig(versionProvider, dnsResolver);
-        for (InstanceConfigListener listener : instanceConfigListeners)
+        this.instancesMetadata = buildInstancesMetadata(versionProvider, dnsResolver);
+        for (InstancesMetadataListener listener : instancesMetadataListeners)
         {
-            listener.onInstancesConfigChange(this.instancesMetadata);
+            listener.onInstancesMetadataChange(this.instancesMetadata);
         }
     }
 
-    private InstancesMetadata buildInstancesConfig(CassandraVersionProvider versionProvider,
-                                                   DnsResolver dnsResolver)
+    private InstancesMetadata buildInstancesMetadata(CassandraVersionProvider versionProvider,
+                                                     DnsResolver dnsResolver)
     {
         UpgradeableCluster cluster = cluster();
         List<InstanceMetadata> metadata = new ArrayList<>();
@@ -342,8 +342,8 @@ public class CassandraSidecarTestContext implements AutoCloseable
     /**
      * A listener for {@link InstancesMetadata} state changes
      */
-    public interface InstanceConfigListener
+    public interface InstancesMetadataListener
     {
-        void onInstancesConfigChange(InstancesMetadata instancesMetadata);
+        void onInstancesMetadataChange(InstancesMetadata instancesMetadata);
     }
 }

--- a/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestBase.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestBase.java
@@ -62,7 +62,7 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.common.server.data.QualifiedTableName;
@@ -391,10 +391,10 @@ public abstract class IntegrationTestBase
         }
     }
 
-    private void healthCheck(InstancesConfig instancesConfig)
+    private void healthCheck(InstancesMetadata instancesMetadata)
     {
-        instancesConfig.instances()
-                       .forEach(instanceMetadata -> instanceMetadata.delegate().healthCheck());
+        instancesMetadata.instances()
+                         .forEach(instanceMetadata -> instanceMetadata.delegate().healthCheck());
     }
 
     protected CertificateBundle ca() throws Exception

--- a/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestBase.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestBase.java
@@ -205,7 +205,7 @@ public abstract class IntegrationTestBase
                                   Consumer<WebClient> tester)
     throws Exception
     {
-        CassandraAdapterDelegate delegate = sidecarTestContext.instancesConfig()
+        CassandraAdapterDelegate delegate = sidecarTestContext.instancesMetadata()
                                                               .instanceFromId(1)
                                                               .delegate();
 
@@ -241,7 +241,7 @@ public abstract class IntegrationTestBase
         {
             try
             {
-                sidecarTestContext.refreshInstancesConfig();
+                sidecarTestContext.refreshInstancesMetadata();
 
                 Session session = maybeGetSession();
 
@@ -369,7 +369,7 @@ public abstract class IntegrationTestBase
      */
     public List<Path> findChildFile(CassandraSidecarTestContext context, String hostname, String keyspaceName, String target)
     {
-        InstanceMetadata instanceConfig = context.instancesConfig().instanceFromHost(hostname);
+        InstanceMetadata instanceConfig = context.instancesMetadata().instanceFromHost(hostname);
         List<String> parentDirectories = instanceConfig.dataDirs();
 
         return parentDirectories.stream()

--- a/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestModule.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestModule.java
@@ -82,7 +82,7 @@ public class IntegrationTestModule extends AbstractModule
 
     @Provides
     @Singleton
-    public InstancesMetadata instancesConfig()
+    public InstancesMetadata instancesMetadata()
     {
         return new WrapperInstancesMetadata();
     }
@@ -181,7 +181,7 @@ public class IntegrationTestModule extends AbstractModule
         public List<InstanceMetadata> instances()
         {
             if (cassandraTestContext != null && cassandraTestContext.isClusterBuilt())
-                return cassandraTestContext.instancesConfig().instances();
+                return cassandraTestContext.instancesMetadata().instances();
             return Collections.emptyList();
         }
 
@@ -195,7 +195,7 @@ public class IntegrationTestModule extends AbstractModule
         @Override
         public InstanceMetadata instanceFromId(int id) throws NoSuchSidecarInstanceException
         {
-            return cassandraTestContext.instancesConfig().instanceFromId(id);
+            return cassandraTestContext.instancesMetadata().instanceFromId(id);
         }
 
         /**
@@ -208,7 +208,7 @@ public class IntegrationTestModule extends AbstractModule
         @Override
         public InstanceMetadata instanceFromHost(String host) throws NoSuchSidecarInstanceException
         {
-            return cassandraTestContext.instancesConfig().instanceFromHost(host);
+            return cassandraTestContext.instancesMetadata().instanceFromHost(host);
         }
     }
 }

--- a/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestModule.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/testing/IntegrationTestModule.java
@@ -29,7 +29,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.vertx.core.Vertx;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
 import org.apache.cassandra.sidecar.config.AccessControlConfiguration;
@@ -82,9 +82,9 @@ public class IntegrationTestModule extends AbstractModule
 
     @Provides
     @Singleton
-    public InstancesConfig instancesConfig()
+    public InstancesMetadata instancesConfig()
     {
-        return new WrapperInstancesConfig();
+        return new WrapperInstancesMetadata();
     }
 
     @Provides
@@ -171,7 +171,7 @@ public class IntegrationTestModule extends AbstractModule
                                                   new CacheConfigurationImpl());
     }
 
-    class WrapperInstancesConfig implements InstancesConfig
+    class WrapperInstancesMetadata implements InstancesMetadata
     {
         /**
          * @return metadata of instances owned by the sidecar

--- a/server/src/test/java/org/apache/cassandra/sidecar/TestModule.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/TestModule.java
@@ -34,8 +34,8 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
-import org.apache.cassandra.sidecar.cluster.InstancesConfigImpl;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadataImpl;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.MockCassandraFactory;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
@@ -150,9 +150,9 @@ public class TestModule extends AbstractModule
 
     @Provides
     @Singleton
-    public InstancesConfig instancesConfig(DnsResolver dnsResolver)
+    public InstancesMetadata instancesConfig(DnsResolver dnsResolver)
     {
-        return new InstancesConfigImpl(instancesMetas(), dnsResolver);
+        return new InstancesMetadataImpl(instancesMetas(), dnsResolver);
     }
 
     @Provides

--- a/server/src/test/java/org/apache/cassandra/sidecar/TestModule.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/TestModule.java
@@ -150,7 +150,7 @@ public class TestModule extends AbstractModule
 
     @Provides
     @Singleton
-    public InstancesMetadata instancesConfig(DnsResolver dnsResolver)
+    public InstancesMetadata instancesMetadata(DnsResolver dnsResolver)
     {
         return new InstancesMetadataImpl(instancesMetas(), dnsResolver);
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
@@ -45,11 +45,11 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipTest
     private static final SidecarConfigurationImpl CONFIG = new SidecarConfigurationImpl();
 
     @Test
-    void testEmptyInstancesConfig()
+    void testEmptyInstancesMetadata()
     {
-        InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
-        when(mockInstancesConfig.instances()).thenReturn(Collections.emptyList());
-        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(mockInstancesConfig, null, CONFIG);
+        InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+        when(mockInstancesMetadata.instances()).thenReturn(Collections.emptyList());
+        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(mockInstancesMetadata, null, CONFIG);
         assertThat(membership.isMember()).as("When no local instances are managed by Sidecar, we can't determine participation")
                                          .isFalse();
     }
@@ -57,18 +57,18 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipTest
     @Test
     void testCqlSessionIsNotActive() throws UnknownHostException
     {
-        InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
+        InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
         InstanceMetadata instanceMetadata = mock(InstanceMetadata.class);
         CassandraAdapterDelegate mockCassandraAdapterDelegate = mock(CassandraAdapterDelegate.class);
         when(mockCassandraAdapterDelegate.localStorageBroadcastAddress()).thenReturn(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 8888));
         when(mockCassandraAdapterDelegate.storageOperations()).thenReturn(mock(StorageOperations.class));
         when(mockCassandraAdapterDelegate.nodeSettings()).thenReturn(mock(NodeSettings.class));
         when(instanceMetadata.delegate()).thenReturn(mockCassandraAdapterDelegate);
-        when(mockInstancesConfig.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+        when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
         CQLSessionProvider mockCQLSessionProvider = mock(CQLSessionProvider.class);
         // the session is not available so we return null
         when(mockCQLSessionProvider.get()).thenReturn(null);
-        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(mockInstancesConfig, mockCQLSessionProvider, CONFIG);
+        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(mockInstancesMetadata, mockCQLSessionProvider, CONFIG);
         assertThat(membership.isMember()).as("When the CQL connection is unavailable, we can't determine participation")
                                          .isFalse();
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -49,7 +49,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
 import org.apache.cassandra.sidecar.coordination.ClusterLease;
@@ -254,15 +254,15 @@ public class SidecarSchemaTest
 
         @Provides
         @Singleton
-        public InstancesConfig instancesConfig()
+        public InstancesMetadata instancesConfig()
         {
             InstanceMetadata instanceMeta = mock(InstanceMetadata.class);
             when(instanceMeta.stagingDir()).thenReturn("/tmp/staging"); // not an actual file
-            InstancesConfig instancesConfig = mock(InstancesConfig.class);
-            when(instancesConfig.instances()).thenReturn(Collections.singletonList(instanceMeta));
-            when(instancesConfig.instanceFromHost(any())).thenReturn(instanceMeta);
-            when(instancesConfig.instanceFromId(anyInt())).thenReturn(instanceMeta);
-            return instancesConfig;
+            InstancesMetadata instancesMetadata = mock(InstancesMetadata.class);
+            when(instancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMeta));
+            when(instancesMetadata.instanceFromHost(any())).thenReturn(instanceMeta);
+            when(instancesMetadata.instanceFromId(anyInt())).thenReturn(instanceMeta);
+            return instancesMetadata;
         }
 
         @Provides

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -254,7 +254,7 @@ public class SidecarSchemaTest
 
         @Provides
         @Singleton
-        public InstancesMetadata instancesConfig()
+        public InstancesMetadata instancesMetadata()
         {
             InstanceMetadata instanceMeta = mock(InstanceMetadata.class);
             when(instanceMeta.stagingDir()).thenReturn("/tmp/staging"); // not an actual file

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/ConnectedClientStatsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/ConnectedClientStatsHandlerTest.java
@@ -48,7 +48,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.ConnectedClientStatsResponse;
 import org.apache.cassandra.sidecar.common.response.data.ClientConnectionEntry;
@@ -134,7 +134,7 @@ public class ConnectedClientStatsHandlerTest
     {
         @Provides
         @Singleton
-        public InstancesConfig instanceConfig()
+        public InstancesMetadata instanceConfig()
         {
             ConnectedClientStatsResponse summaryResponse = new ConnectedClientStatsResponse(Collections.emptyList(),
                                                                                             EXPECTED_TOTAL_CLIENTS,
@@ -158,12 +158,12 @@ public class ConnectedClientStatsHandlerTest
             when(delegate.metricsOperations()).thenReturn(mockMetricsOperations);
             when(instanceMetadata.delegate()).thenReturn(delegate);
 
-            InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
-            when(mockInstancesConfig.instances()).thenReturn(Collections.singletonList(instanceMetadata));
-            when(mockInstancesConfig.instanceFromId(instanceId)).thenReturn(instanceMetadata);
-            when(mockInstancesConfig.instanceFromHost(host)).thenReturn(instanceMetadata);
+            InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+            when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+            when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
 
-            return mockInstancesConfig;
+            return mockInstancesMetadata;
         }
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/GossipInfoHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/GossipInfoHandlerTest.java
@@ -43,7 +43,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.GossipInfoResponse;
 import org.apache.cassandra.sidecar.common.server.ClusterMembershipOperations;
@@ -122,7 +122,7 @@ public class GossipInfoHandlerTest
     {
         @Provides
         @Singleton
-        public InstancesConfig instanceConfig()
+        public InstancesMetadata instanceConfig()
         {
             final int instanceId = 100;
             final String host = "127.0.0.1";
@@ -137,12 +137,12 @@ public class GossipInfoHandlerTest
             when(delegate.clusterMembershipOperations()).thenReturn(ops);
             when(instanceMetadata.delegate()).thenReturn(delegate);
 
-            InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
-            when(mockInstancesConfig.instances()).thenReturn(Collections.singletonList(instanceMetadata));
-            when(mockInstancesConfig.instanceFromId(instanceId)).thenReturn(instanceMetadata);
-            when(mockInstancesConfig.instanceFromHost(host)).thenReturn(instanceMetadata);
+            InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+            when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+            when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
 
-            return mockInstancesConfig;
+            return mockInstancesMetadata;
         }
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/RingHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/RingHandlerTest.java
@@ -48,7 +48,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.RingResponse;
 import org.apache.cassandra.sidecar.common.response.data.RingEntry;
@@ -205,7 +205,7 @@ class RingHandlerTest
 
         @Provides
         @Singleton
-        public InstancesConfig instanceConfig() throws IOException
+        public InstancesMetadata instanceConfig() throws IOException
         {
             int instanceId = 100;
             String host = "127.0.0.1";
@@ -220,12 +220,12 @@ class RingHandlerTest
             when(delegate.storageOperations()).thenReturn(ops);
             when(instanceMetadata.delegate()).thenReturn(delegate);
 
-            InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
-            when(mockInstancesConfig.instances()).thenReturn(Collections.singletonList(instanceMetadata));
-            when(mockInstancesConfig.instanceFromId(instanceId)).thenReturn(instanceMetadata);
-            when(mockInstancesConfig.instanceFromHost(host)).thenReturn(instanceMetadata);
+            InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+            when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+            when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
 
-            return mockInstancesConfig;
+            return mockInstancesMetadata;
         }
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/SchemaHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/SchemaHandlerTest.java
@@ -50,7 +50,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.utils.IOUtils;
 import org.apache.cassandra.sidecar.server.MainModule;
@@ -156,7 +156,7 @@ class SchemaHandlerTest
     {
         @Provides
         @Singleton
-        public InstancesConfig instanceConfig() throws IOException
+        public InstancesMetadata instanceConfig() throws IOException
         {
             final int instanceId = 100;
             final String host = "127.0.0.1";
@@ -179,12 +179,12 @@ class SchemaHandlerTest
 
             when(mockCassandraAdapterDelegate.metadata()).thenReturn(mockMetadata);
 
-            InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
-            when(mockInstancesConfig.instances()).thenReturn(Collections.singletonList(instanceMetadata));
-            when(mockInstancesConfig.instanceFromId(instanceId)).thenReturn(instanceMetadata);
-            when(mockInstancesConfig.instanceFromHost(host)).thenReturn(instanceMetadata);
+            InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+            when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+            when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
 
-            return mockInstancesConfig;
+            return mockInstancesMetadata;
         }
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/restore/BaseRestoreJobTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/restore/BaseRestoreJobTests.java
@@ -50,7 +50,7 @@ import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.request.data.CreateRestoreJobRequestPayload;
@@ -338,14 +338,14 @@ public abstract class BaseRestoreJobTests
             ThrowableFunction<String, RestoreJobProgressTracker.Status, RestoreJobFatalException> submitFunc;
 
             public TestRestoreJobManagerGroup(SidecarConfiguration configuration,
-                                              InstancesConfig instancesConfig,
+                                              InstancesMetadata instancesMetadata,
                                               ExecutorPools executorPools,
                                               PeriodicTaskExecutor periodicTaskExecutor,
                                               RestoreProcessor restoreProcessor,
                                               RestoreJobDiscoverer jobDiscoverer,
                                               RingTopologyRefresher ringTopologyRefresher)
             {
-                super(configuration, instancesConfig, executorPools, periodicTaskExecutor, restoreProcessor,
+                super(configuration, instancesMetadata, executorPools, periodicTaskExecutor, restoreProcessor,
                       jobDiscoverer, ringTopologyRefresher);
             }
 
@@ -398,7 +398,7 @@ public abstract class BaseRestoreJobTests
         @Provides
         @Singleton
         public RestoreJobManagerGroup restoreJobManagerGroup(SidecarConfiguration configuration,
-                                                             InstancesConfig instancesConfig,
+                                                             InstancesMetadata instancesMetadata,
                                                              ExecutorPools executorPools,
                                                              PeriodicTaskExecutor loopExecutor,
                                                              RestoreProcessor restoreProcessor,
@@ -406,7 +406,7 @@ public abstract class BaseRestoreJobTests
                                                              RingTopologyRefresher ringTopologyRefresher)
         {
             return new TestRestoreJobManagerGroup(configuration,
-                                                  instancesConfig,
+                                                  instancesMetadata,
                                                   executorPools,
                                                   loopExecutor,
                                                   restoreProcessor,

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandlerTest.java
@@ -49,7 +49,7 @@ import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.cluster.CQLSessionProviderImpl;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.common.response.ListSnapshotFilesResponse;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
 import org.apache.cassandra.sidecar.common.server.TableOperations;
@@ -256,7 +256,7 @@ class ListSnapshotHandlerTest
     {
         @Provides
         @Singleton
-        public InstancesConfig instancesConfig(Vertx vertx) throws IOException
+        public InstancesMetadata instancesConfig(Vertx vertx) throws IOException
         {
             CQLSessionProvider mockSession1 = mock(CQLSessionProviderImpl.class);
             TableOperations mockTableOperations = mock(TableOperations.class);

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandlerTest.java
@@ -60,7 +60,7 @@ import org.apache.cassandra.sidecar.snapshots.SnapshotUtils;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
-import static org.apache.cassandra.sidecar.snapshots.SnapshotUtils.mockInstancesConfig;
+import static org.apache.cassandra.sidecar.snapshots.SnapshotUtils.mockInstancesMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -256,7 +256,7 @@ class ListSnapshotHandlerTest
     {
         @Provides
         @Singleton
-        public InstancesMetadata instancesConfig(Vertx vertx) throws IOException
+        public InstancesMetadata instancesMetadata(Vertx vertx) throws IOException
         {
             CQLSessionProvider mockSession1 = mock(CQLSessionProviderImpl.class);
             TableOperations mockTableOperations = mock(TableOperations.class);
@@ -264,7 +264,7 @@ class ListSnapshotHandlerTest
             .thenReturn(Collections.singletonList(canonicalTemporaryPath + "/d1/data/keyspace1/table1-1234"));
             CassandraAdapterDelegate mockDelegate = mock(CassandraAdapterDelegate.class);
             when(mockDelegate.tableOperations()).thenReturn(mockTableOperations);
-            return mockInstancesConfig(vertx, canonicalTemporaryPath, mockDelegate, mockSession1);
+            return mockInstancesMetadata(vertx, canonicalTemporaryPath, mockDelegate, mockSession1);
         }
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/BaseUploadsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/BaseUploadsHandlerTest.java
@@ -68,7 +68,7 @@ import static org.apache.cassandra.sidecar.config.yaml.TrafficShapingConfigurati
 import static org.apache.cassandra.sidecar.config.yaml.TrafficShapingConfigurationImpl.DEFAULT_MAX_DELAY_TIME;
 import static org.apache.cassandra.sidecar.config.yaml.TrafficShapingConfigurationImpl.DEFAULT_OUTBOUND_GLOBAL_BANDWIDTH_LIMIT;
 import static org.apache.cassandra.sidecar.config.yaml.TrafficShapingConfigurationImpl.DEFAULT_PEAK_OUTBOUND_GLOBAL_BANDWIDTH_LIMIT;
-import static org.apache.cassandra.sidecar.snapshots.SnapshotUtils.mockInstancesConfig;
+import static org.apache.cassandra.sidecar.snapshots.SnapshotUtils.mockInstancesMetadata;
 import static org.apache.cassandra.sidecar.utils.TestMetricUtils.registry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -213,9 +213,9 @@ class BaseUploadsHandlerTest
 
         @Provides
         @Singleton
-        public InstancesMetadata instancesConfig(Vertx vertx)
+        public InstancesMetadata instancesMetadata(Vertx vertx)
         {
-            return mockInstancesConfig(vertx, canonicalTemporaryPath, delegate, null);
+            return mockInstancesMetadata(vertx, canonicalTemporaryPath, delegate, null);
         }
 
         @Singleton

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/BaseUploadsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/sstableuploads/BaseUploadsHandlerTest.java
@@ -52,7 +52,7 @@ import org.apache.cassandra.sidecar.TestCassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.adapters.base.CassandraTableOperations;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.config.SSTableUploadConfiguration;
 import org.apache.cassandra.sidecar.config.ServiceConfiguration;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
@@ -213,7 +213,7 @@ class BaseUploadsHandlerTest
 
         @Provides
         @Singleton
-        public InstancesConfig instancesConfig(Vertx vertx)
+        public InstancesMetadata instancesConfig(Vertx vertx)
         {
             return mockInstancesConfig(vertx, canonicalTemporaryPath, delegate, null);
         }

--- a/server/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilderTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotPathBuilderTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.ServiceConfiguration;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
@@ -32,9 +32,9 @@ class SnapshotPathBuilderTest extends AbstractSnapshotPathBuilderTest
 {
     @Override
     public SnapshotPathBuilder initialize(Vertx vertx, ServiceConfiguration serviceConfiguration,
-                                          InstancesConfig instancesConfig,
+                                          InstancesMetadata instancesMetadata,
                                           CassandraInputValidator validator, ExecutorPools executorPools)
     {
-        return new SnapshotPathBuilder(vertx, instancesConfig, validator, executorPools);
+        return new SnapshotPathBuilder(vertx, instancesMetadata, validator, executorPools);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
@@ -101,16 +101,16 @@ public class SnapshotUtils
                    .setLastModified(System.currentTimeMillis() + 2_000_000)).isTrue();
     }
 
-    public static InstancesMetadata mockInstancesConfig(Vertx vertx, String rootPath)
+    public static InstancesMetadata mockInstancesMetadata(Vertx vertx, String rootPath)
     {
         CQLSessionProvider mockSession1 = mock(CQLSessionProviderImpl.class);
-        return mockInstancesConfig(vertx, rootPath, null, mockSession1);
+        return mockInstancesMetadata(vertx, rootPath, null, mockSession1);
     }
 
-    public static InstancesMetadata mockInstancesConfig(Vertx vertx,
-                                                        String rootPath,
-                                                        CassandraAdapterDelegate delegate,
-                                                        CQLSessionProvider cqlSessionProvider1)
+    public static InstancesMetadata mockInstancesMetadata(Vertx vertx,
+                                                          String rootPath,
+                                                          CassandraAdapterDelegate delegate,
+                                                          CQLSessionProvider cqlSessionProvider1)
     {
         CassandraVersionProvider.Builder versionProviderBuilder = new CassandraVersionProvider.Builder();
         versionProviderBuilder.add(new MockCassandraFactory());

--- a/server/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/snapshots/SnapshotUtils.java
@@ -31,8 +31,8 @@ import java.util.List;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.sidecar.cluster.CQLSessionProviderImpl;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
-import org.apache.cassandra.sidecar.cluster.InstancesConfigImpl;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadataImpl;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadataImpl;
 import org.apache.cassandra.sidecar.common.MockCassandraFactory;
@@ -101,16 +101,16 @@ public class SnapshotUtils
                    .setLastModified(System.currentTimeMillis() + 2_000_000)).isTrue();
     }
 
-    public static InstancesConfig mockInstancesConfig(Vertx vertx, String rootPath)
+    public static InstancesMetadata mockInstancesConfig(Vertx vertx, String rootPath)
     {
         CQLSessionProvider mockSession1 = mock(CQLSessionProviderImpl.class);
         return mockInstancesConfig(vertx, rootPath, null, mockSession1);
     }
 
-    public static InstancesConfig mockInstancesConfig(Vertx vertx,
-                                                      String rootPath,
-                                                      CassandraAdapterDelegate delegate,
-                                                      CQLSessionProvider cqlSessionProvider1)
+    public static InstancesMetadata mockInstancesConfig(Vertx vertx,
+                                                        String rootPath,
+                                                        CassandraAdapterDelegate delegate,
+                                                        CQLSessionProvider cqlSessionProvider1)
     {
         CassandraVersionProvider.Builder versionProviderBuilder = new CassandraVersionProvider.Builder();
         versionProviderBuilder.add(new MockCassandraFactory());
@@ -144,7 +144,7 @@ public class SnapshotUtils
                                                               .metricRegistry(METRIC_REGISTRY_PROVIDER.getOrCreate(2))
                                                               .build();
         List<InstanceMetadata> instanceMetas = Arrays.asList(localhost, localhost2);
-        return new InstancesConfigImpl(instanceMetas, DnsResolver.DEFAULT);
+        return new InstancesMetadataImpl(instanceMetas, DnsResolver.DEFAULT);
     }
 
     public static List<String[]> mockSnapshotDirectories()

--- a/server/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
@@ -34,7 +34,7 @@ import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.HealthCheckConfiguration;
@@ -62,7 +62,7 @@ class HealthCheckPeriodicTaskTest
     SidecarConfiguration mockConfiguration;
     HealthCheckConfiguration mockHealthCheckConfiguration;
     HealthCheckPeriodicTask healthCheck;
-    InstancesConfig mockInstancesConfig;
+    InstancesMetadata mockInstancesMetadata;
     SidecarMetrics metrics;
 
     @BeforeEach
@@ -74,7 +74,7 @@ class HealthCheckPeriodicTaskTest
         when(mockHealthCheckConfiguration.initialDelayMillis()).thenReturn(10);
         when(mockHealthCheckConfiguration.checkIntervalMillis()).thenReturn(1000);
 
-        mockInstancesConfig = mock(InstancesConfig.class);
+        mockInstancesMetadata = mock(InstancesMetadata.class);
 
         Vertx vertx = Vertx.vertx();
         MetricRegistryFactory mockRegistryFactory = mock(MetricRegistryFactory.class);
@@ -82,7 +82,7 @@ class HealthCheckPeriodicTaskTest
         InstanceMetadataFetcher mockInstanceMetadataFetcher = mock(InstanceMetadataFetcher.class);
         metrics = new SidecarMetricsImpl(mockRegistryFactory, mockInstanceMetadataFetcher);
         ExecutorPools executorPools = new ExecutorPools(vertx, new ServiceConfigurationImpl());
-        healthCheck = new HealthCheckPeriodicTask(vertx, mockConfiguration, mockInstancesConfig,
+        healthCheck = new HealthCheckPeriodicTask(vertx, mockConfiguration, mockInstancesMetadata,
                                                   executorPools, metrics);
     }
 
@@ -106,7 +106,7 @@ class HealthCheckPeriodicTaskTest
         int expectedUpInstances = 0;
         int expectedDownInstances = 0;
         List<InstanceMetadata> mockInstanceMetadata = Collections.emptyList();
-        when(mockInstancesConfig.instances()).thenReturn(mockInstanceMetadata);
+        when(mockInstancesMetadata.instances()).thenReturn(mockInstanceMetadata);
         Promise<Void> promise = Promise.promise();
         healthCheck.execute(promise);
         promise.future().onComplete(context.succeeding(v -> {
@@ -125,7 +125,7 @@ class HealthCheckPeriodicTaskTest
         Checkpoint healthCheckCheckPoint = context.checkpoint(numberOfInstances);
         List<InstanceMetadata> mockInstanceMetadata =
         buildMockInstanceMetadata(healthCheckCheckPoint, numberOfInstances);
-        when(mockInstancesConfig.instances()).thenReturn(mockInstanceMetadata);
+        when(mockInstancesMetadata.instances()).thenReturn(mockInstanceMetadata);
         Promise<Void> promise = Promise.promise();
         healthCheck.execute(promise);
         promise.future().onComplete(context.succeeding(v -> {
@@ -147,7 +147,7 @@ class HealthCheckPeriodicTaskTest
         InstanceMetadata mockInstance = mock(InstanceMetadata.class);
         when(mockInstance.delegate()).thenThrow(new RuntimeException());
         mockInstanceMetadata.set(3, mockInstance);
-        when(mockInstancesConfig.instances()).thenReturn(mockInstanceMetadata);
+        when(mockInstancesMetadata.instances()).thenReturn(mockInstanceMetadata);
         Promise<Void> promise = Promise.promise();
         healthCheck.execute(promise);
         promise.future().onComplete(context.failing(v -> {
@@ -171,7 +171,7 @@ class HealthCheckPeriodicTaskTest
         when(mockInstance.delegate()).thenReturn(mockDelegate);
         doThrow(new RuntimeException()).when(mockDelegate).healthCheck();
         mockInstanceMetadata.set(3, mockInstance);
-        when(mockInstancesConfig.instances()).thenReturn(mockInstanceMetadata);
+        when(mockInstancesMetadata.instances()).thenReturn(mockInstanceMetadata);
         Promise<Void> promise = Promise.promise();
         healthCheck.execute(promise);
         promise.future().onComplete(context.failing(v -> {

--- a/server/src/testFixtures/java/org/apache/cassandra/sidecar/snapshots/AbstractSnapshotPathBuilderTest.java
+++ b/server/src/testFixtures/java/org/apache/cassandra/sidecar/snapshots/AbstractSnapshotPathBuilderTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
-import org.apache.cassandra.sidecar.cluster.InstancesConfig;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.ServiceConfiguration;
@@ -71,20 +71,20 @@ public abstract class AbstractSnapshotPathBuilderTest
     {
         CassandraInputValidator validator = new CassandraInputValidator();
 
-        InstancesConfig mockInstancesConfig = mock(InstancesConfig.class);
+        InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
         InstanceMetadata mockInstanceMeta = mock(InstanceMetadata.class);
         InstanceMetadata mockInvalidDataDirInstanceMeta = mock(InstanceMetadata.class);
         InstanceMetadata mockEmptyDataDirInstanceMeta = mock(InstanceMetadata.class);
 
-        when(mockInstancesConfig.instanceFromHost("localhost")).thenReturn(mockInstanceMeta);
+        when(mockInstancesMetadata.instanceFromHost("localhost")).thenReturn(mockInstanceMeta);
         when(mockInstanceMeta.dataDirs()).thenReturn(Arrays.asList(dataDir0.getAbsolutePath(),
                                                                    dataDir1.getAbsolutePath()));
 
-        when(mockInstancesConfig.instanceFromHost("invalidDataDirInstance")).thenReturn(mockInvalidDataDirInstanceMeta);
+        when(mockInstancesMetadata.instanceFromHost("invalidDataDirInstance")).thenReturn(mockInvalidDataDirInstanceMeta);
         String invalidDirPath = dataDir0.getParentFile().getAbsolutePath() + "/invalid-data-dir";
         when(mockInvalidDataDirInstanceMeta.dataDirs()).thenReturn(Collections.singletonList(invalidDirPath));
 
-        when(mockInstancesConfig.instanceFromHost("emptyDataDirInstance")).thenReturn(mockEmptyDataDirInstanceMeta);
+        when(mockInstancesMetadata.instanceFromHost("emptyDataDirInstance")).thenReturn(mockEmptyDataDirInstanceMeta);
         when(mockEmptyDataDirInstanceMeta.dataDirs()).thenReturn(Collections.emptyList());
 
         // Create some files and directories
@@ -165,7 +165,7 @@ public abstract class AbstractSnapshotPathBuilderTest
         ServiceConfiguration serviceConfiguration = new ServiceConfigurationImpl();
         executorPools = new ExecutorPools(vertx, serviceConfiguration);
 
-        instance = initialize(vertx, serviceConfiguration, mockInstancesConfig, validator, executorPools);
+        instance = initialize(vertx, serviceConfiguration, mockInstancesMetadata, validator, executorPools);
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -178,7 +178,7 @@ public abstract class AbstractSnapshotPathBuilderTest
 
     protected abstract SnapshotPathBuilder initialize(Vertx vertx,
                                                       ServiceConfiguration serviceConfiguration,
-                                                      InstancesConfig instancesConfig,
+                                                      InstancesMetadata instancesMetadata,
                                                       CassandraInputValidator validator,
                                                       ExecutorPools executorPools);
 


### PR DESCRIPTION
Suggesting to refactor InstancesConfig to InstancesMetadata as all the methods in it are returning InstanceMetadata and not InstanceConfiguration.

For CASSANDRASC-175