### PR TITLE
CASSSIDECAR-224 Enhancing Sidecar Client to download files for Live Migration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.2.0
 -----
+ * Enhanced Sidecarclient to list Cassandra instance files and to download them for Live Migration (CASSSIDECAR-224)
  * Fix CdcRawDirectorySpaceCleaner (CASSSIDECAR-267)
  * Add API that allows downloading of files listed by Live Migration (CASSSIDECAR-223)
  * Fixing settings endpoint should return Service Unavailable when Cassandra instance is down (CASSSIDECAR-264)

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/DownloadableRequest.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/DownloadableRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.request;
+
+/**
+ * A request that downloads a file.
+ */
+public interface DownloadableRequest
+{
+    /**
+     * @return the full path to the destination of the file on disk
+     */
+    String destinationPath();
+}

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/LiveMigrationListInstanceFilesRequest.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/LiveMigrationListInstanceFilesRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.request;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.cassandra.sidecar.common.response.InstanceFilesListResponse;
+
+import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.LIVE_MIGRATION_FILES_API;
+
+/**
+ * Request class for Live Migration list instance files.
+ */
+public class LiveMigrationListInstanceFilesRequest extends JsonRequest<InstanceFilesListResponse>
+{
+    /**
+     * Constructs a decodable request.
+     */
+    public LiveMigrationListInstanceFilesRequest()
+    {
+        super(LIVE_MIGRATION_FILES_API);
+    }
+
+    @Override
+    public HttpMethod method()
+    {
+        return HttpMethod.GET;
+    }
+}

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/StreamFileRequest.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/StreamFileRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.request;
+
+import io.netty.handler.codec.http.HttpMethod;
+
+/**
+ * Request to stream a file from remote.
+ */
+public class StreamFileRequest extends Request implements DownloadableRequest
+{
+    private final String destinationPath;
+
+    /**
+     * Constructs a Sidecar request with the given {@code requestURI}. Defaults to {@code ssl} enabled.
+     *
+     * @param requestURI      the URI of the request
+     * @param destinationPath the full path to the destination of the file on disk
+     */
+    public StreamFileRequest(String requestURI, String destinationPath)
+    {
+        super(requestURI);
+        this.destinationPath = destinationPath;
+    }
+
+    @Override
+    public HttpMethod method()
+    {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String destinationPath()
+    {
+        return destinationPath;
+    }
+}

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
@@ -917,13 +917,12 @@ public class SidecarClient implements AutoCloseable, SidecarClientBlobRestoreExt
      * @param targetFilePath destination file path to save file coming from remote
      * @return a CompletableFuture representing the completion of the operation
      */
-    public CompletableFuture<Boolean> liveMigrationStreamFileAsync(SidecarInstance instance, String reqPath, String targetFilePath)
+    public CompletableFuture<Void> liveMigrationStreamFileAsync(SidecarInstance instance, String reqPath, String targetFilePath)
     {
         return executor.executeRequestAsync(requestBuilder().singleInstanceSelectionPolicy(instance)
                                                             .request(new StreamFileRequest(reqPath, targetFilePath))
                                                             .retryPolicy(new LiveMigrationDownloadRetryPolicy(defaultRetryPolicy, targetFilePath))
-                                                            .build())
-                       .thenApply(v -> true);
+                                                            .build());
     }
 
     /**

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.cassandra.sidecar.client.retry.CreateRestoreJobRetryPolicy;
 import org.apache.cassandra.sidecar.client.retry.IgnoreConflictRetryPolicy;
+import org.apache.cassandra.sidecar.client.retry.LiveMigrationDownloadRetryPolicy;
 import org.apache.cassandra.sidecar.client.retry.OncePerInstanceRetryPolicy;
 import org.apache.cassandra.sidecar.client.retry.RetryPolicy;
 import org.apache.cassandra.sidecar.client.retry.RunnableOnStatusCodeRetryPolicy;
@@ -43,10 +44,12 @@ import org.apache.cassandra.sidecar.common.request.CreateRestoreJobSliceRequest;
 import org.apache.cassandra.sidecar.common.request.DeleteServiceConfigRequest;
 import org.apache.cassandra.sidecar.common.request.ImportSSTableRequest;
 import org.apache.cassandra.sidecar.common.request.ListCdcSegmentsRequest;
+import org.apache.cassandra.sidecar.common.request.LiveMigrationListInstanceFilesRequest;
 import org.apache.cassandra.sidecar.common.request.RestoreJobProgressRequest;
 import org.apache.cassandra.sidecar.common.request.RestoreJobSummaryRequest;
 import org.apache.cassandra.sidecar.common.request.Service;
 import org.apache.cassandra.sidecar.common.request.StreamCdcSegmentRequest;
+import org.apache.cassandra.sidecar.common.request.StreamFileRequest;
 import org.apache.cassandra.sidecar.common.request.UpdateRestoreJobRequest;
 import org.apache.cassandra.sidecar.common.request.UpdateServiceConfigRequest;
 import org.apache.cassandra.sidecar.common.request.data.AbortRestoreJobRequestPayload;
@@ -61,6 +64,7 @@ import org.apache.cassandra.sidecar.common.request.data.UpdateRestoreJobRequestP
 import org.apache.cassandra.sidecar.common.response.ConnectedClientStatsResponse;
 import org.apache.cassandra.sidecar.common.response.GossipInfoResponse;
 import org.apache.cassandra.sidecar.common.response.HealthResponse;
+import org.apache.cassandra.sidecar.common.response.InstanceFilesListResponse;
 import org.apache.cassandra.sidecar.common.response.ListCdcSegmentsResponse;
 import org.apache.cassandra.sidecar.common.response.ListOperationalJobsResponse;
 import org.apache.cassandra.sidecar.common.response.ListSnapshotFilesResponse;
@@ -888,6 +892,38 @@ public class SidecarClient implements AutoCloseable, SidecarClientBlobRestoreExt
     public <T> CompletableFuture<T> executeRequestAsync(RequestContext context)
     {
         return executor.executeRequestAsync(context);
+    }
+
+    /**
+     * Gets list of files available at a Cassandra Instance using Sidecar during Live Migration.
+     *
+     * @param instance Sidecar instance where the request will be executed
+     * @return a CompletableFuture representing the completion of the operation
+     */
+    public CompletableFuture<InstanceFilesListResponse> liveMigrationListInstanceFilesAsync(SidecarInstance instance)
+    {
+        return executor.executeRequestAsync(requestBuilder().singleInstanceSelectionPolicy(instance)
+                                                            .request(new LiveMigrationListInstanceFilesRequest())
+                                                            .build());
+    }
+
+
+    /**
+     * Downloads requested file {@code reqPath} to the destination file provided with param {@code targetFile}
+     * during Live Migration.
+     *
+     * @param instance       the instance where the request will be executed
+     * @param reqPath        instance file path to copy
+     * @param targetFilePath destination file path to save file coming from remote
+     * @return a CompletableFuture representing the completion of the operation
+     */
+    public CompletableFuture<Boolean> liveMigrationStreamFileAsync(SidecarInstance instance, String reqPath, String targetFilePath)
+    {
+        return executor.executeRequestAsync(requestBuilder().singleInstanceSelectionPolicy(instance)
+                                                            .request(new StreamFileRequest(reqPath, targetFilePath))
+                                                            .retryPolicy(new LiveMigrationDownloadRetryPolicy(defaultRetryPolicy, targetFilePath))
+                                                            .build())
+                       .thenApply(v -> true);
     }
 
     /**

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/retry/LiveMigrationDownloadRetryPolicy.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/retry/LiveMigrationDownloadRetryPolicy.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.client.retry;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.cassandra.sidecar.client.HttpResponse;
+import org.apache.cassandra.sidecar.common.request.Request;
+
+/**
+ * A retry policy to handle status codes returned from Sidecar server when downloading a file for Live Migration.
+ */
+public class LiveMigrationDownloadRetryPolicy extends RetryPolicy
+{
+    private final RetryPolicy delegate;
+    private final String destinationPath;
+
+    public LiveMigrationDownloadRetryPolicy(RetryPolicy delegate, String destinationPath)
+    {
+        this.delegate = delegate;
+        this.destinationPath = destinationPath;
+    }
+
+    @Override
+    public void onResponse(CompletableFuture<HttpResponse> responseFuture,
+                           Request request,
+                           HttpResponse response,
+                           Throwable throwable,
+                           int attempts,
+                           boolean canRetryOnADifferentHost,
+                           RetryAction retryAction)
+    {
+        if (response != null)
+        {
+            if (response.statusCode() == HttpResponseStatus.OK.code())
+            {
+                logger.debug("Successfully downloaded file={}", destinationPath);
+                responseFuture.complete(response);
+                return;
+            }
+            else if (response.statusCode() == HttpResponseStatus.NOT_FOUND.code()
+                     || response.statusCode() == HttpResponseStatus.REQUESTED_RANGE_NOT_SATISFIABLE.code())
+            {
+                // 404 -  FILE NOT FOUND means file does not exist in remote
+                // and no need to download file, hence considering it as success.
+                // 416 -  RANGE NOT SATISFIABLE thrown by sidecar when file
+                // of size length zero is requested.
+                logger.info("File not found at URI={}", request.requestURI());
+                responseFuture.complete(response);
+                return;
+            }
+        }
+        delegate.onResponse(responseFuture, request, response, throwable, attempts, canRetryOnADifferentHost,
+                            retryAction);
+    }
+}

