### PR TITLE
CASSSIDECAR-183: Upgrade base image used when building Docker image with jib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ plugins {
     // since we're using a specific version here, we delay applying the plugin till the all projects
     id "com.github.spotbugs" version "6.0.20" apply false
 
+    // Help resolve dependency conflicts between jib and ospackage
+    // See: https://github.com/GoogleContainerTools/jib/issues/4235#issuecomment-2088829367
+    id('com.google.cloud.tools.jib') version '3.4.4' apply false
+
     // https://github.com/nebula-plugins/gradle-ospackage-plugin/wiki
     id "com.netflix.nebula.ospackage" version "11.10.0"
     id 'com.netflix.nebula.ospackage-application' version "11.10.0"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,7 +29,7 @@ plugins {
     // and is published
     id('maven-publish')
     // and produces a docker image
-    id('com.google.cloud.tools.jib') version '2.2.0'
+    id('com.google.cloud.tools.jib') version '3.4.4'
 }
 
 sourceCompatibility = 1.8
@@ -314,6 +314,15 @@ tasks.register("containerTest", Test) {
     classpath = sourceSets.containerTest.runtimeClasspath
     shouldRunAfter test
     finalizedBy jacocoTestReport // report is always generated after tests run
+}
+
+jib {
+    from {
+        image = 'gcr.io/distroless/java11-debian11@sha256:56ffee16297ae1d3484bd47575cacd8102e5ba2be425a7772b3f8ad0d48def3b'
+    }
+    to {
+        image = "cassandra-sidecar:${project.version}"
+    }
 }
 
 compileIntegrationTestJava.onlyIf { "true" != System.getenv("skipIntegrationTest") }


### PR DESCRIPTION
This PR updates the jib Gradle task to set the base image to the distroless Java 11 image and pin it on a sha so that we can guarantee repeatable builds. 

Additionally, this PR sets a meaningful name for the resulting image. The existing behavior produced an image tagged `server`, after this PR we tag the image with the name `cassandra-sidecar`. 