### PR TITLE
CASSSIDECAR-209: HealthCheckPeriodicTask leak in Sidecar

### DIFF
--- a/scripts/build-dtest-jars.sh
+++ b/scripts/build-dtest-jars.sh
@@ -20,7 +20,7 @@
 set -xe
 CANDIDATE_BRANCHES=(
   "cassandra-4.0:64b8d6b9add607b80752cd1a8fbce51839af9ec4"
-  "cassandra-4.1:eff82685e2c893999a009efc0e1d73f1ad390087"
+  "cassandra-4.1:044727aabafeab2f6fef74c52d349d55c8732ef5"
   "cassandra-5.0:a0d58a9ce8814d096c1bd8a0440e8e28d8ea15a9"
   # note the trunk hash cannot be advanced beyond ae0842372ff6dd1437d026f82968a3749f555ff4 (TCM), which breaks integration test
   "trunk:2a5e1b77c9f8a205dbec1afdea3f4ed1eaf6a4eb"
@@ -30,6 +30,7 @@ echo ${BRANCHES[*]}
 REPO=${REPO:-"https://github.com/apache/cassandra.git"}
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
 DTEST_JAR_DIR="$(dirname "${SCRIPT_DIR}/")/dtest-jars"
+DTEST_JAR_DIR=${CASSANDRA_DEP_DIR:-$DTEST_JAR_DIR}
 BUILD_DIR="${DTEST_JAR_DIR}/build"
 
 if [[ "x$CLEAN" != "x" ]]; then

--- a/scripts/build-shaded-dtest-jar-local.sh
+++ b/scripts/build-shaded-dtest-jar-local.sh
@@ -26,7 +26,7 @@ CASSANDRA_VERSION=$(cat build.xml | grep 'property name="base.version"' | awk -F
 GIT_HASH=$(git rev-parse --short HEAD)
 DTEST_ARTIFACT_ID=${ARTIFACT_NAME}-local
 DTEST_JAR_DIR="$(dirname "${SCRIPT_DIR}/")/dtest-jars"
-
+DTEST_JAR_DIR=${CASSANDRA_DEP_DIR:-$DTEST_JAR_DIR}
 echo "${CASSANDRA_VERSION}"
 echo "${GIT_HASH}"
 echo "${DTEST_ARTIFACT_ID}"

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/Server.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/Server.java
@@ -303,11 +303,10 @@ public class Server
      */
     protected Future<String> scheduleInternalPeriodicTasks(String deploymentId)
     {
-        HealthCheckPeriodicTask healthCheckPeriodicTask = new HealthCheckPeriodicTask(
-        sidecarConfiguration,
-                                                                   instancesMetadata,
-                                                                   executorPools,
-                                                                   metrics);
+        HealthCheckPeriodicTask healthCheckPeriodicTask = new HealthCheckPeriodicTask(sidecarConfiguration,
+                                                                                      instancesMetadata,
+                                                                                      executorPools,
+                                                                                      metrics);
         periodicTaskExecutor.schedule(healthCheckPeriodicTask);
         vertx.eventBus().localConsumer(ON_SERVER_STOP.address(), message ->
                                                                  periodicTaskExecutor.unschedule(healthCheckPeriodicTask));

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/Server.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/Server.java
@@ -62,6 +62,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_ALL_CASSANDRA_CQL_READY;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CASSANDRA_CQL_READY;
+import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
 
 /**
  * The Sidecar {@link Server} class that manages the start and stop lifecycle of the service
@@ -302,11 +303,15 @@ public class Server
      */
     protected Future<String> scheduleInternalPeriodicTasks(String deploymentId)
     {
-        periodicTaskExecutor.schedule(new HealthCheckPeriodicTask(vertx,
-                                                                  sidecarConfiguration,
-                                                                  instancesMetadata,
-                                                                  executorPools,
-                                                                  metrics));
+        HealthCheckPeriodicTask healthCheckPeriodicTask = new HealthCheckPeriodicTask(
+        sidecarConfiguration,
+                                                                   instancesMetadata,
+                                                                   executorPools,
+                                                                   metrics);
+        periodicTaskExecutor.schedule(healthCheckPeriodicTask);
+        vertx.eventBus().localConsumer(ON_SERVER_STOP.address(), message ->
+                                                                 periodicTaskExecutor.unschedule(healthCheckPeriodicTask));
+
         maybeScheduleKeyStoreCheckPeriodicTask();
 
         MessageConsumer<JsonObject> cqlReadyConsumer = vertx.eventBus().localConsumer(ON_CASSANDRA_CQL_READY.address());

--- a/server/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTask.java
@@ -27,8 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.EventBus;
 import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
@@ -39,37 +37,26 @@ import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.metrics.HealthMetrics;
 import org.apache.cassandra.sidecar.metrics.SidecarMetrics;
 
-import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
-
 /**
  * Periodically checks the health of every instance configured in the {@link InstancesMetadata}.
  */
 public class HealthCheckPeriodicTask implements PeriodicTask
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckPeriodicTask.class);
-    private final EventBus eventBus;
     private final PeriodicTaskConfiguration configuration;
     private final InstancesMetadata instancesMetadata;
     private final TaskExecutorPool internalPool;
     private final HealthMetrics metrics;
 
-    public HealthCheckPeriodicTask(Vertx vertx,
-                                   SidecarConfiguration configuration,
+    public HealthCheckPeriodicTask(SidecarConfiguration configuration,
                                    InstancesMetadata instancesMetadata,
                                    ExecutorPools executorPools,
                                    SidecarMetrics metrics)
     {
-        eventBus = vertx.eventBus();
         this.configuration = configuration.healthCheckConfiguration();
         this.instancesMetadata = instancesMetadata;
         this.internalPool = executorPools.internal();
         this.metrics = metrics.server().health();
-    }
-
-    @Override
-    public void registerPeriodicTaskExecutor(PeriodicTaskExecutor executor)
-    {
-        eventBus.localConsumer(ON_SERVER_STOP.address(), message -> executor.unschedule(this));
     }
 
     @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/tasks/HealthCheckPeriodicTaskTest.java
@@ -84,7 +84,7 @@ class HealthCheckPeriodicTaskTest
         InstanceMetadataFetcher mockInstanceMetadataFetcher = mock(InstanceMetadataFetcher.class);
         metrics = new SidecarMetricsImpl(mockRegistryFactory, mockInstanceMetadataFetcher);
         ExecutorPools executorPools = new ExecutorPools(vertx, new ServiceConfigurationImpl());
-        healthCheck = new HealthCheckPeriodicTask(vertx, mockConfiguration, mockInstancesMetadata,
+        healthCheck = new HealthCheckPeriodicTask(mockConfiguration, mockInstancesMetadata,
                                                   executorPools, metrics);
     }
 


### PR DESCRIPTION
Also fixes a minor build script issue where dtest jars could not be found if using the CASSANDRA_DEP_DIR environment variable to centralize dtest jars across projects (the shell scripts didn't honor it but the gradle build tried to).