--- a/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
+++ b/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
@@ -78,6 +78,8 @@ import org.apache.cassandra.sidecar.common.request.data.XXHash32Digest;
 import org.apache.cassandra.sidecar.common.response.ConnectedClientStatsResponse;
 import org.apache.cassandra.sidecar.common.response.GossipInfoResponse;
 import org.apache.cassandra.sidecar.common.response.HealthResponse;
+import org.apache.cassandra.sidecar.common.response.InstanceFileInfo;
+import org.apache.cassandra.sidecar.common.response.InstanceFilesListResponse;
 import org.apache.cassandra.sidecar.common.response.ListCdcSegmentsResponse;
 import org.apache.cassandra.sidecar.common.response.ListOperationalJobsResponse;
 import org.apache.cassandra.sidecar.common.response.ListSnapshotFilesResponse;
@@ -105,10 +107,13 @@ import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.PARTIAL_CONTENT;
 import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.JOB_ID_PATH_PARAM;
 import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.KEYSPACE_PATH_PARAM;
+import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.LIVE_MIGRATION_FILES_API;
 import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.OPERATIONAL_JOB_ID_PATH_PARAM;
 import static org.apache.cassandra.sidecar.common.ApiEndpointsV1.TABLE_PATH_PARAM;
 import static org.apache.cassandra.sidecar.common.http.SidecarHttpHeaderNames.CONTENT_XXHASH32;
 import static org.apache.cassandra.sidecar.common.http.SidecarHttpHeaderNames.CONTENT_XXHASH32_SEED;
