### PR TITLE
CASSSIDECAR-201: Make sidecar operations resilient to down Cassandra nodes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Make sidecar operations resilient to down Cassandra nodes (CASSSIDECAR-201)
  * Fix Cassandra instance not found error (CASSSIDECAR-192)
  * Implemented Schema Reporter for Integration with DataHub (CASSSIDECAR-191)
  * Add sidecar endpoint to retrieve stream stats (CASSSIDECAR-180)

--- a/scripts/build-shaded-dtest-jar-local.sh
+++ b/scripts/build-shaded-dtest-jar-local.sh
@@ -32,6 +32,9 @@ echo "${GIT_HASH}"
 echo "${DTEST_ARTIFACT_ID}"
 echo "${JAVA_HOME}"
 
+# The container that runs the script has jdk11 installed only.
+# Setting the env var to build with jdk11.
+export CASSANDRA_USE_JDK11=true
 ant realclean
 ant dtest-jar -Dno-checkstyle=true
 

--- a/server-common/src/main/java/org/apache/cassandra/sidecar/db/DatabaseAccessor.java
+++ b/server-common/src/main/java/org/apache/cassandra/sidecar/db/DatabaseAccessor.java
@@ -53,6 +53,14 @@ public abstract class DatabaseAccessor<T extends TableSchema>
         return cqlSessionProvider.get();
     }
 
+    /**
+     * @return whether DatabaseAccessor is available to access database
+     */
+    public boolean isAvailable()
+    {
+        return tableSchema.isInitialized();
+    }
+
     protected ResultSet execute(Statement statement)
     {
         return session().execute(statement);

--- a/server-common/src/main/java/org/apache/cassandra/sidecar/db/schema/AbstractSchema.java
+++ b/server-common/src/main/java/org/apache/cassandra/sidecar/db/schema/AbstractSchema.java
@@ -37,11 +37,19 @@ import org.jetbrains.annotations.NotNull;
 public abstract class AbstractSchema
 {
     protected Logger logger = LoggerFactory.getLogger(this.getClass());
-    private boolean initialized = false;
+    private volatile boolean initialized = false;
 
     public synchronized boolean initialize(@NotNull Session session, @NotNull Predicate<AbstractSchema> shouldCreateSchema)
     {
         initialized = initialized || initializeInternal(session, shouldCreateSchema);
+        return initialized;
+    }
+
+    /**
+     * @return whether schema is initialized
+     */
+    public boolean isInitialized()
+    {
         return initialized;
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/AuthorizationParameterValidateHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/AuthorizationParameterValidateHandler.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.snapshots.SnapshotPathBuilder;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Simple handler that extracts authorization parameters keyspace/table parameters from the path, validates them,
@@ -61,7 +62,7 @@ public class AuthorizationParameterValidateHandler extends AbstractHandler<Quali
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   QualifiedTableName qualifiedTableName)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTask.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTask.java
@@ -123,7 +123,10 @@ public class ClusterLeaseClaimTask implements PeriodicTask
             clusterLease.setOwnership(ClusterLease.Ownership.LOST);
             return ScheduleDecision.SKIP;
         }
-        return ScheduleDecision.EXECUTE;
+
+        // When accessor is available, it permits execution (where accessor is used)
+        // Otherwise, it reschedules to skip the run and retry sooner, assuming initial delay is less than delay
+        return accessor.isAvailable() ? ScheduleDecision.EXECUTE : ScheduleDecision.RESCHEDULE;
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTask.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTask.java
@@ -107,7 +107,15 @@ public class ClusterLeaseClaimTask implements PeriodicTask
         {
             // Do expensive call when the feature is enabled to determine if this Sidecar is member
             // of the electorate
-            isMember = electorateMembership.isMember();
+            try
+            {
+                isMember = electorateMembership.isMember();
+            }
+            catch (Throwable t)
+            {
+                LOGGER.debug("Membership determination fails due to unexpected exception", t);
+                // isMember remains false
+            }
             LOGGER.debug("Sidecar instance part of electorate isMember={}", isMember);
         }
         if (!isEnabled || !isMember)

--- a/server/src/main/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembership.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembership.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
@@ -86,7 +87,8 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
             return false;
         }
 
