### PR TITLE
CASSSIDECAR-195: Fix missing field for INDEX_STATUS in GossipInfo

### DIFF
--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/GossipInfoResponse.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/GossipInfoResponse.java
@@ -283,7 +283,8 @@ public class GossipInfoResponse extends HashMap<String, GossipInfoResponse.Gossi
          **/
         SSTABLE_VERSIONS,
         DISK_USAGE,
-        INDEX_STATUS;
+        INDEX_STATUS, // Introduced in Cassandra 5.0 for SAI 
+        ;
 
         static String read(GossipInfo gossipInfo, GossipField field)
         {

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/GossipInfoResponse.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/GossipInfoResponse.java
@@ -188,7 +188,7 @@ public class GossipInfoResponse extends HashMap<String, GossipInfoResponse.Gossi
 
         @Nullable
         public String hostId()
-        {INDEX_STATUS;
+        {
             return read(this, HOST_ID);
         }
 

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/GossipInfoResponse.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/GossipInfoResponse.java
@@ -30,6 +30,7 @@ import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.Go
 import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.GENERATION;
 import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.HEARTBEAT;
 import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.HOST_ID;
+import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.INDEX_STATUS;
 import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.INTERNAL_ADDRESS_AND_PORT;
 import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.INTERNAL_IP;
 import static org.apache.cassandra.sidecar.common.response.GossipInfoResponse.GossipField.LOAD;
@@ -187,8 +188,14 @@ public class GossipInfoResponse extends HashMap<String, GossipInfoResponse.Gossi
 
         @Nullable
         public String hostId()
-        {
+        {INDEX_STATUS;
             return read(this, HOST_ID);
+        }
+
+        @Nullable
+        public String indexStatus()
+        {
+            return read(this, INDEX_STATUS);
         }
 
         @Nullable
@@ -275,7 +282,8 @@ public class GossipInfoResponse extends HashMap<String, GossipInfoResponse.Gossi
          * as a comma-separated list.
          **/
         SSTABLE_VERSIONS,
-        DISK_USAGE;
+        DISK_USAGE,
+        INDEX_STATUS;
 
         static String read(GossipInfo gossipInfo, GossipField field)
         {

--- a/server-common/src/test/java/org/apache/cassandra/sidecar/common/server/utils/GossipInfoParserTest.java
+++ b/server-common/src/test/java/org/apache/cassandra/sidecar/common/server/utils/GossipInfoParserTest.java
@@ -35,7 +35,7 @@ class GossipInfoParserTest
         assertThat(result).containsKey("/127.0.0.1")
                           .containsKey("localhost2/127.0.0.2")
                           .containsKey("/127.0.0.3");
-        assertThat(result.get("/127.0.0.1")).hasSize(6);
+        assertThat(result.get("/127.0.0.1")).hasSize(7);
         assertThat(result.get("localhost2/127.0.0.2")).hasSize(6);
         assertThat(result.get("/127.0.0.3")).hasSize(6);
         GossipInfoResponse.GossipInfo gossipInfo = result.get("/127.0.0.1");
@@ -45,6 +45,7 @@ class GossipInfoParserTest
         assertThat(gossipInfo.statusWithPort()).isEqualTo("NORMAL,-9223372036854775808");
         assertThat(gossipInfo.sstableVersions()).isEqualTo(Collections.singletonList("big-nb"));
         assertThat(gossipInfo.tokens()).isEqualTo("<hidden>");
+        assertThat(gossipInfo.indexStatus()).isEqualTo("{\"ks.tbl_idx\":\"BUILD_SUCCEEDED\"}");
     }
 
     @Test
@@ -82,5 +83,6 @@ class GossipInfoParserTest
         "  LOAD:211:88971.0\n" +
         "  STATUS_WITH_PORT:19:NORMAL,-9223372036854775808\n" +
         "  SSTABLE_VERSIONS:6:big-nb\n" +
-        "  TOKENS:18:<hidden>";
+        "  TOKENS:18:<hidden>\n" +
+        "  INDEX_STATUS:2198:{\"ks.tbl_idx\":\"BUILD_SUCCEEDED\"}";
 }


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/CASSSIDECAR-195

`INDEX_STATUS` was added as a field to Gossip information in 5.0. This patch adds the field to the GossipInfoResponse so Sidecar doesn't error out when the new field is present. INDEX_STATUS was added here: https://github.com/apache/cassandra/commit/cde91e56f09d9ebf315c79c9a81b89f70f4eb724 (https://issues.apache.org/jira/browse/CASSANDRA-18058)