+import static org.apache.cassandra.sidecar.common.response.InstanceFileInfo.FileType.DIRECTORY;
+import static org.apache.cassandra.sidecar.common.response.InstanceFileInfo.FileType.FILE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -1809,6 +1814,90 @@ abstract class SidecarClientTest
             String requestBody = request.getBody().readUtf8();
             assertThat(requestBody).isEqualTo("{\"state\":\"stop\"}");
         });
+    }
+
+    @Test
+    public void testLiveMigrationListInstanceFiles() throws ExecutionException, InterruptedException, JsonProcessingException
+    {
+        List<InstanceFileInfo> fileInfoList = Arrays.asList(new InstanceFileInfo("commit-log1", 100, FILE, System.currentTimeMillis()),
+                                                            new InstanceFileInfo("commit-log2", 100, DIRECTORY, System.currentTimeMillis()));
+        InstanceFilesListResponse filesListResponse = new InstanceFilesListResponse(fileInfoList);
+        ObjectMapper mapper = new ObjectMapper();
+
+        MockResponse response = new MockResponse();
+        response.setResponseCode(200);
+        response.setHeader("content-type", "application/json");
+        response.setBody(mapper.writeValueAsString(filesListResponse));
+        enqueue(response);
+
+        SidecarInstance instance = instances.get(0);
+        InstanceFilesListResponse result = client.liveMigrationListInstanceFilesAsync(instance).get();
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(filesListResponse);
+        validateResponseServed(ApiEndpointsV1.LIVE_MIGRATION_FILES_API);
+    }
+
+    @Test
+    public void testLiveMigrationStreamFileAsync(@TempDir Path tempDirectory) throws ExecutionException, InterruptedException, IOException
+    {
+        String dummyFileContent = "Some dummy file content";
+        MockResponse response = new MockResponse();
+        response.setResponseCode(200);
+        response.setHeader("content-type", "application/text");
+        response.setBody(dummyFileContent);
+        enqueue(response);
+
+        Path filePath = tempDirectory.resolve("test_file.txt");
+        SidecarInstance instance = instances.get(0);
+        String fileUrl = LIVE_MIGRATION_FILES_API + "/data/0/test_file.text";
+
+        Boolean result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString()).get();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isTrue();
+        assertThat(Files.exists(filePath)).isTrue();
+        assertThat(new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8)).isEqualTo(dummyFileContent);
+        validateResponseServed(fileUrl);
+    }
+
+    @Test
+    public void testLiveMigrationStreamFileAsyncFileNotFound(@TempDir Path tempDirectory) throws ExecutionException, InterruptedException
+    {
+        MockResponse response = new MockResponse();
+        response.setResponseCode(404);
+        enqueue(response);
+
+        Path filePath = tempDirectory.resolve("test_file.txt");
+        SidecarInstance instance = instances.get(0);
+        String fileUrl = LIVE_MIGRATION_FILES_API + "/data/0/test_file.text";
+
+        Boolean result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString()).get();
+
+        assertThat(result).isNotNull();
+        assertThat(result).isTrue(); // File not found is treated as success for LiveMigration
+        assertThat(Files.exists(filePath)).isFalse();
+        validateResponseServed(fileUrl);
+    }
+
+    @Test
+    public void testLiveMigrationStreamFileAsyncBadRequest(@TempDir Path tempDirectory) throws InterruptedException
+    {
+        MockResponse response = new MockResponse();
+        response.setResponseCode(400);
+        enqueue(response);
+
+        Path filePath = tempDirectory.resolve("test_file.txt");
+        SidecarInstance instance = instances.get(0);
+        String fileUrl = LIVE_MIGRATION_FILES_API + "/data/0/test_file.text";
+
+        CompletableFuture<Boolean> result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString());
+
+        assertThatExceptionOfType(ExecutionException.class).isThrownBy(result::get);
+        assertThat(result).isNotNull();
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.isCompletedExceptionally()).isTrue();
+        assertThat(Files.exists(filePath)).isFalse();
+        validateResponseServed(fileUrl);
     }
 
     private void enqueue(MockResponse response)

