### PR TITLE
CASSSIDECAR-207: Upgrade Netty to 4.1.118.Final and Vert.x to 4.5.13 Version

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 1.0.0
 -----
+ * Upgrade Netty to 4.1.118.Final and Vert.x to 4.5.13 Version (CASSSIDECAR-207)
  * Fix missing field for INDEX_STATUS in GossipInfo (CASSSIDECAR-195)
  * Add feature level permissions to Sidecar (CASSSIDECAR-193)
  * Sidecar schema initialization can be executed on multiple thread (CASSSIDECAR-200)

--- a/client-common/build.gradle
+++ b/client-common/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compileOnly(group: 'org.slf4j', name: 'slf4j-api', version: "${project.slf4jVersion}")
     compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${project.jacksonVersion}")
     compileOnly(group: 'org.jetbrains', name: 'annotations', version: '23.0.0')
-    compileOnly(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
+    compileOnly(group: 'io.netty', name: 'netty-codec-http', version: "${project.nettyVersion}")
     compileOnly(group: 'com.google.guava', name: 'guava', version: "${project.guavaVersion}")
 
     testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${project.jacksonVersion}")
@@ -65,7 +65,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${project.junitVersion}")
     testImplementation("org.junit.jupiter:junit-jupiter-params:${project.junitVersion}")
-    testImplementation(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
+    testImplementation(group: 'io.netty', name: 'netty-codec-http', version: "${project.nettyVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}")
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -78,14 +78,14 @@ dependencies {
     implementation("org.slf4j:slf4j-api:${project.slf4jVersion}")
 
     compileOnly('org.jetbrains:annotations:23.0.0')
-    compileOnly(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
+    compileOnly(group: 'io.netty', name: 'netty-codec-http', version: "${project.nettyVersion}")
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation('org.mockito:mockito-core:4.10.0')
     testImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
-    testImplementation(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
+    testImplementation(group: 'io.netty', name: 'netty-codec-http', version: "${project.nettyVersion}")
 
     testFixturesImplementation(testFixtures(project(":client-common")))
     testFixturesImplementation(platform('org.junit:junit-bom:5.9.2'))
@@ -94,7 +94,7 @@ dependencies {
     testFixturesImplementation('org.mockito:mockito-core:4.10.0')
     testFixturesImplementation('com.squareup.okhttp3:mockwebserver:4.10.0')
     testFixturesImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${project.jacksonVersion}")
-    testFixturesCompileOnly(group: 'io.netty', name: 'netty-codec-http', version: '4.1.69.Final')
+    testFixturesCompileOnly(group: 'io.netty', name: 'netty-codec-http', version: "${project.nettyVersion}")
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,8 @@
 
 version=1.0-SNAPSHOT
 junitVersion=5.9.2
-vertxVersion=4.5.7
+vertxVersion=4.5.13
+nettyVersion=4.1.118.Final
 guavaVersion=27.0.1-jre
 slf4jVersion=1.7.36
 jacksonVersion=2.14.3

--- a/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/DataResourceScope.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/DataResourceScope.java
@@ -53,14 +53,8 @@ public class DataResourceScope implements ResourceScope
      */
     public static final String DATA_WITH_KEYSPACE = String.format("data/{%s}", KEYSPACE);
 
-    // TODO remove this hack once VariableAwareExpression bug is fixed
-    // VariableAwareExpression in vertx-auth-common package has a bug during String.substring() call, hence
-    // we cannot set resources that do not end in curly braces (e.g. data/keyspace/*) in
-    // PermissionBasedAuthorizationImpl or WildcardPermissionBasedAuthorizationImpl. data/{%s}/{TABLE_WILDCARD} treats
-    // TABLE_WILDCARD as a variable. This hack allows to read resource level permissions that could be set for all
-    // tables through data/<keyspace_name>/*. Bug should be fixed in 4.5.12
-    // Note: DATA_WITH_KEYSPACE_ALL_TABLES authorizes for all tables under the keyspace excluding the keyspace itself
-    public static final String DATA_WITH_KEYSPACE_ALL_TABLES = String.format("data/{%s}/{TABLE_WILDCARD}", KEYSPACE);
+    // DATA_WITH_KEYSPACE_ALL_TABLES authorizes for all tables under the keyspace excluding the keyspace itself
+    public static final String DATA_WITH_KEYSPACE_ALL_TABLES = String.format("data/{%s}/*", KEYSPACE);
 
     public static final String DATA_WITH_KEYSPACE_TABLE = String.format("data/{%s}/{%s}", KEYSPACE, TABLE);
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/routes/AccessProtectedRouteBuilder.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/routes/AccessProtectedRouteBuilder.java
@@ -208,14 +208,6 @@ public class AccessProtectedRouteBuilder
             {
                 authZContext.variables().add(TABLE, table);
             }
-
-            // TODO remove this hack once VariableAwareExpression bug is fixed
-            // VariableAwareExpression in vertx-auth-common package has a bug during String.substring() call, hence
-            // we cannot set resources that do not end in curly braces (e.g. data/keyspace/*) in
-            // PermissionBasedAuthorizationImpl or WildcardPermissionBasedAuthorizationImpl. hence we treat
-            // TABLE_WILDCARD as a variable and set it always. This hack allows to read
-            // resource level permissions that could be set for all tables through data/<keyspace_name>/*
-            authZContext.variables().add("TABLE_WILDCARD", "*");
         };
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/acl/authorization/ResourceScopeTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/acl/authorization/ResourceScopeTest.java
@@ -80,7 +80,7 @@ class ResourceScopeTest
         assertThat(TABLE_SCOPE.expandedResources()).hasSize(4)
                                                    .contains("data",
                                                              "data/{keyspace}",
-                                                             "data/{keyspace}/{TABLE_WILDCARD}",
+                                                             "data/{keyspace}/*",
                                                              "data/{keyspace}/{table}");
     }
 


### PR DESCRIPTION
Netty released 4.1.118.Final https://netty.io/news/2025/02/10/4-1-118-Final.html with critical CVE fix and Vert.x released 4.5.13 with Netty upgrade. This patch upgrades Netty version to 4.1.118.Final and Vert.x version to 4.5.13 in Sidecar. With Vert.x 4.5.13 version, a bug fix for vert.x auth package was also released. We integrate the bug fix as well. 