### PR TITLE
Fix rpm broken symlink

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.2.0
 -----
+ * Fix rpm broken symlink (CASSSIDECAR-327)
  * Fix system_views client table access and make CreateRestoreJobRequestPayload serialization backward compatible (CASSSIDECAR-326)
  * CdcRawDirectorySpaceCleaner always uses fallback after the first time it is queried from system_views.settings (CASSSIDECAR-325)
  * Allow restore jobs to restore to the local datacenter only (CASSSIDECAR-269)

--- a/build.gradle
+++ b/build.gradle
@@ -364,7 +364,7 @@ ospackage {
     version = project.version
     // ospackage puts packages into /opt/[package] by default
     // which is _technically_ the right spot for packages
-    link("/usr/local/bin/cassandra-sidecar", "/opt/cassandra-sidecar/bin/cassandra-sidecar")
+    link("/usr/local/bin/cassandra-sidecar", "/opt/${packageName}/bin/cassandra-sidecar")
     license = "Apache License 2.0"
     summary = "Sidecar Management Tool for Apache Cassandra"
     description = "Sidecar Management Tool for Apache Cassandra"


### PR DESCRIPTION
CASSSIDECAR-327

CASSSIDECAR-218 renamed the rpm/deb package to `apache-cassandra-sidecar`, but kept the symlink to the same place that now doesn't exist (`/opt/cassandra-sidecar/bin/cassandra-sidecar`)