--- a/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
+++ b/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
@@ -1817,7 +1817,7 @@ abstract class SidecarClientTest
     }
 
     @Test
-    public void testLiveMigrationListInstanceFiles() throws ExecutionException, InterruptedException, JsonProcessingException
+    void testLiveMigrationListInstanceFiles() throws ExecutionException, InterruptedException, JsonProcessingException
     {
         List<InstanceFileInfo> fileInfoList = Arrays.asList(new InstanceFileInfo("commit-log1", 100, FILE, System.currentTimeMillis()),
                                                             new InstanceFileInfo("commit-log2", 100, DIRECTORY, System.currentTimeMillis()));
@@ -1838,7 +1838,7 @@ abstract class SidecarClientTest
     }
 
     @Test
-    public void testLiveMigrationStreamFileAsync(@TempDir Path tempDirectory) throws ExecutionException, InterruptedException, IOException
+    void testLiveMigrationStreamFileAsync(@TempDir Path tempDirectory) throws ExecutionException, InterruptedException, IOException
     {
         String dummyFileContent = "Some dummy file content";
         MockResponse response = new MockResponse();
@@ -1851,17 +1851,15 @@ abstract class SidecarClientTest
         SidecarInstance instance = instances.get(0);
         String fileUrl = LIVE_MIGRATION_FILES_API + "/data/0/test_file.text";
 
-        Boolean result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString()).get();
+        client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString()).get();
 