-        TokenRangeReplicasResponse tokenRangeReplicas = instanceMetadataFetcher.callOnFirstAvailableInstance(delegate -> {
+        TokenRangeReplicasResponse tokenRangeReplicas = instanceMetadataFetcher.callOnFirstAvailableInstance(instance -> {
+            CassandraAdapterDelegate delegate = instance.delegate();
             StorageOperations operations = delegate.storageOperations();
             NodeSettings nodeSettings = delegate.nodeSettings();
             return operations.tokenRangeReplicas(new Name(userKeyspace), nodeSettings.partitioner());

--- a/server/src/main/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembership.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembership.java
@@ -24,15 +24,12 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Session;
-import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
-import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
@@ -42,6 +39,7 @@ import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.common.server.utils.StringUtils;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 
 /**
  * An implementation of {@link ElectorateMembership} where the current Sidecar will
@@ -55,15 +53,15 @@ import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements ElectorateMembership
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MostReplicatedKeyspaceTokenZeroElectorateMembership.class);
-    private final InstancesMetadata instancesMetadata;
+    private final InstanceMetadataFetcher instanceMetadataFetcher;
     private final CQLSessionProvider cqlSessionProvider;
     private final SidecarConfiguration configuration;
 
-    public MostReplicatedKeyspaceTokenZeroElectorateMembership(InstancesMetadata instancesMetadata,
+    public MostReplicatedKeyspaceTokenZeroElectorateMembership(InstanceMetadataFetcher instanceMetadataFetcher,
                                                                CQLSessionProvider cqlSessionProvider,
                                                                SidecarConfiguration sidecarConfiguration)
     {
-        this.instancesMetadata = instancesMetadata;
+        this.instanceMetadataFetcher = instanceMetadataFetcher;
         this.cqlSessionProvider = cqlSessionProvider;
         this.configuration = sidecarConfiguration;
     }
@@ -81,15 +79,6 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
             return false;
         }
 
-        StorageOperations operations = firstAvailableOperationFromDelegate(CassandraAdapterDelegate::storageOperations);
-        NodeSettings nodeSettings = firstAvailableOperationFromDelegate(CassandraAdapterDelegate::nodeSettings);
-
-        if (operations == null || nodeSettings == null)
-        {
-            // not expected, but for completeness
-            return false;
-        }
-
         String userKeyspace = highestReplicationFactorKeyspace();
         if (userKeyspace == null)
         {
@@ -97,14 +86,19 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
             return false;
         }
 
-        TokenRangeReplicasResponse tokenRangeReplicas = operations.tokenRangeReplicas(new Name(userKeyspace), nodeSettings.partitioner());
+        TokenRangeReplicasResponse tokenRangeReplicas = instanceMetadataFetcher.callOnFirstAvailableInstance(delegate -> {
+            StorageOperations operations = delegate.storageOperations();
+            NodeSettings nodeSettings = delegate.nodeSettings();
+            return operations.tokenRangeReplicas(new Name(userKeyspace), nodeSettings.partitioner());
+        });
+
         return anyInstanceOwnsTokenZero(tokenRangeReplicas, localInstancesHostsAndPorts);
     }
 
     Set<String> collectLocalInstancesHostsAndPorts()
     {
         Set<String> result = new HashSet<>();
-        for (InstanceMetadata instance : instancesMetadata.instances())
+        for (InstanceMetadata instance : instanceMetadataFetcher.allLocalInstances())
         {
             try
             {
@@ -120,24 +114,6 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
         return result;
     }
 
-    <O> O firstAvailableOperationFromDelegate(Function<CassandraAdapterDelegate, O> mapper)
-    {
-        for (InstanceMetadata instance : instancesMetadata.instances())
-        {
-            try
-            {
-                CassandraAdapterDelegate delegate = instance.delegate();
-                return mapper.apply(delegate);
-            }
-            catch (CassandraUnavailableException exception)
-            {
-                // no-op; try the next instance
-                LOGGER.debug("CassandraAdapterDelegate is not available for instance. instance={}", instance, exception);
-            }
-        }
-        return null;
-    }
-
     /**
      * Performs pre-checks ensuring local instances are configured; an active session to the database is present;
      * and returns the keyspace with the highest replication factor. If multiple keyspaces have the highest
@@ -148,7 +124,7 @@ public class MostReplicatedKeyspaceTokenZeroElectorateMembership implements Elec
      */
     String highestReplicationFactorKeyspace()
     {
-        if (instancesMetadata.instances().isEmpty())
+        if (instanceMetadataFetcher.allLocalInstances().isEmpty())
         {
             LOGGER.warn("There are no local Cassandra instances managed by this Sidecar");
             return null;

--- a/server/src/main/java/org/apache/cassandra/sidecar/metrics/SidecarMetrics.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/metrics/SidecarMetrics.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.metrics;
 
 import org.apache.cassandra.sidecar.metrics.instance.InstanceMetrics;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Tracks both server metrics and Cassandra instance specific metrics that Sidecar maintains.
@@ -46,5 +47,5 @@ public interface SidecarMetrics
      * @param host Cassandra instance host name
      * @return {@link InstanceMetrics} maintained for provided Cassandra instance
      */
-    InstanceMetrics instance(String host);
+    InstanceMetrics instance(@NotNull String host);
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/metrics/SidecarMetricsImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/metrics/SidecarMetricsImpl.java
@@ -23,6 +23,7 @@ import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.metrics.instance.InstanceMetrics;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Tracks both server metrics and Cassandra instance specific metrics that Sidecar maintains.
@@ -55,7 +56,7 @@ public class SidecarMetricsImpl implements SidecarMetrics
     }
 
     @Override
-    public InstanceMetrics instance(String host) throws NoSuchCassandraInstanceException, CassandraUnavailableException
+    public InstanceMetrics instance(@NotNull String host) throws NoSuchCassandraInstanceException, CassandraUnavailableException
     {
         return instanceMetadataFetcher.instance(host).metrics();
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RingTopologyRefresher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RingTopologyRefresher.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -32,7 +33,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
@@ -41,7 +41,6 @@ import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
 import org.apache.cassandra.sidecar.config.RestoreJobConfiguration;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.db.RestoreJob;
-import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.tasks.PeriodicTask;
 import org.apache.cassandra.sidecar.tasks.ScheduleDecision;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
@@ -84,7 +83,7 @@ public class RingTopologyRefresher implements PeriodicTask
     @Override
     public void execute(Promise<Void> promise)
     {
-        executeBlocking();
+        prepareAndFetch(this::loadAll);
         promise.tryComplete();
     }
 
@@ -122,24 +121,20 @@ public class RingTopologyRefresher implements PeriodicTask
         return replicaByTokenRangePerKeyspace.futureOf(restoreJob);
     }
 
-    private void executeBlocking()
+    // Declaring the Void return type to be compliant with the BiFunction parameter
+    private Void loadAll(StorageOperations storageOperations, NodeSettings nodeSettings)
     {
-        CassandraAdapterDelegate delegate;
-        StorageOperations storageOperations;
-        NodeSettings nodeSettings;
-        try
-        {
-            delegate = metadataFetcher.anyInstance().delegate();
-            storageOperations = delegate.storageOperations();
-            nodeSettings = delegate.nodeSettings();
-        }
-        catch (CassandraUnavailableException ignored)
-        {
-            LOGGER.debug("Not yet connect to Cassandra");
-            return;
-        }
-        String partitioner = nodeSettings.partitioner();
-        replicaByTokenRangePerKeyspace.load(keyspace -> storageOperations.tokenRangeReplicas(new Name(keyspace), partitioner));
+        replicaByTokenRangePerKeyspace.load(keyspace -> storageOperations.tokenRangeReplicas(new Name(keyspace), nodeSettings.partitioner()));
+        return null;
+    }
+
+    private <T> T prepareAndFetch(BiFunction<StorageOperations, NodeSettings, T> fetcher)
+    {
+        return metadataFetcher.callOnFirstAvailableInstance(delegate -> {
+            StorageOperations storageOperations = delegate.storageOperations();
+            NodeSettings nodeSettings = delegate.nodeSettings();
+            return fetcher.apply(storageOperations, nodeSettings);
+        });
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/RingTopologyRefresher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/RingTopologyRefresher.java
@@ -33,6 +33,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
@@ -130,7 +131,8 @@ public class RingTopologyRefresher implements PeriodicTask
 
     private <T> T prepareAndFetch(BiFunction<StorageOperations, NodeSettings, T> fetcher)
     {
-        return metadataFetcher.callOnFirstAvailableInstance(delegate -> {
+        return metadataFetcher.callOnFirstAvailableInstance(instance -> {
+            CassandraAdapterDelegate delegate = instance.delegate();
             StorageOperations storageOperations = delegate.storageOperations();
             NodeSettings nodeSettings = delegate.nodeSettings();
             return fetcher.apply(storageOperations, nodeSettings);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
@@ -32,6 +32,7 @@ import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailable
 import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.common.server.data.QualifiedTableName;
 import org.apache.cassandra.sidecar.common.server.exceptions.JmxAuthenticationException;
+import org.apache.cassandra.sidecar.common.utils.Preconditions;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
@@ -141,7 +142,7 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
             try
             {
                 int instanceId = Integer.parseInt(instanceIdParam);
-                return  metadataFetcher.instance(instanceId).host();
+                return metadataFetcher.instance(instanceId).host();
             }
             catch (NumberFormatException ex)
             {
@@ -159,9 +160,9 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
             {
                 return extractHostAddressWithoutPort(context.request());
             }
-            catch (NoSuchCassandraInstanceException ex)
+            catch (IllegalArgumentException ex)
             {
-                throw new HttpException(HttpResponseStatus.NOT_FOUND.code(), ex.getMessage());
+                throw new HttpException(HttpResponseStatus.BAD_REQUEST.code(), ex.getMessage());
             }
         }
     }
@@ -294,16 +295,13 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
      *
      * @param request http server request
      * @return host address without port information
-     * @throws NoSuchCassandraInstanceException thrown when input address is null
+     * @throws IllegalArgumentException thrown when host header is missing in the request
      */
     @NotNull
-    public static String extractHostAddressWithoutPort(HttpServerRequest request) throws NoSuchCassandraInstanceException
+    public static String extractHostAddressWithoutPort(HttpServerRequest request) throws IllegalArgumentException
     {
         String host = request.host();
-        if (host == null)
-        {
-            throw new NoSuchCassandraInstanceException("No such Cassandra instance when Host header is absent");
-        }
+        Preconditions.checkArgument(host != null, "Missing 'host' header in the request");
 
         if (host.contains(":"))
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
@@ -18,8 +18,6 @@
 
 package org.apache.cassandra.sidecar.routes;
 
-import java.util.NoSuchElementException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +29,6 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
 import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
-import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.common.server.data.QualifiedTableName;
 import org.apache.cassandra.sidecar.common.server.exceptions.JmxAuthenticationException;
@@ -39,6 +36,8 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -117,7 +116,7 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
      */
     protected abstract void handleInternal(RoutingContext context,
                                            HttpServerRequest httpRequest,
-                                           String host,
+                                           @NotNull String host,
                                            SocketAddress remoteAddress,
                                            T request);
 
@@ -129,6 +128,7 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
      * @return the host for the routing context
      * @throws HttpException when the {@code /instance/} path parameter is {@code null}
      */
+    @NotNull
     public String host(RoutingContext context)
     {
         if (context.request().params().contains(INSTANCE_ID))
@@ -140,27 +140,31 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
                                         "InstanceId query parameter must be provided");
             }
 
-            InstanceMetadata instance;
             try
             {
                 int instanceId = Integer.parseInt(instanceIdParam);
-                instance = metadataFetcher.instance(instanceId);
+                return  metadataFetcher.instance(instanceId).host();
             }
             catch (NumberFormatException ex)
             {
                 throw new HttpException(HttpResponseStatus.BAD_REQUEST.code(),
                                         "InstanceId query parameter must be a valid integer");
             }
-            catch (NoSuchElementException | IllegalStateException ex)
+            catch (NoSuchCassandraInstanceException | IllegalStateException ex)
             {
                 throw new HttpException(HttpResponseStatus.NOT_FOUND.code(), ex.getMessage());
             }
-
-            return instance.host();
         }
         else
         {
-            return extractHostAddressWithoutPort(context.request().host());
+            try
+            {
+                return extractHostAddressWithoutPort(context.request());
+            }
+            catch (NoSuchCassandraInstanceException ex)
+            {
+                throw new HttpException(HttpResponseStatus.NOT_FOUND.code(), ex.getMessage());
+            }
         }
     }
 
@@ -292,20 +296,29 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
      *
      * @param address ip address
      * @return host address without port information
+     * @throws NoSuchCassandraInstanceException thrown when input address is null
      */
-    public static String extractHostAddressWithoutPort(String address)
+    @NotNull
+    public static String extractHostAddressWithoutPort(HttpServerRequest request) throws NoSuchCassandraInstanceException
     {
-        if (address.contains(":"))
+        String host = request.host();
+        if (host == null)
+        {
+            throw new NoSuchCassandraInstanceException("No such Cassandra instance when Host header is absent");
+        }
+
+        if (host.contains(":"))
         {
             // just ipv6 host name present without port information
-            if (address.split(":").length > 2 && !address.startsWith("["))
+            if (host.split(":").length > 2 && !host.startsWith("["))
             {
-                return address;
+                return host;
             }
-            String host = address.substring(0, address.lastIndexOf(':'));
-            // remove brackets from ipv6 addresses
-            return host.startsWith("[") ? host.substring(1, host.length() - 1) : host;
+            String hostWithoutPort = host.substring(0, host.lastIndexOf(':'));
+            return hostWithoutPort.startsWith("[")
+                   ? hostWithoutPort.substring(1, hostWithoutPort.length() - 1) // remove brackets from ipv6 addresses
+                   : hostWithoutPort; // return ipv4 directly
         }
-        return address;
+        return host;
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/AbstractHandler.java
@@ -37,10 +37,8 @@ import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
-
 
 /**
  * An abstract {@link Handler Handler&lt;RoutingContext&gt;} that provides common functionality for handler
@@ -294,7 +292,7 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
      * Given a combined host address like 127.0.0.1:9042 or [2001:db8:0:0:0:ff00:42:8329]:9042, this method
      * removes port information and returns 127.0.0.1 or 2001:db8:0:0:0:ff00:42:8329.
      *
-     * @param address ip address
+     * @param request http server request
      * @return host address without port information
      * @throws NoSuchCassandraInstanceException thrown when input address is null
      */

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/CassandraHealthHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/CassandraHealthHandler.java
@@ -30,6 +30,7 @@ import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.JMX;
 import static org.apache.cassandra.sidecar.server.MainModule.NOT_OK_STATUS;
@@ -68,15 +69,15 @@ public class CassandraHealthHandler extends AbstractHandler<Void>
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   Void request)
     {
-        CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
+        CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
 
         boolean isServiceUp = context.request().path().contains(JMX)
-                              ? delegate != null && delegate.isJmxUp()
-                              : delegate != null && delegate.isNativeUp();
+                              ? delegate.isJmxUp()
+                              : delegate.isNativeUp();
         if (isServiceUp)
         {
             context.json(OK_STATUS);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/CassandraHealthHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/CassandraHealthHandler.java
@@ -73,7 +73,7 @@ public class CassandraHealthHandler extends AbstractHandler<Void>
                                   SocketAddress remoteAddress,
                                   Void request)
     {
-        CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
+        CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
 
         boolean isServiceUp = context.request().path().contains(JMX)
                               ? delegate.isJmxUp()

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/ConnectedClientStatsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/ConnectedClientStatsHandler.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.sidecar.acl.authorization.VariableAwareResource;
 import org.apache.cassandra.sidecar.common.server.MetricsOperations;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.RequestUtils.parseBooleanQueryParam;
 
@@ -72,11 +73,11 @@ public class ConnectedClientStatsHandler extends AbstractHandler<Boolean> implem
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Boolean summaryOnly)
     {
-        MetricsOperations operations = metadataFetcher.delegate(host).metricsOperations();
+        MetricsOperations operations = metadataFetcher.instance(host).delegate().metricsOperations();
         executorPools.service()
                      .executeBlocking(() -> operations.connectedClientStats(summaryOnly))
                      .onSuccess(context::json)

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/ConnectedClientStatsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/ConnectedClientStatsHandler.java
@@ -77,7 +77,7 @@ public class ConnectedClientStatsHandler extends AbstractHandler<Boolean> implem
                                SocketAddress remoteAddress,
                                Boolean summaryOnly)
     {
-        MetricsOperations operations = metadataFetcher.instance(host).delegate().metricsOperations();
+        MetricsOperations operations = metadataFetcher.delegate(host).metricsOperations();
         executorPools.service()
                      .executeBlocking(() -> operations.connectedClientStats(summaryOnly))
                      .onSuccess(context::json)

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/DiskSpaceProtectionHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/DiskSpaceProtectionHandler.java
@@ -30,6 +30,7 @@ import org.apache.cassandra.sidecar.config.ServiceConfiguration;
 import org.apache.cassandra.sidecar.exceptions.InsufficientStorageException;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.AsyncFileSystemUtils.ensureSufficientStorage;
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -63,7 +64,7 @@ public class DiskSpaceProtectionHandler extends AbstractHandler<Void>
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   Void request)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/FileStreamHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/FileStreamHandler.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.models.HttpResponse;
 import org.apache.cassandra.sidecar.utils.FileStreamer;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
@@ -61,7 +62,7 @@ public class FileStreamHandler extends AbstractHandler<String>
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                String localFile)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
@@ -57,7 +57,7 @@ public class GossipHealthHandler extends AbstractHandler<Void>
                                SocketAddress remoteAddress,
                                Void request)
     {
-        StorageOperations operations = metadataFetcher.instance(host).delegate().storageOperations();
+        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
         executorPools.service()
                      .executeBlocking(operations::isGossipRunning)
                      .onSuccess(isGossipRunning -> context.json(isGossipRunning ? OK_STATUS : NOT_OK_STATUS))

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipHealthHandler.java
@@ -25,6 +25,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.server.MainModule.NOT_OK_STATUS;
 import static org.apache.cassandra.sidecar.server.MainModule.OK_STATUS;
@@ -52,11 +53,11 @@ public class GossipHealthHandler extends AbstractHandler<Void>
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Void request)
     {
-        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
+        StorageOperations operations = metadataFetcher.instance(host).delegate().storageOperations();
         executorPools.service()
                      .executeBlocking(operations::isGossipRunning)
                      .onSuccess(isGossipRunning -> context.json(isGossipRunning ? OK_STATUS : NOT_OK_STATUS))

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipInfoHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipInfoHandler.java
@@ -21,8 +21,6 @@ package org.apache.cassandra.sidecar.routes;
 import java.util.Collections;
 import java.util.Set;
 
-import com.google.common.base.Preconditions;
-
 import com.google.inject.Inject;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipInfoHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipInfoHandler.java
@@ -35,6 +35,7 @@ import org.apache.cassandra.sidecar.common.server.ClusterMembershipOperations;
 import org.apache.cassandra.sidecar.common.server.utils.GossipInfoParser;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 
 /**
@@ -67,16 +68,14 @@ public class GossipInfoHandler extends AbstractHandler<Void> implements AccessPr
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Void request)
     {
         executorPools.service()
                      .executeBlocking(() -> {
-                         CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
+                         CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
                          ClusterMembershipOperations operations = delegate.clusterMembershipOperations();
-                         Preconditions.checkState(operations != null,
-                                                  "Unable to connect to Cassandra");
                          String rawGossipInfo = operations.gossipInfo();
                          return GossipInfoParser.parse(rawGossipInfo);
                      })

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipInfoHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/GossipInfoHandler.java
@@ -72,7 +72,7 @@ public class GossipInfoHandler extends AbstractHandler<Void> implements AccessPr
     {
         executorPools.service()
                      .executeBlocking(() -> {
-                         CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
+                         CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
                          ClusterMembershipOperations operations = delegate.clusterMembershipOperations();
                          String rawGossipInfo = operations.gossipInfo();
                          return GossipInfoParser.parse(rawGossipInfo);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceRingHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceRingHandler.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -71,11 +72,11 @@ public class KeyspaceRingHandler extends AbstractHandler<Name> implements Access
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Name keyspace)
     {
-        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
+        StorageOperations operations = metadataFetcher.instance(host).delegate().storageOperations();
         executorPools.service()
                      .executeBlocking(() -> operations.ring(keyspace))
                      .onSuccess(context::json)

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceRingHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceRingHandler.java
@@ -76,7 +76,7 @@ public class KeyspaceRingHandler extends AbstractHandler<Name> implements Access
                                SocketAddress remoteAddress,
                                Name keyspace)
     {
-        StorageOperations operations = metadataFetcher.instance(host).delegate().storageOperations();
+        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
         executorPools.service()
                      .executeBlocking(() -> operations.ring(keyspace))
                      .onSuccess(context::json)

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceSchemaHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceSchemaHandler.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.MetadataUtils;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -76,7 +77,7 @@ public class KeyspaceSchemaHandler extends AbstractHandler<Name> implements Acce
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Name keyspace)
     {
@@ -128,7 +129,7 @@ public class KeyspaceSchemaHandler extends AbstractHandler<Name> implements Acce
     {
         return executorPools.service().executeBlocking(() -> {
             // metadata can block so we need to run in a blocking thread
-            return metadataFetcher.delegate(host).metadata();
+            return metadataFetcher.instance(host).delegate().metadata();
         });
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceSchemaHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/KeyspaceSchemaHandler.java
@@ -129,7 +129,7 @@ public class KeyspaceSchemaHandler extends AbstractHandler<Name> implements Acce
     {
         return executorPools.service().executeBlocking(() -> {
             // metadata can block so we need to run in a blocking thread
-            return metadataFetcher.instance(host).delegate().metadata();
+            return metadataFetcher.delegate(host).metadata();
         });
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/ListOperationalJobsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/ListOperationalJobsHandler.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.job.OperationalJobManager;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
 
@@ -68,7 +69,7 @@ public class ListOperationalJobsHandler extends AbstractHandler<Void> implements
     }
 
     @Override
-    protected void handleInternal(RoutingContext context, HttpServerRequest httpRequest, String host, SocketAddress remoteAddress, Void request)
+    protected void handleInternal(RoutingContext context, HttpServerRequest httpRequest, @NotNull String host, SocketAddress remoteAddress, Void request)
     {
         ListOperationalJobsResponse listResponse = new ListOperationalJobsResponse();
         jobManager.allInflightJobs()

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/NodeDecommissionHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/NodeDecommissionHandler.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.sidecar.job.OperationalJobManager;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.OperationalJobUtils;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.RequestUtils.parseBooleanQueryParam;
 
@@ -84,11 +85,11 @@ public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Boolean isForce)
     {
-        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
+        StorageOperations operations = metadataFetcher.instance(host).delegate().storageOperations();
         NodeDecommissionJob job = new NodeDecommissionJob(UUIDs.timeBased(), operations, isForce);
         try
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/NodeDecommissionHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/NodeDecommissionHandler.java
@@ -89,7 +89,7 @@ public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements
                                SocketAddress remoteAddress,
                                Boolean isForce)
     {
-        StorageOperations operations = metadataFetcher.instance(host).delegate().storageOperations();
+        StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
         NodeDecommissionJob job = new NodeDecommissionJob(UUIDs.timeBased(), operations, isForce);
         try
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/OperationalJobHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/OperationalJobHandler.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.sidecar.job.OperationalJobManager;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.OperationalJobUtils;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.OPERATIONAL_JOB_ID_PATH_PARAM;
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -70,7 +71,7 @@ public class OperationalJobHandler extends AbstractHandler<UUID> implements Acce
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                UUID jobId)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamSSTableComponentHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamSSTableComponentHandler.java
@@ -99,7 +99,7 @@ public class StreamSSTableComponentHandler extends AbstractHandler<StreamSSTable
             int dataDirIndex = request.dataDirectoryIndex();
             if (request.tableId() != null)
             {
-                StorageOperations storageOperations = metadataFetcher.instance(host).delegate().storageOperations();
+                StorageOperations storageOperations = metadataFetcher.delegate(host).storageOperations();
                 List<String> dataDirList = storageOperations.dataFileLocations();
                 if (dataDirIndex < 0 || dataDirIndex >= dataDirList.size())
                 {
@@ -110,7 +110,7 @@ public class StreamSSTableComponentHandler extends AbstractHandler<StreamSSTable
             else
             {
                 logger.debug("Streaming SSTable component without a table Id. request={}, instance={}", request, host);
-                TableOperations tableOperations = metadataFetcher.instance(host).delegate().tableOperations();
+                TableOperations tableOperations = metadataFetcher.delegate(host).tableOperations();
                 // asking jmx to give us the path for keyspace/table - tableId
                 // as opposed to storageOperations.dataFileLocations, the table directory can change
                 // when someone drops a table and recreates it with the same name, the table id will change

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamSSTableComponentHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamSSTableComponentHandler.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.sidecar.routes.data.StreamSSTableComponentRequestPar
 import org.apache.cassandra.sidecar.snapshots.SnapshotPathBuilder;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -81,7 +82,7 @@ public class StreamSSTableComponentHandler extends AbstractHandler<StreamSSTable
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                StreamSSTableComponentRequestParam request)
     {
@@ -98,7 +99,7 @@ public class StreamSSTableComponentHandler extends AbstractHandler<StreamSSTable
             int dataDirIndex = request.dataDirectoryIndex();
             if (request.tableId() != null)
             {
-                StorageOperations storageOperations = metadataFetcher.delegate(host).storageOperations();
+                StorageOperations storageOperations = metadataFetcher.instance(host).delegate().storageOperations();
                 List<String> dataDirList = storageOperations.dataFileLocations();
                 if (dataDirIndex < 0 || dataDirIndex >= dataDirList.size())
                 {
@@ -109,7 +110,7 @@ public class StreamSSTableComponentHandler extends AbstractHandler<StreamSSTable
             else
             {
                 logger.debug("Streaming SSTable component without a table Id. request={}, instance={}", request, host);
-                TableOperations tableOperations = metadataFetcher.delegate(host).tableOperations();
+                TableOperations tableOperations = metadataFetcher.instance(host).delegate().tableOperations();
                 // asking jmx to give us the path for keyspace/table - tableId
                 // as opposed to storageOperations.dataFileLocations, the table directory can change
                 // when someone drops a table and recreates it with the same name, the table id will change

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamStatsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamStatsHandler.java
@@ -71,7 +71,7 @@ public class StreamStatsHandler extends AbstractHandler<Void> implements AccessP
                                Void request)
     {
 
-        CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
+        CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
 
         executorPools.service()
                      .executeBlocking(() -> {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamStatsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/StreamStatsHandler.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.sidecar.common.response.StreamStatsResponse;
 import org.apache.cassandra.sidecar.common.response.data.StreamsProgressStats;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Handler for retrieving node streams stats
@@ -65,12 +66,12 @@ public class StreamStatsHandler extends AbstractHandler<Void> implements AccessP
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Void request)
     {
 
-        CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
+        CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
 
         executorPools.service()
                      .executeBlocking(() -> {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/TokenRangeReplicaMapHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/TokenRangeReplicaMapHandler.java
@@ -82,7 +82,7 @@ public class TokenRangeReplicaMapHandler extends AbstractHandler<Name> implement
                                SocketAddress remoteAddress,
                                Name keyspace)
     {
-        CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
+        CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
         NodeSettings nodeSettings = delegate.nodeSettings();
         StorageOperations operations = delegate.storageOperations();
         executorPools.service()

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/TokenRangeReplicaMapHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/TokenRangeReplicaMapHandler.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.HttpExceptions;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -77,11 +78,11 @@ public class TokenRangeReplicaMapHandler extends AbstractHandler<Name> implement
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Name keyspace)
     {
-        CassandraAdapterDelegate delegate = metadataFetcher.delegate(host);
+        CassandraAdapterDelegate delegate = metadataFetcher.instance(host).delegate();
         NodeSettings nodeSettings = delegate.nodeSettings();
         StorageOperations operations = delegate.storageOperations();
         executorPools.service()

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/cassandra/NodeSettingsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/cassandra/NodeSettingsHandler.java
@@ -59,7 +59,7 @@ public class NodeSettingsHandler extends AbstractHandler<Void>
                                SocketAddress remoteAddress,
                                Void request)
     {
-        context.json(metadataFetcher.instance(host).delegate().nodeSettings());
+        context.json(metadataFetcher.delegate(host).nodeSettings());
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/cassandra/NodeSettingsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/cassandra/NodeSettingsHandler.java
@@ -26,6 +26,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.routes.AbstractHandler;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Provides REST endpoint to get the configured settings of a cassandra node.
@@ -54,11 +55,11 @@ public class NodeSettingsHandler extends AbstractHandler<Void>
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                Void request)
     {
-        context.json(metadataFetcher.delegate(host).nodeSettings());
+        context.json(metadataFetcher.instance(host).delegate().nodeSettings());
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/cdc/ListCdcDirHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/cdc/ListCdcDirHandler.java
@@ -52,6 +52,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.CdcUtil;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.CdcUtil.getIdxFileName;
 import static org.apache.cassandra.sidecar.utils.CdcUtil.getLogFilePrefix;
@@ -89,7 +90,7 @@ public class ListCdcDirHandler extends AbstractHandler<Void> implements AccessPr
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   Void request)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/cdc/StreamCdcSegmentHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/cdc/StreamCdcSegmentHandler.java
@@ -49,6 +49,7 @@ import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.CdcUtil;
 import org.apache.cassandra.sidecar.utils.FileStreamer;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.CdcUtil.getIdxFileName;
 import static org.apache.cassandra.sidecar.utils.CdcUtil.isLogFile;
@@ -91,7 +92,7 @@ public class StreamCdcSegmentHandler extends AbstractHandler<String> implements 
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   String segment)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/AbortRestoreJobHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/AbortRestoreJobHandler.java
@@ -81,7 +81,7 @@ public class AbortRestoreJobHandler extends AbstractHandler<AbortRestoreJobReque
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   AbortRestoreJobRequestPayload payload)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/CreateRestoreJobHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/CreateRestoreJobHandler.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.routes.RoutingContextUtils.SC_QUALIFIED_TABLE_NAME;
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -77,7 +78,7 @@ public class CreateRestoreJobHandler extends AbstractHandler<CreateRestoreJobReq
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   CreateRestoreJobRequestPayload request)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/CreateRestoreSliceHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/CreateRestoreSliceHandler.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.routes.RoutingContextUtils.SC_QUALIFIED_TABLE_NAME;
 import static org.apache.cassandra.sidecar.routes.RoutingContextUtils.SC_RESTORE_JOB;
@@ -86,7 +87,7 @@ public class CreateRestoreSliceHandler extends AbstractHandler<CreateSliceReques
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   CreateSliceRequestPayload request)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/RestoreJobProgressHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/RestoreJobProgressHandler.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.routes.RoutingContextUtils.SC_RESTORE_JOB;
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -96,7 +97,7 @@ public class RestoreJobProgressHandler extends AbstractHandler<RestoreJobProgres
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   RestoreJobProgressFetchPolicy fetchPolicy)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/RestoreJobSummaryHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/RestoreJobSummaryHandler.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.routes.RoutingContextUtils.SC_RESTORE_JOB;
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -67,7 +68,7 @@ public class RestoreJobSummaryHandler extends AbstractHandler<String> implements
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   String jobId)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/UpdateRestoreJobHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/restore/UpdateRestoreJobHandler.java
@@ -48,6 +48,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.routes.RoutingContextUtils.SC_RESTORE_JOB;
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -83,7 +84,7 @@ public class UpdateRestoreJobHandler extends AbstractHandler<UpdateRestoreJobReq
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   UpdateRestoreJobRequestPayload requestPayload)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ClearSnapshotHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ClearSnapshotHandler.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.data.SnapshotRequestParam;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -77,11 +78,11 @@ public class ClearSnapshotHandler extends AbstractHandler<SnapshotRequestParam> 
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                SnapshotRequestParam requestParams)
     {
-        StorageOperations storageOperations = metadataFetcher.delegate(host).storageOperations();
+        StorageOperations storageOperations = metadataFetcher.instance(host).delegate().storageOperations();
         executorPools.service().runBlocking(() -> {
             logger.debug("Clearing snapshot request={}, remoteAddress={}, instance={}",
                          requestParams, remoteAddress, host);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ClearSnapshotHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ClearSnapshotHandler.java
@@ -82,7 +82,7 @@ public class ClearSnapshotHandler extends AbstractHandler<SnapshotRequestParam> 
                                SocketAddress remoteAddress,
                                SnapshotRequestParam requestParams)
     {
-        StorageOperations storageOperations = metadataFetcher.instance(host).delegate().storageOperations();
+        StorageOperations storageOperations = metadataFetcher.delegate(host).storageOperations();
         executorPools.service().runBlocking(() -> {
             logger.debug("Clearing snapshot request={}, remoteAddress={}, instance={}",
                          requestParams, remoteAddress, host);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/CreateSnapshotHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/CreateSnapshotHandler.java
@@ -88,7 +88,7 @@ public class CreateSnapshotHandler extends AbstractHandler<SnapshotRequestParam>
                                SocketAddress remoteAddress,
                                SnapshotRequestParam requestParams)
     {
-        StorageOperations storageOperations = metadataFetcher.instance(host).delegate().storageOperations();
+        StorageOperations storageOperations = metadataFetcher.delegate(host).storageOperations();
         executorPools.service().runBlocking(() -> {
                          logger.debug("Creating snapshot request={}, remoteAddress={}, instance={}",
                                       requestParams, remoteAddress, host);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/CreateSnapshotHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/CreateSnapshotHandler.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.routes.data.SnapshotRequestParam;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -83,11 +84,11 @@ public class CreateSnapshotHandler extends AbstractHandler<SnapshotRequestParam>
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                SnapshotRequestParam requestParams)
     {
-        StorageOperations storageOperations = metadataFetcher.delegate(host).storageOperations();
+        StorageOperations storageOperations = metadataFetcher.instance(host).delegate().storageOperations();
         executorPools.service().runBlocking(() -> {
                          logger.debug("Creating snapshot request={}, remoteAddress={}, instance={}",
                                       requestParams, remoteAddress, host);

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandler.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.sidecar.snapshots.SnapshotPathBuilder;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.RequestUtils;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -123,7 +124,7 @@ public class ListSnapshotHandler extends AbstractHandler<SnapshotRequestParam> i
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                SnapshotRequestParam request)
     {
@@ -202,7 +203,8 @@ public class ListSnapshotHandler extends AbstractHandler<SnapshotRequestParam> i
 
     protected Future<List<String>> dataPaths(String host, String keyspace, String table)
     {
-        return executorPools.service().executeBlocking(() -> metadataFetcher.delegate(host)
+        return executorPools.service().executeBlocking(() -> metadataFetcher.instance(host)
+                                                                            .delegate()
                                                                             .tableOperations()
                                                                             .getDataPaths(keyspace, table));
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/snapshots/ListSnapshotHandler.java
@@ -203,8 +203,7 @@ public class ListSnapshotHandler extends AbstractHandler<SnapshotRequestParam> i
 
     protected Future<List<String>> dataPaths(String host, String keyspace, String table)
     {
-        return executorPools.service().executeBlocking(() -> metadataFetcher.instance(host)
-                                                                            .delegate()
+        return executorPools.service().executeBlocking(() -> metadataFetcher.delegate(host)
                                                                             .tableOperations()
                                                                             .getDataPaths(keyspace, table));
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableCleanupHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableCleanupHandler.java
@@ -36,6 +36,7 @@ import org.apache.cassandra.sidecar.routes.AbstractHandler;
 import org.apache.cassandra.sidecar.routes.AccessProtected;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.SSTableUploadsPathBuilder;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Manages cleaning up uploaded SSTables
@@ -76,7 +77,7 @@ public class SSTableCleanupHandler extends AbstractHandler<String> implements Ac
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                String uploadId)
     {

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandler.java
@@ -185,7 +185,7 @@ public class SSTableImportHandler extends AbstractHandler<SSTableImportRequestPa
         {
             // ensure that table operations are available from the delegate before doing the import
             // otherwise fail fast propagating the HttpException
-            metadataFetcher.instance(importOptions.host()).delegate().tableOperations();
+            metadataFetcher.delegate(importOptions.host()).tableOperations();
             return uploadPathBuilder.isValidDirectory(importOptions.directory())
                                     .compose(validDirectory -> importer.scheduleImport(importOptions));
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableImportHandler.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.SSTableImporter;
 import org.apache.cassandra.sidecar.utils.SSTableUploadsPathBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -101,7 +102,7 @@ public class SSTableImportHandler extends AbstractHandler<SSTableImportRequestPa
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                SSTableImportRequestParam request)
     {
@@ -184,7 +185,7 @@ public class SSTableImportHandler extends AbstractHandler<SSTableImportRequestPa
         {
             // ensure that table operations are available from the delegate before doing the import
             // otherwise fail fast propagating the HttpException
-            metadataFetcher.delegate(importOptions.host()).tableOperations();
+            metadataFetcher.instance(importOptions.host()).delegate().tableOperations();
             return uploadPathBuilder.isValidDirectory(importOptions.directory())
                                     .compose(validDirectory -> importer.scheduleImport(importOptions));
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
@@ -203,7 +203,7 @@ public class SSTableUploadHandler extends AbstractHandler<SSTableUploadRequestPa
                                                                        SSTableUploadRequestParam request)
     {
         TaskExecutorPool pool = executorPools.service();
-        return pool.executeBlocking(() -> metadataFetcher.instance(host).delegate().metadata())
+        return pool.executeBlocking(() -> metadataFetcher.delegate(host).metadata())
                    .compose(metadata -> {
                        KeyspaceMetadata keyspaceMetadata = MetadataUtils.keyspace(metadata, request.keyspace());
                        if (keyspaceMetadata == null)

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/sstableuploads/SSTableUploadHandler.java
@@ -55,6 +55,7 @@ import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.sidecar.utils.MetadataUtils;
 import org.apache.cassandra.sidecar.utils.SSTableUploader;
 import org.apache.cassandra.sidecar.utils.SSTableUploadsPathBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 import static org.apache.cassandra.sidecar.utils.MetricUtils.parseSSTableComponent;
@@ -116,7 +117,7 @@ public class SSTableUploadHandler extends AbstractHandler<SSTableUploadRequestPa
     @Override
     public void handleInternal(RoutingContext context,
                                HttpServerRequest httpRequest,
-                               String host,
+                               @NotNull String host,
                                SocketAddress remoteAddress,
                                SSTableUploadRequestParam request)
     {
@@ -202,7 +203,7 @@ public class SSTableUploadHandler extends AbstractHandler<SSTableUploadRequestPa
                                                                        SSTableUploadRequestParam request)
     {
         TaskExecutorPool pool = executorPools.service();
-        return pool.executeBlocking(() -> metadataFetcher.delegate(host).metadata())
+        return pool.executeBlocking(() -> metadataFetcher.instance(host).delegate().metadata())
                    .compose(metadata -> {
                        KeyspaceMetadata keyspaceMetadata = MetadataUtils.keyspace(metadata, request.keyspace());
                        if (keyspaceMetadata == null)

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/validations/ValidateTableExistenceHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/validations/ValidateTableExistenceHandler.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.sidecar.routes.AbstractHandler;
 import org.apache.cassandra.sidecar.routes.RoutingContextUtils;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
@@ -64,7 +65,7 @@ public class ValidateTableExistenceHandler extends AbstractHandler<QualifiedTabl
     @Override
     protected void handleInternal(RoutingContext context,
                                   HttpServerRequest httpRequest,
-                                  String host,
+                                  @NotNull String host,
                                   SocketAddress remoteAddress,
                                   QualifiedTableName input)
     {
@@ -111,6 +112,9 @@ public class ValidateTableExistenceHandler extends AbstractHandler<QualifiedTabl
 
     private Future<KeyspaceMetadata> getKeyspaceMetadata(String host, String keyspace)
     {
-        return executorPools.service().executeBlocking(() -> metadataFetcher.delegate(host).metadata().getKeyspace(keyspace));
+        return executorPools.service().executeBlocking(() -> metadataFetcher.instance(host)
+                                                                            .delegate()
+                                                                            .metadata()
+                                                                            .getKeyspace(keyspace));
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
 import com.google.common.util.concurrent.SidecarRateLimiter;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.slf4j.Logger;
@@ -842,11 +843,11 @@ public class MainModule extends AbstractModule
 
     @Provides
     @Singleton
-    public ElectorateMembership electorateMembership(InstancesMetadata instancesMetadata,
+    public ElectorateMembership electorateMembership(InstanceMetadataFetcher instanceMetadataFetcher,
                                                      CQLSessionProvider cqlSessionProvider,
                                                      SidecarConfiguration configuration)
     {
-        return new MostReplicatedKeyspaceTokenZeroElectorateMembership(instancesMetadata, cqlSessionProvider, configuration);
+        return new MostReplicatedKeyspaceTokenZeroElectorateMembership(instanceMetadataFetcher, cqlSessionProvider, configuration);
     }
 
     @Provides
@@ -886,13 +887,13 @@ public class MainModule extends AbstractModule
     @Singleton
     public IdentifiersProvider identifiersProvider(@NotNull InstanceMetadataFetcher fetcher)
     {
-        LazyInitializer<String> cluster = new LazyInitializer<String>()
+        LazyInitializer<String> cluster = new LazyInitializer<>()
         {
             @Override
             @NotNull
             protected String initialize()
             {
-                return fetcher.anyInstance().delegate().storageOperations().clusterName();
+                return fetcher.callOnFirstAvailableInstance(delegate -> delegate.storageOperations().clusterName());
             }
         };
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -893,7 +893,7 @@ public class MainModule extends AbstractModule
             @NotNull
             protected String initialize()
             {
-                return fetcher.callOnFirstAvailableInstance(delegate -> delegate.storageOperations().clusterName());
+                return fetcher.callOnFirstAvailableInstance(i -> i.delegate().storageOperations().clusterName());
             }
         };
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
@@ -19,17 +19,22 @@
 package org.apache.cassandra.sidecar.utils;
 
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+
+import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.CQL_AND_JMX;
 
 /**
  * Helper class to retrieve instance information from an instanceId or hostname.
@@ -37,6 +42,8 @@ import org.jetbrains.annotations.Nullable;
 @Singleton
 public class InstanceMetadataFetcher
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceMetadataFetcher.class);
+
     private final InstancesMetadata instancesMetadata;
 
     @Inject
@@ -46,19 +53,15 @@ public class InstanceMetadataFetcher
     }
 
     /**
-     * Returns the {@link InstanceMetadata} for the given {@code host}. When the {@code host} is {@code null},
-     * returns the first instance from the list of configured instances.
+     * Returns the {@link InstanceMetadata} for the given {@code host}.
      *
      * @param host the Cassandra instance hostname or IP address
-     * @return the {@link InstanceMetadata} for the given {@code host}, or the first instance when {@code host} is
-     * {@code null}
+     * @return the {@link InstanceMetadata} for the given {@code host}
      */
     @NotNull
-    public InstanceMetadata instance(@Nullable String host) throws NoSuchCassandraInstanceException
+    public InstanceMetadata instance(@NotNull String host) throws NoSuchCassandraInstanceException
     {
-        return host == null
-               ? firstInstance()
-               : instancesMetadata.instanceFromHost(host);
+        return instancesMetadata.instanceFromHost(host);
     }
 
     /**
@@ -77,60 +80,40 @@ public class InstanceMetadataFetcher
     }
 
     /**
-     * Returns the {@link CassandraAdapterDelegate} for the given {@code host}. When the {@code host} is {@code null},
-     * returns the delegate for the first instance from the list of configured instances.
+     * Iterate through the local instances and call the function on the first available instance
      *
-     * @param host the Cassandra instance hostname or IP address
-     * @return the {@link CassandraAdapterDelegate} for the given {@code host}, or the first instance when {@code host}
-     * is {@code null}
-     * @throws NoSuchCassandraInstanceException when the Cassandra instance with {@code host} does not exist
-     * @throws CassandraUnavailableException  when Cassandra is not yet connected
+     * @param function function applies to {@link CassandraAdapterDelegate}
+     * @return function eval result. Null can be returned when all local instances are exhausted
+     * @param <T> type of the result
+     * @throws CassandraUnavailableException when all local instances are exhausted.
      */
     @NotNull
-    public CassandraAdapterDelegate delegate(@Nullable String host) throws NoSuchCassandraInstanceException, CassandraUnavailableException
+    public <T> T callOnFirstAvailableInstance(Function<CassandraAdapterDelegate, T> function) throws CassandraUnavailableException
     {
-        return instance(host).delegate();
-    }
-
-    /**
-     * Returns the {@link CassandraAdapterDelegate} for the given {@code instanceId}
-     *
-     * @param instanceId the identifier for the Cassandra instance
-     * @return the {@link CassandraAdapterDelegate} for the given {@code instanceId}
-     * @throws NoSuchCassandraInstanceException when the Cassandra instance with {@code instanceId} does not exist
-     * @throws CassandraUnavailableException  when Cassandra is not yet connected
-     */
-    @NotNull
-    public CassandraAdapterDelegate delegate(int instanceId) throws NoSuchCassandraInstanceException, CassandraUnavailableException
-    {
-        return instance(instanceId).delegate();
-    }
-
-    /**
-     * @return the first instance from the list of configured instances
-     * @throws IllegalStateException when there are no configured instances
-     */
-    public InstanceMetadata firstInstance()
-    {
-        ensureInstancesMetadataConfigured();
-        return instancesMetadata.instances().get(0);
-    }
-
-    /**
-     * @return any instance from the list of configured instances
-     * @throws IllegalStateException when there are no configured instances
-     */
-    public InstanceMetadata anyInstance()
-    {
-        ensureInstancesMetadataConfigured();
-        List<InstanceMetadata> instances = instancesMetadata.instances();
-        if (instances.size() == 1)
+        for (InstanceMetadata instance : allLocalInstances())
         {
-            return instances.get(0);
+            try
+            {
+                CassandraAdapterDelegate delegate = instance.delegate();
+                return function.apply(delegate);
+            }
+            catch (CassandraUnavailableException | OperationUnavailableException exception)
+            {
+                // no-op; try the next instance
+                LOGGER.debug("CassandraAdapterDelegate is not available for instance. instance={}", instance, exception);
+            }
         }
 
-        int randomPick = ThreadLocalRandom.current().nextInt(instances.size());
-        return instances.get(randomPick);
+        throw new CassandraUnavailableException(CQL_AND_JMX, "All local Cassandra nodes are exhausted. But none is available");
+    }
+
+    /**
+     * @return all the configured local instances
+     */
+    public List<InstanceMetadata> allLocalInstances()
+    {
+        ensureInstancesMetadataConfigured();
+        return instancesMetadata.instances();
     }
 
     private void ensureInstancesMetadataConfigured()

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
-import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
@@ -80,22 +79,22 @@ public class InstanceMetadataFetcher
     }
 
     /**
-     * Iterate through the local instances and call the function on the first available instance
+     * Iterate through the local instances and call the function on the first available instance, i.e. no CassandraUnavailableException
+     * or OperationUnavailableException is thrown for the operations
      *
-     * @param function function applies to {@link CassandraAdapterDelegate}
+     * @param function function applies to {@link InstanceMetadata}
      * @return function eval result. Null can be returned when all local instances are exhausted
      * @param <T> type of the result
      * @throws CassandraUnavailableException when all local instances are exhausted.
      */
     @NotNull
-    public <T> T callOnFirstAvailableInstance(Function<CassandraAdapterDelegate, T> function) throws CassandraUnavailableException
+    public <T> T callOnFirstAvailableInstance(Function<InstanceMetadata, T> function) throws CassandraUnavailableException
     {
         for (InstanceMetadata instance : allLocalInstances())
         {
             try
             {
-                CassandraAdapterDelegate delegate = instance.delegate();
-                return function.apply(delegate);
+                return function.apply(instance);
             }
             catch (CassandraUnavailableException | OperationUnavailableException exception)
             {

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
@@ -76,6 +77,23 @@ public class InstanceMetadataFetcher
     public InstanceMetadata instance(int instanceId) throws NoSuchCassandraInstanceException
     {
         return instancesMetadata.instanceFromId(instanceId);
+    }
+
+    /**
+     * Returns the {@link CassandraAdapterDelegate} for the given {@code host}
+     *
+     * <p><b>Note</b>: the method to retrieve delegate should not be the responsibility of this class. However, for historic reasons, it is kept.
+     * That said, it does <i>not</i> warrant adding any more convenient methods to return members of {@link InstanceMetadata}.
+     *
+     * @param host the Cassandra instance hostname or IP address
+     * @return the {@link CassandraAdapterDelegate} for the given {@code host}
+     * @throws NoSuchCassandraInstanceException when the Cassandra instance with {@code host} does not exist
+     * @throws CassandraUnavailableException when Cassandra is not yet connected
+     */
+    @NotNull
+    public CassandraAdapterDelegate delegate(@NotNull String host) throws NoSuchCassandraInstanceException, CassandraUnavailableException
+    {
+        return instance(host).delegate();
     }
 
     /**

--- a/server/src/test/integration/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest.java
@@ -59,6 +59,7 @@ import org.apache.cassandra.sidecar.metrics.MetricRegistryFactory;
 import org.apache.cassandra.sidecar.metrics.instance.InstanceHealthMetrics;
 import org.apache.cassandra.sidecar.testing.SharedExecutorNettyOptions;
 import org.apache.cassandra.sidecar.utils.CassandraVersionProvider;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.testing.TestVersion;
 
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
@@ -172,7 +173,8 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipIntegrationTest
             CQLSessionProvider sessionProvider =
             new CQLSessionProviderImpl(address, address, 500, instance.config().localDatacenter(), 0, SharedExecutorNettyOptions.INSTANCE);
             InstancesMetadata instancesMetadata = buildInstancesMetadata(instance, sessionProvider, metricRegistryProvider);
-            result.add(new MostReplicatedKeyspaceTokenZeroElectorateMembership(instancesMetadata, sessionProvider, CONFIG));
+            InstanceMetadataFetcher instanceMetadataFetcher = new InstanceMetadataFetcher(instancesMetadata);
+            result.add(new MostReplicatedKeyspaceTokenZeroElectorateMembership(instanceMetadataFetcher, sessionProvider, CONFIG));
         }
         return result;
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTaskTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTaskTest.java
@@ -93,6 +93,22 @@ class ClusterLeaseClaimTaskTest
         verify(mockElectorateMembership, times(1)).isMember();
     }
 
+    @Test
+    void testShouldRescheduleWhenDatabaseAccessorIsUnavailable()
+    {
+        ServiceConfiguration serviceConfiguration = mockConfiguration(true, true);
+        ElectorateMembership mockElectorateMembership = mock(ElectorateMembership.class);
+        when(mockElectorateMembership.isMember()).thenReturn(true);
+        SidecarLeaseDatabaseAccessor databaseAccessor = mock(SidecarLeaseDatabaseAccessor.class);
+        when(databaseAccessor.isAvailable()).thenReturn(false);
+        ClusterLeaseClaimTask task = new ClusterLeaseClaimTask(mock(Vertx.class), serviceConfiguration, mockElectorateMembership,
+                                                               databaseAccessor, new ClusterLease(),
+                                                               mock(SidecarMetrics.class, RETURNS_DEEP_STUBS));
+
+        assertThat(task.scheduleDecision()).isEqualTo(ScheduleDecision.RESCHEDULE);
+        verify(mockElectorateMembership, times(1)).isMember();
+    }
+
     @ParameterizedTest(name = "{index} => configuredInitialDelay {0} millis")
     @ValueSource(longs = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
     void testInitialDelayFromConfiguration(long configuredDelayMillis)

--- a/server/src/test/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTaskTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/coordination/ClusterLeaseClaimTaskTest.java
@@ -85,8 +85,10 @@ class ClusterLeaseClaimTaskTest
         ServiceConfiguration serviceConfiguration = mockConfiguration(true, true);
         ElectorateMembership mockElectorateMembership = mock(ElectorateMembership.class);
         when(mockElectorateMembership.isMember()).thenReturn(true);
+        SidecarLeaseDatabaseAccessor accessor = mock(SidecarLeaseDatabaseAccessor.class);
+        when(accessor.isAvailable()).thenReturn(true);
         ClusterLeaseClaimTask task = new ClusterLeaseClaimTask(mock(Vertx.class), serviceConfiguration, mockElectorateMembership,
-                                                               mock(SidecarLeaseDatabaseAccessor.class), new ClusterLease(),
+                                                               accessor, new ClusterLease(),
                                                                mock(SidecarMetrics.class, RETURNS_DEEP_STUBS));
 
         assertThat(task.scheduleDecision()).isEqualTo(ScheduleDecision.EXECUTE);

--- a/server/src/test/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipTest.java
@@ -36,7 +36,6 @@ import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 
 import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.CQL;
-import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.JMX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/server/src/test/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/coordination/MostReplicatedKeyspaceTokenZeroElectorateMembershipTest.java
@@ -33,8 +33,10 @@ import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.config.yaml.SidecarConfigurationImpl;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 
 import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.CQL;
+import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.JMX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -47,11 +49,17 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipTest
     private static final SidecarConfigurationImpl CONFIG = new SidecarConfigurationImpl();
 
     @Test
-    void testEmptyInstancesMetadata()
+    void testNoAvailableLocalInstances()
     {
         InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
-        when(mockInstancesMetadata.instances()).thenReturn(Collections.emptyList());
-        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(mockInstancesMetadata, null, CONFIG);
+        InstanceMetadata instanceMetadata = mock(InstanceMetadata.class);
+        CassandraAdapterDelegate mockCassandraAdapterDelegate = mock(CassandraAdapterDelegate.class);
+        when(mockCassandraAdapterDelegate.localStorageBroadcastAddress())
+        .thenThrow(new CassandraUnavailableException(CQL, "Cannot retrieve storageBroadcastAddress"));
+        when(instanceMetadata.delegate()).thenReturn(mockCassandraAdapterDelegate);
+        when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+        InstanceMetadataFetcher instanceMetadataFetcher = new InstanceMetadataFetcher(mockInstancesMetadata);
+        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(instanceMetadataFetcher, null, CONFIG);
         assertThat(membership.isMember()).as("When no local instances are managed by Sidecar, we can't determine participation")
                                          .isFalse();
     }
@@ -67,10 +75,11 @@ class MostReplicatedKeyspaceTokenZeroElectorateMembershipTest
         when(mockCassandraAdapterDelegate.nodeSettings()).thenReturn(mock(NodeSettings.class));
         when(instanceMetadata.delegate()).thenReturn(mockCassandraAdapterDelegate);
         when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+        InstanceMetadataFetcher instanceMetadataFetcher = new InstanceMetadataFetcher(mockInstancesMetadata);
         CQLSessionProvider mockCQLSessionProvider = mock(CQLSessionProvider.class);
         // the session is not available so we return null
         when(mockCQLSessionProvider.get()).thenThrow(new CassandraUnavailableException(CQL, new RuntimeException("connection failed")));
-        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(mockInstancesMetadata, mockCQLSessionProvider, CONFIG);
+        ElectorateMembership membership = new MostReplicatedKeyspaceTokenZeroElectorateMembership(instanceMetadataFetcher, mockCQLSessionProvider, CONFIG);
         assertThat(membership.isMember()).as("When the CQL connection is unavailable, we can't determine participation")
                                          .isFalse();
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/AbstractHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/AbstractHandlerTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.server.MainModule;
 import org.apache.cassandra.sidecar.server.Server;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -122,7 +123,7 @@ class AbstractHandlerTest
         @Override
         protected void handleInternal(RoutingContext context,
                                       HttpServerRequest httpRequest,
-                                      String host,
+                                      @NotNull String host,
                                       SocketAddress remoteAddress,
                                       Object request)
         {

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/ExtractHostAddressWithoutPortTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/ExtractHostAddressWithoutPortTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.vertx.core.http.HttpServerRequest;
-import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,8 +50,8 @@ class ExtractHostAddressWithoutPortTest
     void testExtractNullInput()
     {
         assertThatThrownBy(() -> AbstractHandler.extractHostAddressWithoutPort(mockRequest(null)))
-        .isExactlyInstanceOf(NoSuchCassandraInstanceException.class)
-        .hasMessage("No such Cassandra instance when Host header is absent");
+        .isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing 'host' header in the request");
     }
 
     static Stream<Arguments> inputs()

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/ExtractHostAddressWithoutPortTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/ExtractHostAddressWithoutPortTest.java
@@ -18,54 +18,61 @@
 
 package org.apache.cassandra.sidecar.routes;
 
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.vertx.core.http.HttpServerRequest;
+import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link AbstractHandler#extractHostAddressWithoutPort} functionality
  */
 class ExtractHostAddressWithoutPortTest
 {
-    @Test
-    void testAddressWithIPv4Host()
+    @ParameterizedTest(name = "{index} => input={0}, expected={1}")
+    @MethodSource(value = { "inputs" })
+    void testHostExtraction(String input, String expectedValue)
     {
-        final String host = AbstractHandler.extractHostAddressWithoutPort("127.0.0.1");
-        assertEquals("127.0.0.1", host);
+        String host = AbstractHandler.extractHostAddressWithoutPort(mockRequest(input));
+        assertThat(host).isEqualTo(expectedValue);
     }
 
     @Test
-    void testAddressIPv4HostAndPort()
+    void testExtractNullInput()
     {
-        final String host = AbstractHandler.extractHostAddressWithoutPort("127.0.0.1:9043");
-        assertEquals("127.0.0.1", host);
+        assertThatThrownBy(() -> AbstractHandler.extractHostAddressWithoutPort(mockRequest(null)))
+        .isExactlyInstanceOf(NoSuchCassandraInstanceException.class)
+        .hasMessage("No such Cassandra instance when Host header is absent");
     }
 
-    @Test
-    void testAddressWithIPv6Host()
+    static Stream<Arguments> inputs()
     {
-        final String host = AbstractHandler.extractHostAddressWithoutPort("2001:db8:0:0:0:ff00:42:8329");
-        assertEquals("2001:db8:0:0:0:ff00:42:8329", host);
+        return Stream.of(
+        arguments("127.0.0.1", "127.0.0.1"),
+        arguments("127.0.0.1:9043", "127.0.0.1"),
+        arguments("2001:db8:0:0:0:ff00:42:8329", "2001:db8:0:0:0:ff00:42:8329"),
+        arguments("[2001:db8:0:0:0:ff00:42:8329]:9043", "2001:db8:0:0:0:ff00:42:8329"),
+        arguments("::1", "::1"),
+        arguments("[::1]:9043", "::1"),
+        arguments("www.apache.cassandra.sidecar.com", "www.apache.cassandra.sidecar.com"),
+        arguments("www.apache.cassandra.sidecar.com:9043", "www.apache.cassandra.sidecar.com")
+        );
     }
 
-    @Test
-    void testAddressWithIPv6HostAndPort()
+    private HttpServerRequest mockRequest(String host)
     {
-        final String host = AbstractHandler.extractHostAddressWithoutPort("[2001:db8:0:0:0:ff00:42:8329]:9043");
-        assertEquals("2001:db8:0:0:0:ff00:42:8329", host);
-    }
-
-    @Test
-    void testAddressWithIPv6HostShortcut()
-    {
-        final String host = AbstractHandler.extractHostAddressWithoutPort("::1");
-        assertEquals("::1", host);
-    }
-
-    @Test
-    void testAddressWithIPv6HostShortcutWithPort()
-    {
-        final String host = AbstractHandler.extractHostAddressWithoutPort("[::1]:9043");
-        assertEquals("::1", host);
+        HttpServerRequest req = mock(HttpServerRequest.class);
+        when(req.host()).thenReturn(host);
+        return req;
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/routes/ExtractHostAddressWithoutPortTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/routes/ExtractHostAddressWithoutPortTest.java
@@ -24,13 +24,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.vertx.core.http.HttpServerRequest;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcherTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcherTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.utils;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadataImpl;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadataImpl;
+import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
+import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class InstanceMetadataFetcherTest
+{
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testCallOnFirstAvailableInstance()
+    {
+        List<InstanceMetadata> instances = Arrays.asList(instance(1, "127.0.0.1", false),
+                                                         instance(2, "127.0.0.2", true),
+                                                         instance(3, "127.0.0.3", true));
+        InstancesMetadataImpl instancesMetadata = new InstancesMetadataImpl(instances, DnsResolver.DEFAULT);
+        InstanceMetadataFetcher fetcher = new InstanceMetadataFetcher(instancesMetadata);
+        CassandraAdapterDelegate delegate = fetcher.callOnFirstAvailableInstance(Function.identity());
+        assertThat(delegate)
+        .describedAs("The delegate of instance 2 should be returned")
+        .isNotNull()
+        .isSameAs(instances.get(1).delegate());
+    }
+
+    @Test
+    void testCallOnFirstAvailableInstanceExhausts()
+    {
+        List<InstanceMetadata> instances = Arrays.asList(instance(1, "127.0.0.1", false),
+                                                         instance(2, "127.0.0.2", false));
+        InstancesMetadataImpl instancesMetadata = new InstancesMetadataImpl(instances, DnsResolver.DEFAULT);
+        InstanceMetadataFetcher fetcher = new InstanceMetadataFetcher(instancesMetadata);
+        assertThatThrownBy(() -> fetcher.callOnFirstAvailableInstance(Function.identity()))
+        .isExactlyInstanceOf(CassandraUnavailableException.class)
+        .hasMessageContaining("All local Cassandra nodes are exhausted. But none is available");
+    }
+
+    private InstanceMetadata instance(int id, String host, boolean isAvailable)
+    {
+        InstanceMetadataImpl.Builder builder = InstanceMetadataImpl.builder()
+                                                                   .id(id)
+                                                                   .host(host, DnsResolver.DEFAULT)
+                                                                   .port(9042)
+                                                                   .storageDir(tempDir.toString())
+                                                                   .metricRegistry(new MetricRegistry());
+        if (isAvailable)
+        {
+            builder.delegate(mock(CassandraAdapterDelegate.class));
+        }
+        return builder.build();
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcherTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcherTest.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.sidecar.utils;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -51,7 +50,7 @@ class InstanceMetadataFetcherTest
                                                          instance(3, "127.0.0.3", true));
         InstancesMetadataImpl instancesMetadata = new InstancesMetadataImpl(instances, DnsResolver.DEFAULT);
         InstanceMetadataFetcher fetcher = new InstanceMetadataFetcher(instancesMetadata);
-        CassandraAdapterDelegate delegate = fetcher.callOnFirstAvailableInstance(Function.identity());
+        CassandraAdapterDelegate delegate = fetcher.callOnFirstAvailableInstance(InstanceMetadata::delegate);
         assertThat(delegate)
         .describedAs("The delegate of instance 2 should be returned")
         .isNotNull()
@@ -65,7 +64,7 @@ class InstanceMetadataFetcherTest
                                                          instance(2, "127.0.0.2", false));
         InstancesMetadataImpl instancesMetadata = new InstancesMetadataImpl(instances, DnsResolver.DEFAULT);
         InstanceMetadataFetcher fetcher = new InstanceMetadataFetcher(instancesMetadata);
-        assertThatThrownBy(() -> fetcher.callOnFirstAvailableInstance(Function.identity()))
+        assertThatThrownBy(() -> fetcher.callOnFirstAvailableInstance(InstanceMetadata::delegate))
         .isExactlyInstanceOf(CassandraUnavailableException.class)
         .hasMessageContaining("All local Cassandra nodes are exhausted. But none is available");
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/utils/SSTableImporterTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/utils/SSTableImporterTest.java
@@ -95,9 +95,6 @@ class SSTableImporterTest
         when(mockMetadataFetcher.instance("localhost")).thenReturn(mockInstanceMetadata1);
         when(mockMetadataFetcher.instance("127.0.0.2")).thenReturn(mockInstanceMetadata2);
         when(mockMetadataFetcher.instance("127.0.0.3")).thenReturn(mockInstanceMetadata3);
-        when(mockMetadataFetcher.delegate("localhost")).thenReturn(mockCassandraAdapterDelegate1);
-        when(mockMetadataFetcher.delegate("127.0.0.2")).thenReturn(mockCassandraAdapterDelegate2);
-        when(mockMetadataFetcher.delegate("127.0.0.3")).thenReturn(mockCassandraAdapterDelegate3);
         when(mockCassandraAdapterDelegate1.tableOperations()).thenReturn(mockTableOperations1);
         when(mockTableOperations1.importNewSSTables("ks", "tbl", "/dir", true, true,
                                                     true, true, true, true, false))


### PR DESCRIPTION
This patch introduces InstanceMetadataFetcher#callOnFirstAvailableInstance to retry operations the next local Cassandra node until it is successful or exhausted. It also makes sure that host extracted from Host header is non-null to solidify the implementations.

Patch by Yifan Cai; Reviewed by TBD for CASSSIDECAR-201