### PR TITLE
CASSSIDECAR-235 Improvements to CDCConfig classes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.2.0
 -----
+ * Improvements to CDCConfig classes (CASSSIDECAR-235)
  * Hot Reload client and server SSL certificates (CASSSIDECAR-228)
  * Enhance the Cluster Lease Claim task feature (CASSSIDECAR-232)
  * Capture Metrics for Schema Reporting (CASSSIDECAR-216)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcConfigImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcConfigImpl.java
@@ -39,6 +39,7 @@ import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfigur
 import org.apache.cassandra.sidecar.common.server.utils.MinuteBoundConfiguration;
 import org.apache.cassandra.sidecar.config.CdcConfiguration;
 import org.apache.cassandra.sidecar.config.SchemaKeyspaceConfiguration;
+import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.db.CdcConfigAccessor;
 import org.apache.cassandra.sidecar.db.KafkaConfigAccessor;
 import org.apache.cassandra.sidecar.tasks.PeriodicTask;
@@ -70,14 +71,13 @@ public class CdcConfigImpl implements CdcConfig
     private volatile Map<String, String> cdcConfigMappings = Map.of();
 
     @Inject
-    public CdcConfigImpl(CdcConfiguration cdcConfiguration,
-                         SchemaKeyspaceConfiguration schemaKeyspaceConfiguration,
+    public CdcConfigImpl(SidecarConfiguration sidecarConfiguration,
                          CdcConfigAccessor cdcConfigAccessor,
                          KafkaConfigAccessor kafkaConfigAccessor,
                          PeriodicTaskExecutor periodicTaskExecutor)
     {
-        this.schemaKeyspaceConfiguration = schemaKeyspaceConfiguration;
-        this.cdcConfiguration = cdcConfiguration;
+        this.schemaKeyspaceConfiguration = sidecarConfiguration.serviceConfiguration().schemaKeyspaceConfiguration();
+        this.cdcConfiguration = sidecarConfiguration.serviceConfiguration().cdcConfiguration();
         this.cdcConfigAccessor = cdcConfigAccessor;
         this.kafkaConfigAccessor = kafkaConfigAccessor;
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/CdcConfigAccessor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/CdcConfigAccessor.java
@@ -39,8 +39,8 @@ public class CdcConfigAccessor extends ConfigAccessorImpl
     }
 
     @Override
-    public Service service()
+    public String service()
     {
-        return Service.CDC;
+        return Service.CDC.serviceName;
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/ConfigAccessorImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/ConfigAccessorImpl.java
@@ -26,7 +26,6 @@ import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 
-import org.apache.cassandra.sidecar.common.request.Service;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
 import org.apache.cassandra.sidecar.db.schema.ConfigsSchema;
 import org.apache.cassandra.sidecar.db.schema.SidecarSchema;
@@ -39,7 +38,7 @@ import org.apache.cassandra.sidecar.db.schema.SidecarSchema;
 public abstract class ConfigAccessorImpl extends DatabaseAccessor<ConfigsSchema> implements ConfigAccessor
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigAccessorImpl.class);
-    private final Service service = service();
+    private final String serviceName = service();
     private final SidecarSchema sidecarSchema;
 
     protected ConfigAccessorImpl(CQLSessionProvider sessionProvider,
@@ -49,18 +48,18 @@ public abstract class ConfigAccessorImpl extends DatabaseAccessor<ConfigsSchema>
         this.sidecarSchema = sidecarSchema;
     }
 
-    public abstract Service service();
+    public abstract String service();
 
     @Override
     public ServiceConfig getConfig()
     {
         sidecarSchema.ensureInitialized();
         BoundStatement statement = tableSchema.selectConfig()
-                                              .bind(service.serviceName);
+                                              .bind(serviceName);
         Row row = execute(statement).one();
         if (row == null || row.isNull(0))
         {
-            LOGGER.debug(String.format("No %s configs are present in the table Cassandra table", service.serviceName));
+            LOGGER.debug("No {} configs are present in the table Cassandra table", serviceName);
             return new ServiceConfig(Map.of());
         }
         return ServiceConfig.from(row);
@@ -71,7 +70,7 @@ public abstract class ConfigAccessorImpl extends DatabaseAccessor<ConfigsSchema>
     {
         sidecarSchema.ensureInitialized();
         BoundStatement statement = tableSchema.insertConfig()
-                                              .bind(service.serviceName, config);
+                                              .bind(serviceName, config);
         execute(statement);
         return new ServiceConfig(config);
     }
@@ -81,7 +80,7 @@ public abstract class ConfigAccessorImpl extends DatabaseAccessor<ConfigsSchema>
     {
         sidecarSchema.ensureInitialized();
         BoundStatement statement = tableSchema.insertConfigIfNotExists()
-                                              .bind(service.serviceName, config);
+                                              .bind(serviceName, config);
         ResultSet resultSet = execute(statement);
         if (resultSet.wasApplied())
         {
@@ -95,7 +94,7 @@ public abstract class ConfigAccessorImpl extends DatabaseAccessor<ConfigsSchema>
     {
         sidecarSchema.ensureInitialized();
         BoundStatement deleteStatement = tableSchema.deleteConfig()
-                                                    .bind(service.serviceName);
+                                                    .bind(serviceName);
         execute(deleteStatement);
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/KafkaConfigAccessor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/KafkaConfigAccessor.java
@@ -39,8 +39,8 @@ public class KafkaConfigAccessor extends ConfigAccessorImpl
     }
 
     @Override
-    public Service service()
+    public String service()
     {
-        return Service.KAFKA;
+        return Service.KAFKA.serviceName;
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcConfigImplTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcConfigImplTest.java
@@ -31,6 +31,7 @@ import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfigur
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.CdcConfiguration;
 import org.apache.cassandra.sidecar.config.SchemaKeyspaceConfiguration;
+import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.config.yaml.ServiceConfigurationImpl;
 import org.apache.cassandra.sidecar.coordination.ClusterLease;
 import org.apache.cassandra.sidecar.db.CdcConfigAccessor;
@@ -80,7 +81,7 @@ class CdcConfigImplTest
         when(cdcConfigAccessor.isAvailable()).thenReturn(false);
 
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(mockCdcConfiguration(), mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         assertThat(cdcConfig.isConfigReady()).isFalse();
     }
 
@@ -91,7 +92,7 @@ class CdcConfigImplTest
         KafkaConfigAccessor kafkaConfigAccessor = mockKafkaConfigAccessor();
         when(cdcConfigAccessor.getConfig().getConfigs()).thenReturn(Map.of("k1", "v1"));
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(mockCdcConfiguration(), mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         assertThat(cdcConfig.isConfigReady()).isFalse();
     }
 
@@ -102,7 +103,7 @@ class CdcConfigImplTest
         KafkaConfigAccessor kafkaConfigAccessor = mockKafkaConfigAccessor();
         when(cdcConfigAccessor.getConfig().getConfigs()).thenReturn(Map.of("k1", "v1"));
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(mockCdcConfiguration(), mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         assertThat(cdcConfig.isConfigReady()).isFalse();
     }
 
@@ -112,7 +113,7 @@ class CdcConfigImplTest
         CdcConfigAccessor cdcConfigAccessor = mockCdcConfigAccessor();
         KafkaConfigAccessor kafkaConfigAccessor = mockKafkaConfigAccessor();
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(mockCdcConfiguration(), mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         assertThat(cdcConfig.datacenter()).isEqualTo(null);
         assertThat(cdcConfig.env()).isEqualTo("");
         assertThat(cdcConfig.kafkaTopic()).isNull();
@@ -130,7 +131,7 @@ class CdcConfigImplTest
                 .thenReturn(Map.of("k1", "v1"));
 
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(mockCdcConfiguration(), mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         loopAssert(5, ()-> assertThat(cdcConfig.isConfigReady()).isTrue());
         assertThat(cdcConfig.datacenter()).isEqualTo("DC1");
         assertThat(cdcConfig.env()).isEqualTo("if");
@@ -150,7 +151,7 @@ class CdcConfigImplTest
         when(kafkaConfigAccessor.getConfig().getConfigs()).thenReturn(Map.of("topic", "topic1"));
 
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(mockCdcConfiguration(), mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         cdcConfig.registerConfigChangeListener(listener);
 
         // do not wait the periodic task execution, we force running it immediately.
@@ -188,7 +189,7 @@ class CdcConfigImplTest
         when(cdcConfiguration.isEnabled()).thenReturn(false);
 
         CdcConfigImpl cdcConfig =
-                new CdcConfigImpl(cdcConfiguration, mockSchemaKeyspaceConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
+                new CdcConfigImpl(mockSidecarConfiguration(), cdcConfigAccessor, kafkaConfigAccessor, executor);
         assertThat(cdcConfig.configRefreshNotifier().scheduleDecision())
                 .isEqualTo(ScheduleDecision.SKIP)
                 .describedAs("When sidecarSchema is enabled but cdc is disabled, the refresh notifier should skip");
@@ -223,6 +224,14 @@ class CdcConfigImplTest
         SchemaKeyspaceConfiguration schemaKeyspaceConfiguration = mock(SchemaKeyspaceConfiguration.class);
         when(schemaKeyspaceConfiguration.isEnabled()).thenReturn(true);
         return schemaKeyspaceConfiguration;
+    }
+
+    private SidecarConfiguration mockSidecarConfiguration()
+    {
+        SidecarConfiguration sidecarConfiguration = mock(SidecarConfiguration.class, RETURNS_DEEP_STUBS);
+        when(sidecarConfiguration.serviceConfiguration().cdcConfiguration()).thenAnswer(invocation -> mockCdcConfiguration());
+        when(sidecarConfiguration.serviceConfiguration().schemaKeyspaceConfiguration()).thenAnswer(invocation -> mockSchemaKeyspaceConfiguration());
+        return sidecarConfiguration;
     }
 
     private ThrowingRunnable mockRunnable()


### PR DESCRIPTION
Following changes are included in the patch
1. CdcConfigImpl should use SidecarConfiguration instead of CdcConfigAccessor & KafkaConfigAccessor separately in constructor
2. Make `CdcConfigAccessor.service()` return String to make `ConfigAccessorImpl` more extendible. 