-        assertThat(result).isNotNull();
-        assertThat(result).isTrue();
         assertThat(Files.exists(filePath)).isTrue();
         assertThat(new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8)).isEqualTo(dummyFileContent);
         validateResponseServed(fileUrl);
     }
 
     @Test
-    public void testLiveMigrationStreamFileAsyncFileNotFound(@TempDir Path tempDirectory) throws ExecutionException, InterruptedException
+    void testLiveMigrationStreamFileAsyncFileNotFound(@TempDir Path tempDirectory) throws ExecutionException, InterruptedException
     {
         MockResponse response = new MockResponse();
         response.setResponseCode(404);
@@ -1871,16 +1869,14 @@ abstract class SidecarClientTest
         SidecarInstance instance = instances.get(0);
         String fileUrl = LIVE_MIGRATION_FILES_API + "/data/0/test_file.text";
 
-        Boolean result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString()).get();
+        client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString()).get();
 
-        assertThat(result).isNotNull();
-        assertThat(result).isTrue(); // File not found is treated as success for LiveMigration
         assertThat(Files.exists(filePath)).isFalse();
         validateResponseServed(fileUrl);
     }
 
     @Test
-    public void testLiveMigrationStreamFileAsyncBadRequest(@TempDir Path tempDirectory) throws InterruptedException
+    void testLiveMigrationStreamFileAsyncBadRequest(@TempDir Path tempDirectory) throws InterruptedException
     {
         MockResponse response = new MockResponse();
         response.setResponseCode(400);
@@ -1890,11 +1886,9 @@ abstract class SidecarClientTest
         SidecarInstance instance = instances.get(0);
         String fileUrl = LIVE_MIGRATION_FILES_API + "/data/0/test_file.text";
 
-        CompletableFuture<Boolean> result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString());
+        CompletableFuture<Void> result = client.liveMigrationStreamFileAsync(instance, fileUrl, filePath.toString());
 
         assertThatExceptionOfType(ExecutionException.class).isThrownBy(result::get);
-        assertThat(result).isNotNull();
-        assertThat(result.isDone()).isTrue();
         assertThat(result.isCompletedExceptionally()).isTrue();
         assertThat(Files.exists(filePath)).isFalse();
         validateResponseServed(fileUrl);

--- a/vertx-client/src/main/java/org/apache/cassandra/sidecar/client/VertxHttpClient.java
+++ b/vertx-client/src/main/java/org/apache/cassandra/sidecar/client/VertxHttpClient.java
@@ -22,6 +22,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
@@ -54,6 +56,7 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.predicate.ResponsePredicateResult;
 import io.vertx.ext.web.codec.BodyCodec;
+import org.apache.cassandra.sidecar.common.request.DownloadableRequest;
 import org.apache.cassandra.sidecar.common.request.Request;
 import org.apache.cassandra.sidecar.common.request.UploadableRequest;
 
