### PR TITLE
CASSSIDECAR-200: Sidecar schema initialization can be executed on multiple thread

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Sidecar schema initialization can be executed on multiple thread (CASSSIDECAR-200)
  * Make sidecar operations resilient to down Cassandra nodes (CASSSIDECAR-201)
  * Fix Cassandra instance not found error (CASSSIDECAR-192)
  * Implemented Schema Reporter for Integration with DataHub (CASSSIDECAR-191)

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
@@ -18,8 +18,6 @@
 
 package org.apache.cassandra.sidecar.db.schema;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
@@ -40,6 +40,7 @@ import org.apache.cassandra.sidecar.exceptions.SidecarSchemaModificationExceptio
 import org.apache.cassandra.sidecar.metrics.SchemaMetrics;
 import org.apache.cassandra.sidecar.tasks.PeriodicTask;
 import org.apache.cassandra.sidecar.tasks.PeriodicTaskExecutor;
+import org.apache.cassandra.sidecar.tasks.ScheduleDecision;
 
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CASSANDRA_CQL_READY;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SIDECAR_SCHEMA_INITIALIZED;
@@ -151,6 +152,17 @@ public class SidecarSchema
     private class SidecarSchemaInitializer implements PeriodicTask
     {
         @Override
+        public ScheduleDecision scheduleDecision()
+        {
+            if (cqlSessionProvider.getIfConnected() == null)
+            {
+                LOGGER.debug("CQL connection is not yet established. Skip this run of initialization.");
+                return ScheduleDecision.SKIP;
+            }
+            return ScheduleDecision.EXECUTE;
+        }
+
+        @Override
         public DurationSpec delay()
         {
             return INITIALIZATION_LOOP_DELAY;
@@ -176,7 +188,6 @@ public class SidecarSchema
                 LOGGER.warn("Failed to initialize schema. Retry in {}", delay(), ex);
                 if (ex instanceof CassandraUnavailableException)
                 {
-                    LOGGER.debug("Cql session is not yet available. Skip initializing...");
                     return; // do not count Cassandra unavailable as failure
                 }
                 else if (ex instanceof SidecarSchemaModificationException)

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
@@ -97,14 +97,14 @@ public class SidecarSchema
     private void configureSidecarServerEventListeners()
     {
         EventBus eventBus = vertx.eventBus();
-        eventBus.localConsumer(ON_CASSANDRA_CQL_READY.address(), message -> startSidecarSchemaInitializerMaybe());
+        eventBus.localConsumer(ON_CASSANDRA_CQL_READY.address(), message -> maybeStartSidecarSchemaInitializer());
         eventBus.localConsumer(ON_SERVER_STOP.address(), message -> periodicTaskExecutor.unschedule(sidecarSchemaInitializer));
     }
 
     @VisibleForTesting
-    public void startSidecarSchemaInitializerMaybe()
+    public void maybeStartSidecarSchemaInitializer()
     {
-        if (!schemaKeyspaceConfiguration.isEnabled() || sidecarInternalKeyspace == null)
+        if (!schemaKeyspaceConfiguration.isEnabled() || sidecarSchemaInitializer == null)
         {
             return;
         }
@@ -153,7 +153,7 @@ public class SidecarSchema
     }
 
     /**
-     * Initializer that retries until sidecar schema is initialized. Until then, it un-schedules itself.
+     * Initializer that retries until sidecar schema is initialized. Once initialized, it un-schedules itself.
      */
     private class SidecarSchemaInitializer implements PeriodicTask
     {
@@ -170,13 +170,6 @@ public class SidecarSchema
             {
                 Session session = cqlSessionProvider.get();
                 isInitialized = sidecarInternalKeyspace.initialize(session, SidecarSchema.this::shouldCreateSchema);
-
-                if (isInitialized())
-                {
-                    LOGGER.info("Sidecar schema is initialized");
-                    periodicTaskExecutor.unschedule(this);
-                    reportSidecarSchemaInitialized();
-                }
             }
             catch (CassandraUnavailableException ignored)
             {
@@ -191,6 +184,17 @@ public class SidecarSchema
                     metrics.failedModifications.metric.update(1);
                 }
                 metrics.failedInitializations.metric.update(1);
+            }
+
+            if (isInitialized())
+            {
+                LOGGER.info("Sidecar schema is initialized. Stopping SchemaSidecarInitializer");
+                periodicTaskExecutor.unschedule(this);
+                reportSidecarSchemaInitialized();
+            }
+            else
+            {
+                LOGGER.debug("Sidecar schema is not initialized. Retry in {}", delay());
             }
             promise.tryComplete();
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
@@ -40,10 +40,8 @@ import org.apache.cassandra.sidecar.exceptions.SidecarSchemaModificationExceptio
 import org.apache.cassandra.sidecar.metrics.SchemaMetrics;
 import org.apache.cassandra.sidecar.tasks.PeriodicTask;
 import org.apache.cassandra.sidecar.tasks.PeriodicTaskExecutor;
-import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CASSANDRA_CQL_READY;
-import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SIDECAR_SCHEMA_INITIALIZED;
 
 /**
@@ -62,8 +60,6 @@ public class SidecarSchema
     private final CQLSessionProvider cqlSessionProvider;
     private final SchemaMetrics metrics;
     private final ClusterLease clusterLease;
-    @Nullable
-    private final SidecarSchemaInitializer sidecarSchemaInitializer;
 
     private boolean isInitialized = false;
 
@@ -84,12 +80,10 @@ public class SidecarSchema
         this.clusterLease = clusterLease;
         if (this.schemaKeyspaceConfiguration.isEnabled())
         {
-            this.sidecarSchemaInitializer = new SidecarSchemaInitializer();
             configureSidecarServerEventListeners();
         }
         else
         {
-            this.sidecarSchemaInitializer = null;
             LOGGER.info("Sidecar schema is disabled!");
         }
     }
@@ -98,13 +92,12 @@ public class SidecarSchema
     {
         EventBus eventBus = vertx.eventBus();
         eventBus.localConsumer(ON_CASSANDRA_CQL_READY.address(), message -> maybeStartSidecarSchemaInitializer());
-        eventBus.localConsumer(ON_SERVER_STOP.address(), message -> periodicTaskExecutor.unschedule(sidecarSchemaInitializer));
     }
 
     @VisibleForTesting
     public void maybeStartSidecarSchemaInitializer()
     {
-        if (!schemaKeyspaceConfiguration.isEnabled() || sidecarSchemaInitializer == null)
+        if (!schemaKeyspaceConfiguration.isEnabled())
         {
             return;
         }
@@ -112,7 +105,7 @@ public class SidecarSchema
         // schedule one initializer exactly
         if (initializerStarted.compareAndSet(false, true))
         {
-            periodicTaskExecutor.schedule(sidecarSchemaInitializer);
+            periodicTaskExecutor.schedule(new SidecarSchemaInitializer());
         }
     }
 
@@ -170,31 +163,28 @@ public class SidecarSchema
             {
                 Session session = cqlSessionProvider.get();
                 isInitialized = sidecarInternalKeyspace.initialize(session, SidecarSchema.this::shouldCreateSchema);
-            }
-            catch (CassandraUnavailableException ignored)
-            {
-                LOGGER.debug("Cql session is not yet available. Skip initializing...");
+
+                if (isInitialized)
+                {
+                    LOGGER.info("Sidecar schema is initialized. Stopping SchemaSidecarInitializer");
+                    periodicTaskExecutor.unschedule(this);
+                    reportSidecarSchemaInitialized();
+                }
             }
             catch (Exception ex)
             {
-                LOGGER.warn("Failed to initialize schema", ex);
-                if (ex instanceof SidecarSchemaModificationException)
+                LOGGER.warn("Failed to initialize schema. Retry in {}", delay(), ex);
+                if (ex instanceof CassandraUnavailableException)
+                {
+                    LOGGER.debug("Cql session is not yet available. Skip initializing...");
+                    return; // do not count Cassandra unavailable as failure
+                }
+                else if (ex instanceof SidecarSchemaModificationException)
                 {
                     LOGGER.warn("Failed to modify schema", ex);
                     metrics.failedModifications.metric.update(1);
                 }
                 metrics.failedInitializations.metric.update(1);
-            }
-
-            if (isInitialized())
-            {
-                LOGGER.info("Sidecar schema is initialized. Stopping SchemaSidecarInitializer");
-                periodicTaskExecutor.unschedule(this);
-                reportSidecarSchemaInitialized();
-            }
-            else
-            {
-                LOGGER.debug("Sidecar schema is not initialized. Retry in {}", delay());
             }
             promise.tryComplete();
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
@@ -18,17 +18,19 @@
 
 package org.apache.cassandra.sidecar.db.schema;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.Session;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
-import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
+import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
 import org.apache.cassandra.sidecar.config.SchemaKeyspaceConfiguration;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.coordination.ClusterLease;
@@ -36,6 +38,9 @@ import org.apache.cassandra.sidecar.coordination.ExecuteOnClusterLeaseholderOnly
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.exceptions.SidecarSchemaModificationException;
 import org.apache.cassandra.sidecar.metrics.SchemaMetrics;
+import org.apache.cassandra.sidecar.tasks.PeriodicTask;
+import org.apache.cassandra.sidecar.tasks.PeriodicTaskExecutor;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CASSANDRA_CQL_READY;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
@@ -47,21 +52,23 @@ import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SIDECAR
 public class SidecarSchema
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(SidecarSchema.class);
-    protected static final long INITIALIZATION_LOOP_DELAY_MILLIS = 1000;
+    protected static final DurationSpec INITIALIZATION_LOOP_DELAY = MillisecondBoundConfiguration.parse("1s");
 
     private final Vertx vertx;
-    private final ExecutorPools executorPools;
+    private final PeriodicTaskExecutor periodicTaskExecutor;
     private final SchemaKeyspaceConfiguration schemaKeyspaceConfiguration;
     private final SidecarInternalKeyspace sidecarInternalKeyspace;
-    private final AtomicLong initializationTimerId = new AtomicLong(-1L);
+    private final AtomicBoolean initializerStarted = new AtomicBoolean(false);
     private final CQLSessionProvider cqlSessionProvider;
     private final SchemaMetrics metrics;
     private final ClusterLease clusterLease;
+    @Nullable
+    private final SidecarSchemaInitializer sidecarSchemaInitializer;
 
     private boolean isInitialized = false;
 
     public SidecarSchema(Vertx vertx,
-                         ExecutorPools executorPools,
+                         PeriodicTaskExecutor periodicTaskExecutor,
                          SidecarConfiguration config,
                          SidecarInternalKeyspace sidecarInternalKeyspace,
                          CQLSessionProvider cqlSessionProvider,
@@ -69,7 +76,7 @@ public class SidecarSchema
                          ClusterLease clusterLease)
     {
         this.vertx = vertx;
-        this.executorPools = executorPools;
+        this.periodicTaskExecutor = periodicTaskExecutor;
         this.schemaKeyspaceConfiguration = config.serviceConfiguration().schemaKeyspaceConfiguration();
         this.sidecarInternalKeyspace = sidecarInternalKeyspace;
         this.cqlSessionProvider = cqlSessionProvider;
@@ -77,10 +84,12 @@ public class SidecarSchema
         this.clusterLease = clusterLease;
         if (this.schemaKeyspaceConfiguration.isEnabled())
         {
+            this.sidecarSchemaInitializer = new SidecarSchemaInitializer();
             configureSidecarServerEventListeners();
         }
         else
         {
+            this.sidecarSchemaInitializer = null;
             LOGGER.info("Sidecar schema is disabled!");
         }
     }
@@ -88,29 +97,23 @@ public class SidecarSchema
     private void configureSidecarServerEventListeners()
     {
         EventBus eventBus = vertx.eventBus();
-
-        eventBus.localConsumer(ON_CASSANDRA_CQL_READY.address(), message -> startSidecarSchemaInitializer());
-        eventBus.localConsumer(ON_SERVER_STOP.address(), message -> cancelTimer(initializationTimerId.get()));
+        eventBus.localConsumer(ON_CASSANDRA_CQL_READY.address(), message -> startSidecarSchemaInitializerMaybe());
+        eventBus.localConsumer(ON_SERVER_STOP.address(), message -> periodicTaskExecutor.unschedule(sidecarSchemaInitializer));
     }
 
     @VisibleForTesting
-    public void startSidecarSchemaInitializer()
+    public void startSidecarSchemaInitializerMaybe()
     {
         if (!schemaKeyspaceConfiguration.isEnabled() || sidecarInternalKeyspace == null)
-            return;
-
-        // schedule one initializer exactly
-        if (!initializationTimerId.compareAndSet(-1L, 0L))
         {
-            LOGGER.debug("Skipping starting the sidecar schema initializer because there is an initialization " +
-                         "in progress with timerId={}", initializationTimerId);
             return;
         }
 
-        // loop initialization until initialized
-        long timerId = executorPools.internal()
-                                    .setPeriodic(INITIALIZATION_LOOP_DELAY_MILLIS, this::initialize);
-        initializationTimerId.set(timerId);
+        // schedule one initializer exactly
+        if (initializerStarted.compareAndSet(false, true))
+        {
+            periodicTaskExecutor.schedule(sidecarSchemaInitializer);
+        }
     }
 
     public boolean isInitialized()
@@ -124,61 +127,6 @@ public class SidecarSchema
         {
             throw new IllegalStateException("Sidecar schema is not initialized!");
         }
-    }
-
-    protected synchronized void initialize(long timerId)
-    {
-        // it should not happen since the callback is only scheduled when isEnabled == true
-        if (!schemaKeyspaceConfiguration.isEnabled())
-        {
-            LOGGER.debug("Sidecar schema is not enabled");
-            return;
-        }
-
-        if (isInitialized())
-        {
-            LOGGER.debug("Sidecar schema is already initialized!");
-            cancelTimer(timerId);
-            return;
-        }
-
-        try
-        {
-            Session session = cqlSessionProvider.get();
-            isInitialized = sidecarInternalKeyspace.initialize(session, this::shouldCreateSchema);
-
-            if (isInitialized())
-            {
-                LOGGER.info("Sidecar schema is initialized");
-                cancelTimer(timerId);
-                reportSidecarSchemaInitialized();
-            }
-        }
-        catch (CassandraUnavailableException ignored)
-        {
-            LOGGER.debug("Cql session is not yet available. Skip initializing...");
-        }
-        catch (Exception ex)
-        {
-            LOGGER.warn("Failed to initialize schema", ex);
-            if (ex instanceof SidecarSchemaModificationException)
-            {
-                LOGGER.warn("Failed to modify schema", ex);
-                metrics.failedModifications.metric.update(1);
-            }
-            metrics.failedInitializations.metric.update(1);
-        }
-    }
-
-    protected synchronized void cancelTimer(long timerId)
-    {
-        // invalid timerId; nothing to cancel
-        if (timerId < 0)
-        {
-            return;
-        }
-        initializationTimerId.compareAndSet(timerId, -1L);
-        executorPools.internal().cancelTimer(timerId);
     }
 
     protected void reportSidecarSchemaInitialized()
@@ -202,5 +150,49 @@ public class SidecarSchema
             return clusterLease.isClaimedByLocalSidecar();
         }
         return true;
+    }
+
+    /**
+     * Initializer that retries until sidecar schema is initialized. Until then, it un-schedules itself.
+     */
+    private class SidecarSchemaInitializer implements PeriodicTask
+    {
+        @Override
+        public DurationSpec delay()
+        {
+            return INITIALIZATION_LOOP_DELAY;
+        }
+
+        @Override
+        public void execute(Promise<Void> promise)
+        {
+            try
+            {
+                Session session = cqlSessionProvider.get();
+                isInitialized = sidecarInternalKeyspace.initialize(session, SidecarSchema.this::shouldCreateSchema);
+
+                if (isInitialized())
+                {
+                    LOGGER.info("Sidecar schema is initialized");
+                    periodicTaskExecutor.unschedule(this);
+                    reportSidecarSchemaInitialized();
+                }
+            }
+            catch (CassandraUnavailableException ignored)
+            {
+                LOGGER.debug("Cql session is not yet available. Skip initializing...");
+            }
+            catch (Exception ex)
+            {
+                LOGGER.warn("Failed to initialize schema", ex);
+                if (ex instanceof SidecarSchemaModificationException)
+                {
+                    LOGGER.warn("Failed to modify schema", ex);
+                    metrics.failedModifications.metric.update(1);
+                }
+                metrics.failedInitializations.metric.update(1);
+            }
+            promise.tryComplete();
+        }
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SidecarSchema.java
@@ -57,7 +57,6 @@ public class SidecarSchema
     private final PeriodicTaskExecutor periodicTaskExecutor;
     private final SchemaKeyspaceConfiguration schemaKeyspaceConfiguration;
     private final SidecarInternalKeyspace sidecarInternalKeyspace;
-    private final AtomicBoolean initializerStarted = new AtomicBoolean(false);
     private final CQLSessionProvider cqlSessionProvider;
     private final SchemaMetrics metrics;
     private final ClusterLease clusterLease;
@@ -103,11 +102,8 @@ public class SidecarSchema
             return;
         }
 
-        // schedule one initializer exactly
-        if (initializerStarted.compareAndSet(false, true))
-        {
-            periodicTaskExecutor.schedule(new SidecarSchemaInitializer());
-        }
+        // periodicTaskExecutor guarantees there is one initializer scheduled exactly
+        periodicTaskExecutor.schedule(new SidecarSchemaInitializer());
     }
 
     public boolean isInitialized()
@@ -186,7 +182,7 @@ public class SidecarSchema
             catch (Exception ex)
             {
                 LOGGER.warn("Failed to initialize schema. Retry in {}", delay(), ex);
-                if (ex instanceof CassandraUnavailableException)
+                if (ex instanceof CassandraUnavailableException) // not quite expected here according to the schedule decision, but still check for it
                 {
                     return; // do not count Cassandra unavailable as failure
                 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/MainModule.java
@@ -783,7 +783,7 @@ public class MainModule extends AbstractModule
     @Provides
     @Singleton
     public SidecarSchema sidecarSchema(Vertx vertx,
-                                       ExecutorPools executorPools,
+                                       PeriodicTaskExecutor periodicTaskExecutor,
                                        SidecarInternalKeyspace sidecarInternalKeyspace,
                                        SidecarConfiguration configuration,
                                        CQLSessionProvider cqlSessionProvider,
@@ -804,7 +804,7 @@ public class MainModule extends AbstractModule
         sidecarInternalKeyspace.registerTableSchema(systemAuthSchema);
         sidecarInternalKeyspace.registerTableSchema(sidecarLeaseSchema);
         SchemaMetrics schemaMetrics = metrics.server().schema();
-        return new SidecarSchema(vertx, executorPools, configuration,
+        return new SidecarSchema(vertx, periodicTaskExecutor, configuration,
                                  sidecarInternalKeyspace, cqlSessionProvider, schemaMetrics, clusterLease);
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTaskExecutor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/tasks/PeriodicTaskExecutor.java
@@ -67,6 +67,8 @@ public class PeriodicTaskExecutor implements Closeable
 
     /**
      * Schedules the {@code task} iff it has not been scheduled yet.
+     * <p>A task is identified by the combination of its class name and the {@link PeriodicTask#name()}, see {@link PeriodicTaskKey}.
+     * There is one and exactly one task of the same identity can be scheduled.
      *
      * @param task the task to execute
      */

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -114,7 +114,7 @@ public class SidecarSchemaTest
     @Test
     void testSchemaInitOnStartup(VertxTestContext context)
     {
-        sidecarSchema.startSidecarSchemaInitializerMaybe();
+        sidecarSchema.maybeStartSidecarSchemaInitializer();
         context.verify(() -> {
             int maxWaitTime = 20; // about 10 seconds
             while (interceptedPrepStmts.size() < 10

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -114,7 +114,7 @@ public class SidecarSchemaTest
     @Test
     void testSchemaInitOnStartup(VertxTestContext context)
     {
-        sidecarSchema.startSidecarSchemaInitializer();
+        sidecarSchema.startSidecarSchemaInitializerMaybe();
         context.verify(() -> {
             int maxWaitTime = 20; // about 10 seconds
             while (interceptedPrepStmts.size() < 10

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -258,6 +258,7 @@ public class SidecarSchemaTest
                 return ps;
             });
             when(cqlSession.get()).thenReturn(session);
+            when(cqlSession.getIfConnected()).thenReturn(session);
             return cqlSession;
         }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/metrics/SchemaMetricsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/metrics/SchemaMetricsTest.java
@@ -47,6 +47,7 @@ import org.apache.cassandra.sidecar.db.schema.SidecarSchema;
 import org.apache.cassandra.sidecar.exceptions.SidecarSchemaModificationException;
 import org.apache.cassandra.sidecar.server.MainModule;
 import org.apache.cassandra.sidecar.server.Server;
+import org.apache.cassandra.sidecar.tasks.PeriodicTaskExecutor;
 
 import static org.apache.cassandra.sidecar.utils.TestMetricUtils.registry;
 import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
@@ -99,7 +100,7 @@ class SchemaMetricsTest
     @Test
     void testSchemaModificationFailure()
     {
-        sidecarSchema.startSidecarSchemaInitializer();
+        sidecarSchema.startSidecarSchemaInitializerMaybe();
         loopAssert(3, () -> {
             assertThat(metrics.server().schema().failedInitializations.metric.getValue())
             .isGreaterThanOrEqualTo(1);
@@ -124,7 +125,7 @@ class SchemaMetricsTest
         @Provides
         @Singleton
         public SidecarSchema sidecarSchema(Vertx vertx,
-                                           ExecutorPools executorPools,
+                                           PeriodicTaskExecutor periodicTaskExecutor,
                                            SidecarConfiguration configuration,
                                            CQLSessionProvider cqlSessionProvider,
                                            SidecarMetrics metrics)
@@ -134,7 +135,7 @@ class SchemaMetricsTest
             .thenThrow(new SidecarSchemaModificationException("Simulated failure",
                                                               new RuntimeException("Simulated exception")));
             SchemaMetrics schemaMetrics = metrics.server().schema();
-            return new SidecarSchema(vertx, executorPools, configuration,
+            return new SidecarSchema(vertx, periodicTaskExecutor, configuration,
                                      sidecarInternalKeyspace, cqlSessionProvider, schemaMetrics, null);
         }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/metrics/SchemaMetricsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/metrics/SchemaMetricsTest.java
@@ -118,6 +118,7 @@ class SchemaMetricsTest
             CQLSessionProvider cqlSession = mock(CQLSessionProvider.class);
             Session session = mock(Session.class);
             when(cqlSession.get()).thenReturn(session);
+            when(cqlSession.getIfConnected()).thenReturn(session);
             return cqlSession;
         }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/metrics/SchemaMetricsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/metrics/SchemaMetricsTest.java
@@ -38,7 +38,6 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
-import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.coordination.ClusterLease;
 import org.apache.cassandra.sidecar.db.SidecarSchemaTest;
@@ -100,7 +99,7 @@ class SchemaMetricsTest
     @Test
     void testSchemaModificationFailure()
     {
-        sidecarSchema.startSidecarSchemaInitializerMaybe();
+        sidecarSchema.maybeStartSidecarSchemaInitializer();
         loopAssert(3, () -> {
             assertThat(metrics.server().schema().failedInitializations.metric.getValue())
             .isGreaterThanOrEqualTo(1);


### PR DESCRIPTION
The patch defines a SidecarSchemaInitializer periodic task, which is guaranteed to run single-threaded. By doing so, the synchronizations and state checks can be all removed.

Patch by Yifan Cai; Reviewed by TBD for CASSSIDECAR-200