@@ -133,11 +136,7 @@ public class VertxHttpClient implements HttpClient
 
     protected CompletableFuture<HttpResponse> executeInternal(SidecarInstance sidecarInstance, RequestContext context)
     {
-        Future<HttpRequest<Buffer>> future = Future.future(promise -> promise.complete(vertxRequest(sidecarInstance, context)
-                                                                                       .ssl(config.ssl())
-                                                                                       .timeout(config.timeoutMillis())));
-
-        return future
+        return vertxRequestFuture(sidecarInstance, context)
                .compose(vertxRequest -> {
                    Request request = context.request();
                    if (request.requestBody() != null)
@@ -146,16 +145,70 @@ public class VertxHttpClient implements HttpClient
                    }
                    return vertxRequest.send();
                })
-               .map(response -> {
-                   byte[] raw = response.body() != null ? response.body().getBytes() : null;
-                   return (HttpResponse) new HttpResponseImpl(response.statusCode(),
-                                                              response.statusMessage(),
-                                                              raw,
-                                                              mapHeaders(response.headers()),
-                                                              sidecarInstance
-                   );
+               .map(rawResponse -> {
+                   io.vertx.ext.web.client.HttpResponse response = (io.vertx.ext.web.client.HttpResponse) rawResponse;
+                   byte[] raw = null;
+                   if (response.body() instanceof Buffer)
+                   {
+                       raw = ((Buffer) response.body()).getBytes();
+                   }
+
+                   if (response.statusCode() != HttpResponseStatus.OK.code()
+                       && context.request() instanceof DownloadableRequest)
+                   {
+                       DownloadableRequest downloadableRequest = (DownloadableRequest) context.request();
+                       // cleanup the destinationPath
+                       vertx.fileSystem().deleteBlocking(downloadableRequest.destinationPath());
+                   }
+
+                   return new HttpResponseImpl(response.statusCode(),
+                                               response.statusMessage(),
+                                               raw,
+                                               mapHeaders(response.headers()),
+                                               sidecarInstance);
                })
                .toCompletionStage().toCompletableFuture();
+    }
+
+    protected Future<HttpRequest> vertxRequestFuture(SidecarInstance sidecarInstance, RequestContext context)
+    {
+        if (context.request() instanceof DownloadableRequest)
+        {
+            Promise<HttpRequest> promise = Promise.promise();
+            DownloadableRequest downloadableRequest = (DownloadableRequest) context.request();
+            String destinationPath = downloadableRequest.destinationPath();
+            createTargetDirectory(destinationPath)
+            .compose(Void -> openTargetFile(destinationPath))
+            .onSuccess(targetFile -> promise.complete(vertxRequest(sidecarInstance, context)
+                                                      .as(BodyCodec.pipe(targetFile))))
+            .onFailure(promise::fail);
+            return promise.future();
+        }
+        else
+        {
+            return Future.succeededFuture(vertxRequest(sidecarInstance, context)
+                                          .ssl(config.ssl())
+                                          .timeout(config.timeoutMillis()));
+        }
+    }
+
+    protected Future<Void> createTargetDirectory(String targetPath)
+    {
+        Path parent = Paths.get(targetPath).getParent();
+        if (null == parent)
+        {
+            return Future.failedFuture(targetPath + " does not have a parent directory");
+        }
+
+        String targetDirectory = parent.toString();
+        return vertx.fileSystem().mkdirs(targetDirectory)
+                    .onFailure(ex -> LOGGER.error("Unable to create folder {}", targetDirectory, ex));
+    }
+
+    protected Future<AsyncFile> openTargetFile(String targetPath)
+    {
+        return vertx.fileSystem().open(targetPath, new OpenOptions().setTruncateExisting(true)
+                                                                    .setCreate(true));
     }
 
     protected CompletableFuture<HttpResponse> executeUploadFileInternal(SidecarInstance sidecarInstance,


### PR DESCRIPTION
Making this change as part of [CEP-40](https://issues.apache.org/jira/browse/CASSSIDECAR-138).

CASSSIDECAR-224 Enhancing Sidecar Client to download files for Live Migration.

