### PR TITLE
CASSSIDECAR-272: Add /api/v2/cassandra/settings which will return Cassandra configurations stored in system_views.settings

### DIFF
--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraAdapter.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraAdapter.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.adapters.base;
 
 import java.net.InetSocketAddress;
+import java.util.Map;
 
 import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.Host;
@@ -88,6 +89,13 @@ public class CassandraAdapter implements ICassandraAdapter
     public NodeSettings nodeSettings()
     {
         throw new UnsupportedOperationException("Node settings are not provided by this adapter");
+    }
+
+    @Override
+    @NotNull
+    public Map<String, String> cqlNodeSettings()
+    {
+        throw new UnsupportedOperationException("CQL node settings are not provided by this adapter");
     }
 
     @Override

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV2.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV2.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.sidecar.common;
 
 /**

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV2.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV2.java
@@ -1,0 +1,12 @@
+package org.apache.cassandra.sidecar.common;
+
+/**
+ * A constants container class for API endpoints of version 2.
+ */
+public class ApiEndpointsV2
+{
+    public static final String API = "/api";
+    public static final String API_V2 = API + "/v2";
+    public static final String CASSANDRA = "/cassandra";
+    public static final String NODE_SETTINGS_ROUTE = API_V2 + CASSANDRA + "/settings";
+}

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/v2/JmxNodeSettings.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/v2/JmxNodeSettings.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.sidecar.common.response.v2;
+
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.cassandra.sidecar.common.DataObjectBuilder;
+
+/**
+ * JmxNodeSettings stores the settings which are accessible via JMX through the
+ * org.apache.cassandra.db:type=StorageService and org.apache.cassandra.db:type=EndpointSnitchInfo MBeans. This maintains
+ * compatability with the /api/v1/cassandra/settings object, expect the sidecarVersion has been relocated.
+ */
+public class JmxNodeSettings
+{
+    @JsonProperty("releaseVersion")
+    private final String releaseVersion;
+    @JsonProperty("partitioner")
+    private final String partitioner;
+    @JsonProperty("datacenter")
+    private final String datacenter;
+    @JsonProperty("rpcAddress")
+    private final InetAddress rpcAddress;
+    @JsonProperty("rpcPort")
+    private final int rpcPort;
+    @JsonProperty("tokens")
+    private final Set<String> tokens;
+
+    public JmxNodeSettings()
+    {
+        this(builder());
+    }
+
+    protected JmxNodeSettings(Builder builder)
+    {
+        this.releaseVersion = builder.releaseVersion;
+        this.partitioner = builder.partitioner;
+        this.datacenter = builder.datacenter;
+        this.rpcAddress = builder.rpcAddress;
+        this.rpcPort = builder.rpcPort;
+        this.tokens = builder.tokens;
+    }
+
+    @JsonProperty("releaseVersion")
+    public String releaseVersion()
+    {
+        return releaseVersion;
+    }
+
+    @JsonProperty("partitioner")
+    public String partitioner()
+    {
+        return partitioner;
+    }
+
+    @JsonProperty("datacenter")
+    public String datacenter()
+    {
+        return datacenter;
+    }
+
+    @JsonProperty("rpcAddress")
+    public InetAddress rpcAddress()
+    {
+        return rpcAddress;
+    }
+
+    @JsonProperty("rpcPort")
+    public int rpcPort()
+    {
+        return rpcPort;
+    }
+
+    @JsonProperty("tokens")
+    public Set<String> tokens()
+    {
+        return tokens;
+    }
+
+    public static JmxNodeSettings.Builder builder()
+    {
+        return new JmxNodeSettings.Builder();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass()) return false;
+        JmxNodeSettings that = (JmxNodeSettings) o;
+        return rpcPort == that.rpcPort && Objects.equals(releaseVersion, that.releaseVersion) && Objects.equals(partitioner, that.partitioner) && Objects.equals(datacenter, that.datacenter) && Objects.equals(rpcAddress, that.rpcAddress) && Objects.equals(tokens, that.tokens);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(releaseVersion, partitioner, datacenter, rpcAddress, rpcPort, tokens);
+    }
+
+    /**
+     * A Builder to help construct JmxNodeSettings objects.
+     */
+    public static final class Builder implements DataObjectBuilder<Builder, JmxNodeSettings>
+    {
+        private String releaseVersion;
+        private String partitioner;
+        private String datacenter;
+        private InetAddress rpcAddress;
+        private int rpcPort;
+        private Set<String> tokens;
+
+        private Builder(){}
+
+        @Override
+        public Builder self()
+        {
+            return this;
+        }
+
+        @Override
+        public JmxNodeSettings build()
+        {
+            return new JmxNodeSettings(this);
+        }
+
+        public Builder releaseVersion(String releaseVersion)
+        {
+            return update(b -> b.releaseVersion = releaseVersion);
+        }
+
+        public Builder partitioner(String partitioner)
+        {
+            return update(b -> b.partitioner = partitioner);
+        }
+
+        public Builder datacenter(String datacenter)
+        {
+            return update(b -> b.datacenter = datacenter);
+        }
+
+        public Builder rpcAddress(InetAddress rpcAddress)
+        {
+            return update(b -> b.rpcAddress = rpcAddress);
+        }
+
+        public Builder rpcPort(int rpcPort)
+        {
+            return update(b -> b.rpcPort = rpcPort);
+        }
+
+        public Builder tokens(Set<String> tokens)
+        {
+            return update(b -> b.tokens = tokens);
+        }
+    }
+}

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/v2/V2NodeSettings.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/v2/V2NodeSettings.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.sidecar.common.response.v2;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.cassandra.sidecar.common.DataObjectBuilder;
+import org.apache.cassandra.sidecar.common.response.NodeSettings;
+
+/**
+ * V2NodeSettings stores settings information for Cassandra and Sidecar instances.
+ */
+public class V2NodeSettings
+{
+    private static final String VERSION = "version";
+    // Contains settings about this Cassandra Sidecar instance (e.g. version)
+    @JsonProperty("sidecar")
+    private final Map<String, String> sidecar;
+
+    //Contains settings which can be retrieved through JMX.
+    @JsonProperty("jmx")
+    private final JmxNodeSettings jmx;
+
+    // Contains Cassandra node settings from system_views.settigns table.
+    @JsonProperty("cassandra")
+    private final Map<String, String> cassandra;
+
+    /**
+     * Constructs a new {@link NodeSettings}.
+     */
+    public V2NodeSettings()
+    {
+        this(builder());
+    }
+
+    public V2NodeSettings(V2NodeSettings.Builder builder)
+    {
+        this.cassandra = builder.cassandra;
+        this.sidecar = builder.sidecar != null ? builder.sidecar : Collections.emptyMap();
+        this.jmx = builder.jmx;
+
+    }
+
+    @JsonProperty("cassandra")
+    public Map<String, String> cassandra()
+    {
+        return cassandra;
+    }
+
+    @JsonProperty("jmx")
+    public JmxNodeSettings jmx()
+    {
+        return jmx;
+    }
+
+    @JsonProperty("sidecar")
+    public Map<String, String> sidecar()
+    {
+        return sidecar;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == null || getClass() != o.getClass()) return false;
+        V2NodeSettings that = (V2NodeSettings) o;
+        return Objects.equals(sidecar, that.sidecar) && Objects.equals(jmx, that.jmx) && Objects.equals(cassandra, that.cassandra);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(sidecar, jmx, cassandra);
+    }
+
+    /**
+     * A builder class to enable construction of V2NodeSettings objects.
+     */
+    public static final class Builder implements DataObjectBuilder<Builder, V2NodeSettings>
+    {
+        private JmxNodeSettings jmx;
+        private Map<String, String> sidecar;
+        private Map<String, String> cassandra;
+
+        private Builder()
+        {
+        }
+
+        @Override
+        public V2NodeSettings.Builder self()
+        {
+            return this;
+        }
+
+        /**
+         * Sets the Cassandra node settings which can be retrieved from Gossip (e.g. Partitioner, release version, tokens)
+         * @param jmx the node settings retrieved from jmx
+         * @return a reference to this builder.
+         */
+        public V2NodeSettings.Builder jmx(JmxNodeSettings jmx)
+        {
+            return update(b -> b.jmx = jmx);
+        }
+
+        public V2NodeSettings.Builder sidecar(Map<String, String> sidecar)
+        {
+            return update(b -> b.sidecar = sidecar);
+        }
+
+        /**
+         * Sets the {@code sidecarVersion} in the {@code sidecar} map and returns a reference to this Builder
+         * enabling method chaining.
+         *
+         * @param sidecarVersion the {@code sidecarVersion} to set
+         * @return a reference to this Builder
+         */
+        public V2NodeSettings.Builder sidecarVersion(String sidecarVersion)
+        {
+            return update(b -> {
+                if (b.sidecar != null)
+                {
+                    b.sidecar.put(VERSION, sidecarVersion);
+                }
+                else
+                {
+                    b.sidecar = Collections.singletonMap(VERSION, sidecarVersion);
+                }
+            });
+        }
+
+        /**
+         * Sets a value for the Cassandra settings map and returns a reference to this Builder enabling method chaining.
+         * @param cassandra
+         * @return a reference to this Builder
+         */
+        public V2NodeSettings.Builder cassandra(Map<String, String> cassandra)
+        {
+            return update(b -> b.cassandra = cassandra);
+        }
+
+        /**
+         * Returns a {@code NodeSettings} built from the parameters previously set.
+         *
+         * @return a {@code NodeSettings} built with parameters of this {@code NodeSettings.Builder}
+         */
+        @Override
+        public V2NodeSettings build()
+        {
+            return new V2NodeSettings(this);
+        }
+    }
+}

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/v2/V2NodeSettingsIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/v2/V2NodeSettingsIntegrationTest.java
@@ -48,6 +48,38 @@ public class V2NodeSettingsIntegrationTest extends SharedClusterSidecarIntegrati
     @Test
     public void testV2NodeSettings()
     {
+        ensureSettingsAvailable();
+
+        // Disabling NTR should make CQL settings become unavailable
+        cluster.getFirstRunningInstance().nodetool("disablebinary");
+        ensureSettingsBecomeUnavailable("CQL NodeSettings unavailable");
+
+        // Re-enable NTR, settings should become available again.
+        cluster.getFirstRunningInstance().nodetool("enablebinary");
+        ensureSettingsAvailable();
+
+        // Changing a configuration should eventually reflect in settings API.
+        cluster.getFirstRunningInstance().nodetool("setconcurrency", "READ", "10");
+        ensureSettingsAvailable();
+
+        cluster.stopUnchecked(cluster.getFirstRunningInstance());
+        ensureSettingsBecomeUnavailable("NodeSettings unavailable");
+    }
+
+    private void ensureSettingsBecomeUnavailable(String errorMessage)
+    {
+        loopAssert(60, () -> {
+            HttpResponse<Buffer> responseAfterStop = getBlocking(trustedClient().get(serverWrapper.serverPort, "localhost", "/api/v2/cassandra/settings")
+                                                                                .send()
+                                                                                .expecting(HttpResponseExpectation.SC_SERVICE_UNAVAILABLE));
+            assertThat(responseAfterStop).isNotNull();
+            assertThat(responseAfterStop.statusCode()).isEqualTo(SERVICE_UNAVAILABLE.code());
+            assertThat(responseAfterStop.bodyAsJsonObject().getString("message")).contains(errorMessage);
+        });
+    }
+
+    private void ensureSettingsAvailable()
+    {
         loopAssert(60, () -> {
             HttpResponse<Buffer> response = null;
             try
@@ -69,26 +101,6 @@ public class V2NodeSettingsIntegrationTest extends SharedClusterSidecarIntegrati
                    .executeInternalWithResult("SELECT name, value FROM system_views.settings;")
                    .forEach(row -> cqlSettings.put(row.getString("name"), row.getString("value")));
             assertThat(nodeSettings.cassandra()).isEqualTo(cqlSettings);
-        });
-
-        cluster.getFirstRunningInstance().nodetool("disablebinary");
-        loopAssert(60, () -> {
-            HttpResponse<Buffer> responseAfterStop = getBlocking(trustedClient().get(serverWrapper.serverPort, "localhost", "/api/v2/cassandra/settings")
-                                                                                .send()
-                                                                                .expecting(HttpResponseExpectation.SC_SERVICE_UNAVAILABLE));
-            assertThat(responseAfterStop).isNotNull();
-            assertThat(responseAfterStop.statusCode()).isEqualTo(SERVICE_UNAVAILABLE.code());
-            assertThat(responseAfterStop.bodyAsJsonObject().getString("message")).contains("CQL NodeSettings unavailable");
-        });
-
-        cluster.stopUnchecked(cluster.getFirstRunningInstance());
-        loopAssert(60, () -> {
-            HttpResponse<Buffer> responseAfterStop = getBlocking(trustedClient().get(serverWrapper.serverPort, "localhost", "/api/v2/cassandra/settings")
-                                                                                .send()
-                                                                                .expecting(HttpResponseExpectation.SC_SERVICE_UNAVAILABLE));
-            assertThat(responseAfterStop).isNotNull();
-            assertThat(responseAfterStop.statusCode()).isEqualTo(SERVICE_UNAVAILABLE.code());
-            assertThat(responseAfterStop.bodyAsJsonObject().getString("message")).contains("NodeSettings unavailable");
         });
     }
 

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/v2/V2NodeSettingsIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/v2/V2NodeSettingsIntegrationTest.java
@@ -1,0 +1,83 @@
+package org.apache.cassandra.sidecar.routes.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.VertxException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpResponseExpectation;
+import io.vertx.ext.web.client.HttpResponse;
+import org.apache.cassandra.sidecar.common.response.v2.V2NodeSettings;
+import org.apache.cassandra.sidecar.testing.SharedClusterSidecarIntegrationTestBase;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static org.apache.cassandra.testing.utils.AssertionUtils.getBlocking;
+import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * V2NodeSettingsIntegrationTest is responsible for verifying the behavior of the /api/v2/cassandra/settings
+ * endpoint. This includes:
+ *  - Node settings are returned when the node is healthy.
+ *  - A specific error is returned when CQL is not healthy.
+ *  - A separate error is returned when the node is down.
+ */
+public class V2NodeSettingsIntegrationTest extends SharedClusterSidecarIntegrationTestBase
+{
+
+    @Test
+    public void testV2NodeSettings()
+    {
+        loopAssert(60, () -> {
+            HttpResponse<Buffer> response = null;
+            try
+            {
+                response = getBlocking(trustedClient().get(serverWrapper.serverPort, "localhost", "/api/v2/cassandra/settings")
+                                                      .send()
+                                                      .expecting(HttpResponseExpectation.SC_OK));
+            }
+            catch (VertxException e)
+            {
+                Assertions.fail(e);
+            }
+            V2NodeSettings nodeSettings = response.bodyAsJson(V2NodeSettings.class);
+            assertThat(nodeSettings).isNotNull();
+            assertThat(nodeSettings.jmx().partitioner()).isEqualTo("org.apache.cassandra.dht.Murmur3Partitioner");
+            assertThat(nodeSettings.jmx().datacenter()).isEqualTo("datacenter1");
+            Map<String, String> cqlSettings = new HashMap<>();
+            cluster.getFirstRunningInstance()
+                   .executeInternalWithResult("SELECT name, value FROM system_views.settings;")
+                   .forEach(row -> cqlSettings.put(row.getString("name"), row.getString("value")));
+            assertThat(nodeSettings.cassandra()).isEqualTo(cqlSettings);
+        });
+
+        cluster.getFirstRunningInstance().nodetool("disablebinary");
+        loopAssert(60, () -> {
+            HttpResponse<Buffer> responseAfterStop = getBlocking(trustedClient().get(serverWrapper.serverPort, "localhost", "/api/v2/cassandra/settings")
+                                                                                .send()
+                                                                                .expecting(HttpResponseExpectation.SC_SERVICE_UNAVAILABLE));
+            assertThat(responseAfterStop).isNotNull();
+            assertThat(responseAfterStop.statusCode()).isEqualTo(SERVICE_UNAVAILABLE.code());
+            assertThat(responseAfterStop.bodyAsJsonObject().getString("message")).contains("CQL NodeSettings unavailable");
+        });
+
+        cluster.stopUnchecked(cluster.getFirstRunningInstance());
+        loopAssert(60, () -> {
+            HttpResponse<Buffer> responseAfterStop = getBlocking(trustedClient().get(serverWrapper.serverPort, "localhost", "/api/v2/cassandra/settings")
+                                                                                .send()
+                                                                                .expecting(HttpResponseExpectation.SC_SERVICE_UNAVAILABLE));
+            assertThat(responseAfterStop).isNotNull();
+            assertThat(responseAfterStop.statusCode()).isEqualTo(SERVICE_UNAVAILABLE.code());
+            assertThat(responseAfterStop.bodyAsJsonObject().getString("message")).contains("NodeSettings unavailable");
+        });
+    }
+
+    @Override
+    protected void initializeSchemaForTest()
+    {
+        // Do nothing
+    }
+}

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/v2/V2NodeSettingsIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/v2/V2NodeSettingsIntegrationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.sidecar.routes.v2;
 
 import java.util.HashMap;

--- a/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/ICassandraAdapter.java
+++ b/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/ICassandraAdapter.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.common.server;
 
 import java.net.InetSocketAddress;
+import java.util.Map;
 
 import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.ResultSet;
@@ -50,6 +51,13 @@ public interface ICassandraAdapter
      * @throws CassandraUnavailableException when no JMX connection is established
      */
     @NotNull NodeSettings nodeSettings() throws CassandraUnavailableException;
+
+    /**
+     * The settings for this instance which are stored in the system_view.settings virtual table.
+     * @return A map of name: value mappings for the settings in system_view.settings.
+     * @throws CassandraUnavailableException when CQL is not available
+     */
+    @NotNull Map<String, String> cqlNodeSettings() throws CassandraUnavailableException;
 
     /**
      * Execute the provided query on the locally-managed Cassandra instance

--- a/server/src/main/java/org/apache/cassandra/sidecar/CassandraSidecarDaemon.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/CassandraSidecarDaemon.java
@@ -73,7 +73,7 @@ public class CassandraSidecarDaemon
             app.close()
                .toCompletionStage()
                .toCompletableFuture()
-               .get(1, TimeUnit.MINUTES);
+               .get(2, TimeUnit.MINUTES);
             return true;
         }
         catch (Exception ex)

--- a/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/BasicPermissions.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/BasicPermissions.java
@@ -84,4 +84,8 @@ public class BasicPermissions
     // Live Migration permissions
     public static final Permission LIST_FILES = new DomainAwarePermission("LIVE_MIGRATION:LIST_FILES", CLUSTER_SCOPE);
     public static final Permission STREAM_FILES = new DomainAwarePermission("LIVE_MIGRATION:STREAM", CLUSTER_SCOPE);
+
+    // Cassandra Settings Permissions
+    // Caller must have been granted SELECT on `system_view.settings` to hit the /api/v2/cassandra/settings API.
+    public static final Permission READ_SETTINGS = new StandardPermission("SELECT", TABLE_SCOPE);
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegate.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegate.java
@@ -288,6 +288,10 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
             if (isNativeUp.compareAndSet(false, true))
             {
                 notifyNativeConnection();
+            }
+
+            if (isNativeUp.get())
+            {
                 try
                 {
                     // Once CQL is confirmed alive for the first time, we'll initialize systemViewsSchema.
@@ -304,10 +308,6 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
                                 cassandraInstanceId, e);
                     nodeSettingsFromCql = null;
                 }
-            }
-            else
-            {
-                nodeSettingsFromCql = null;
             }
         }
         catch (IllegalArgumentException | NoHostAvailableException e)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegate.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegate.java
@@ -23,6 +23,7 @@ import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -55,6 +56,8 @@ import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.common.server.TableOperations;
 import org.apache.cassandra.sidecar.common.server.utils.DriverUtils;
 import org.apache.cassandra.sidecar.common.utils.Preconditions;
+import org.apache.cassandra.sidecar.db.SystemViewsDatabaseAccessor;
+import org.apache.cassandra.sidecar.db.schema.SystemViewsSchema;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.metrics.instance.InstanceHealthMetrics;
 import org.apache.cassandra.sidecar.utils.CassandraVersionProvider;
@@ -63,6 +66,7 @@ import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.adapters.base.jmx.EndpointSnitchJmxOperations.ENDPOINT_SNITCH_INFO_OBJ_NAME;
 import static org.apache.cassandra.sidecar.adapters.base.jmx.StorageJmxOperations.STORAGE_SERVICE_OBJ_NAME;
+import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.CQL;
 import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.CQL_AND_JMX;
 import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.JMX;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CASSANDRA_CQL_DISCONNECTED;
@@ -96,13 +100,16 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
     private volatile ICassandraAdapter adapter;
     private final AtomicBoolean isNativeUp = new AtomicBoolean(false);
     private volatile NodeSettings nodeSettingsFromJmx = null;
+    private volatile Map<String, String> nodeSettingsFromCql = null;
     private final AtomicBoolean registered = new AtomicBoolean(false);
     private final AtomicBoolean isHealthCheckActive = new AtomicBoolean(false);
     private final InetSocketAddress localNativeTransportAddress;
     private final InstanceHealthMetrics healthMetrics;
     private volatile Host host;
     private volatile boolean closed = false;
-
+    private final SystemViewsSchema systemViewsSchema;
+    private final AtomicBoolean isSystemViewSchemaInitialized = new AtomicBoolean(false);
+    private final SystemViewsDatabaseAccessor systemViewsDatabaseAccessor;
     /**
      * Constructs a new {@link CassandraAdapterDelegate} for the given {@code cassandraInstance}
      *
@@ -138,6 +145,8 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
         this.jmxClient = jmxClient;
         this.healthMetrics = healthMetrics;
         this.notificationListener = initializeJmxListener();
+        this.systemViewsSchema = new SystemViewsSchema();
+        this.systemViewsDatabaseAccessor = new SystemViewsDatabaseAccessor(systemViewsSchema, session);
     }
 
     // TODO: re-organize the methods in the class to group the public/protected/private methods together
@@ -240,7 +249,7 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
     /**
      * Performs health checks by utilizing the native protocol
      */
-    protected void nativeProtocolHealthCheck()
+    protected synchronized void nativeProtocolHealthCheck()
     {
         Session activeSession;
         try
@@ -267,6 +276,7 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
             {
                 LOGGER.warn("Could not find host in cluster metadata by address and port {}",
                             localNativeTransportAddress);
+                nodeSettingsFromCql = null;
                 return;
             }
             healthCheckStatement.setHost(host);
@@ -278,6 +288,26 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
             if (isNativeUp.compareAndSet(false, true))
             {
                 notifyNativeConnection();
+                try
+                {
+                    // Once CQL is confirmed alive for the first time, we'll initialize systemViewsSchema.
+                    if (!isSystemViewSchemaInitialized.get())
+                    {
+                        systemViewsSchema.initialize(activeSession, b -> false);
+                        isSystemViewSchemaInitialized.compareAndSet(false, true);
+                    }
+                    nodeSettingsFromCql = systemViewsDatabaseAccessor.getSettings();
+                }
+                catch (RuntimeException e)
+                {
+                    LOGGER.warn("Unable to retrieve node settings from Cassandra instance {}. Node settings will be null",
+                                cassandraInstanceId, e);
+                    nodeSettingsFromCql = null;
+                }
+            }
+            else
+            {
+                nodeSettingsFromCql = null;
             }
         }
         catch (IllegalArgumentException | NoHostAvailableException e)
@@ -287,6 +317,7 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
             markNativeDownAndMaybeNotifyDisconnection();
             // Unregister the host listener.
             maybeUnregisterHostListener(activeSession);
+            nodeSettingsFromCql = null;
         }
     }
 
@@ -376,6 +407,23 @@ public class CassandraAdapterDelegate implements ICassandraAdapter, Host.StateLi
             throw new CassandraUnavailableException(JMX, "NodeSettings unavailable");
         }
         return nodeSettingsFromJmx;
+    }
+
+    /**
+     * Returns the cached node settings read from the system_views.settings table. These are retrieved after a successful
+     * health check for native transport.
+     * @return Cached node settings from system_view.settings.
+     * @throws CassandraUnavailableException Thrown when native transport is not available. 
+     */
+    @Override
+    @NotNull
+    public Map<String, String> cqlNodeSettings() throws CassandraUnavailableException
+    {
+        if (nodeSettingsFromCql == null)
+        {
+            throw new CassandraUnavailableException(CQL, "CQL NodeSettings unavailable");
+        }
+        return nodeSettingsFromCql;
     }
 
     @Override

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/SystemViewsDatabaseAccessor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/SystemViewsDatabaseAccessor.java
@@ -19,14 +19,15 @@
 package org.apache.cassandra.sidecar.db;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
@@ -94,12 +95,24 @@ public class SystemViewsDatabaseAccessor extends DatabaseAccessor<SystemViewsSch
     public Map<String, String> getSettings(String... names) throws SchemaUnavailableException
     {
         BoundStatement statement = tableSchema.selectSettings().bind(Arrays.asList(names));
+        return querySettings(statement);
+    }
+
+    @NotNull
+    public Map<String, String> getSettings() throws SchemaUnavailableException
+    {
+        BoundStatement statement = tableSchema.selectAllSettings().bind();
+        return querySettings(statement);
+    }
+
+    private @NotNull Map<String, String> querySettings(BoundStatement statement)
+    {
         ResultSet result = execute(statement);
-        return result.all()
-                     .stream()
-                     .collect(Collectors.toMap(
-                              row -> row.getString(0),
-                              row -> row.getString(1))
-                     );
+        Map<String, String> nodeSettings = new HashMap<>();
+        for (Row setting : result.all())
+        {
+            nodeSettings.put(setting.getString("name"), setting.getString("value"));
+        }
+        return nodeSettings;
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SystemViewsSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/SystemViewsSchema.java
@@ -33,6 +33,7 @@ public class SystemViewsSchema extends CassandraSystemTableSchema
     protected static final String SYSTEM_VIEWS_KEYSPACE_NAME = "system_views";
     protected static final String SYSTEM_VIEWS_SETTINGS_TABLE_NAME = "settings";
     private PreparedStatement selectSettings;
+    private PreparedStatement selectAllSettings;
 
     @Override
     protected String keyspaceName()
@@ -52,15 +53,22 @@ public class SystemViewsSchema extends CassandraSystemTableSchema
         return selectSettings;
     }
 
+    public PreparedStatement selectAllSettings() throws SchemaUnavailableException
+    {
+        ensureSchemaAvailable();
+        return selectAllSettings;
+    }
+
     @Override
     protected void prepareStatements(@NotNull Session session)
     {
         this.selectSettings = session.prepare("SELECT name, value FROM system_views.settings WHERE name IN ?");
+        this.selectAllSettings = session.prepare("SELECT name, value FROM system_views.settings");
     }
 
     protected void ensureSchemaAvailable() throws SchemaUnavailableException
     {
-        if (selectSettings == null)
+        if (selectSettings == null || selectAllSettings == null)
         {
             throw new SchemaUnavailableException(keyspaceName(), tableName());
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandler.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.sidecar.handlers.v2.cassandra;
 
 import java.util.Map;

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandler.java
@@ -1,0 +1,75 @@
+package org.apache.cassandra.sidecar.handlers.v2.cassandra;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.inject.Inject;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.auth.authorization.Authorization;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.cassandra.sidecar.acl.authorization.BasicPermissions;
+import org.apache.cassandra.sidecar.common.response.NodeSettings;
+import org.apache.cassandra.sidecar.common.response.v2.JmxNodeSettings;
+import org.apache.cassandra.sidecar.common.response.v2.V2NodeSettings;
+import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.handlers.AbstractHandler;
+import org.apache.cassandra.sidecar.handlers.AccessProtected;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * V2NodeSettingsHandler is responsible for providing access to the configurations of the
+ * Cassandra instances managed by this sidecar. This includes settings accessible through JMX
+ * as well as settings stored in the system_views.settings Cassandra virtual tables. Additionally,
+ * configuration information about this sidecar instance are accessible through this endpoint (e.g., Sidecar verison).
+ */
+public class V2NodeSettingsHandler extends AbstractHandler<Void> implements AccessProtected
+{
+
+    /**
+     * Constructs a handler with the provided {@code metadataFetcher}
+     *
+     * @param metadataFetcher the interface to retrieve instance metadata
+     */
+    @Inject
+    V2NodeSettingsHandler(InstanceMetadataFetcher metadataFetcher, ExecutorPools executorPools)
+    {
+        super(metadataFetcher, executorPools, null);
+    }
+
+    @Override
+    protected Void extractParamsOrThrow(RoutingContext context)
+    {
+        return null;
+    }
+
+    @Override
+    protected void handleInternal(RoutingContext context, HttpServerRequest httpRequest, @NotNull String host, SocketAddress remoteAddress, Void request)
+    {
+        NodeSettings nodeSettings = metadataFetcher.delegate(host).nodeSettings();
+        Map<String, String> cqlSettings = metadataFetcher.delegate(host).cqlNodeSettings();
+        Map<String, String> sidecarSettings = nodeSettings.sidecar();
+        JmxNodeSettings jmxNodeSettings = JmxNodeSettings.builder()
+                                                         .releaseVersion(nodeSettings.releaseVersion())
+                                                         .partitioner(nodeSettings.partitioner())
+                                                         .datacenter(nodeSettings.datacenter())
+                                                         .rpcAddress(nodeSettings.rpcAddress())
+                                                         .rpcPort(nodeSettings.rpcPort())
+                                                         .tokens(nodeSettings.tokens())
+                                                         .build();
+        V2NodeSettings v2nodeSettings = V2NodeSettings.builder()
+                                                    .cassandra(cqlSettings)
+                                                    .sidecar(sidecarSettings)
+                                                    .jmx(jmxNodeSettings)
+                                                    .build();
+        context.json(v2nodeSettings);
+    }
+
+    @Override
+    public Set<Authorization> requiredAuthorizations()
+    {
+        Authorization authorization = BasicPermissions.READ_SETTINGS.toAuthorization("data/system_views/settings");
+        return Set.of(authorization);
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.sidecar.handlers.StreamStatsHandler;
 import org.apache.cassandra.sidecar.handlers.TableStatsHandler;
 import org.apache.cassandra.sidecar.handlers.TokenRangeReplicaMapHandler;
 import org.apache.cassandra.sidecar.handlers.cassandra.NodeSettingsHandler;
+import org.apache.cassandra.sidecar.handlers.v2.cassandra.V2NodeSettingsHandler;
 import org.apache.cassandra.sidecar.handlers.validations.ValidateTableExistenceHandler;
 import org.apache.cassandra.sidecar.modules.multibindings.KeyClassMapKey;
 import org.apache.cassandra.sidecar.modules.multibindings.TableSchemaMapKeys;
@@ -183,6 +184,13 @@ public class CassandraOperationsModule extends AbstractModule
                  responseCode = "200",
                  content = @Content(mediaType = "application/json",
                  schema = @Schema(implementation = SchemaResponse.class)))
+    @ProvidesIntoMap
+    @KeyClassMapKey(VertxRouteMapKeys.V2CassandraNodeSettingsRouteKey.class)
+    VertxRoute v2CassandraNodeSettings(RouteBuilder.Factory factory, V2NodeSettingsHandler v2NodeSettingsHandler)
+    {
+        return factory.buildRouteWithHandler(v2NodeSettingsHandler);
+    }
+
     @ProvidesIntoMap
     @KeyClassMapKey(VertxRouteMapKeys.AllKeyspacesSchemaRouteKey.class)
     VertxRoute cassandraSchemaRoute(RouteBuilder.Factory factory,

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import org.apache.cassandra.sidecar.adapters.base.db.schema.ConnectedClientsSchema;
 import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV2;
 import org.apache.cassandra.sidecar.common.response.ConnectedClientStatsResponse;
 import org.apache.cassandra.sidecar.common.response.GossipInfoResponse;
 import org.apache.cassandra.sidecar.common.response.ListOperationalJobsResponse;
@@ -34,6 +35,7 @@ import org.apache.cassandra.sidecar.common.response.SchemaResponse;
 import org.apache.cassandra.sidecar.common.response.StreamStatsResponse;
 import org.apache.cassandra.sidecar.common.response.TableStatsResponse;
 import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
+import org.apache.cassandra.sidecar.common.response.v2.V2NodeSettings;
 import org.apache.cassandra.sidecar.db.schema.TableSchema;
 import org.apache.cassandra.sidecar.handlers.ConnectedClientStatsHandler;
 import org.apache.cassandra.sidecar.handlers.GossipInfoHandler;
@@ -176,6 +178,22 @@ public class CassandraOperationsModule extends AbstractModule
                       .build();
     }
 
+
+    @GET
+    @Path(ApiEndpointsV2.NODE_SETTINGS_ROUTE)
+    @Operation(summary = "Get node settings",
+                description = "Returns configuration settings for the Cassandra node.")
+    @APIResponse(description = "Node settings retrieved successfully",
+                 responseCode = "200",
+                 content = @Content(mediaType = "application/json",
+                 schema = @Schema(implementation = V2NodeSettings.class)))
+    @ProvidesIntoMap
+    @KeyClassMapKey(VertxRouteMapKeys.V2CassandraNodeSettingsRouteKey.class)
+    VertxRoute v2CassandraNodeSettings(RouteBuilder.Factory factory, V2NodeSettingsHandler v2NodeSettingsHandler)
+    {
+        return factory.buildRouteWithHandler(v2NodeSettingsHandler);
+    }
+
     @GET
     @Path(ApiEndpointsV1.ALL_KEYSPACES_SCHEMA_ROUTE)
     @Operation(summary = "Get all keyspaces schema",
@@ -184,13 +202,6 @@ public class CassandraOperationsModule extends AbstractModule
                  responseCode = "200",
                  content = @Content(mediaType = "application/json",
                  schema = @Schema(implementation = SchemaResponse.class)))
-    @ProvidesIntoMap
-    @KeyClassMapKey(VertxRouteMapKeys.V2CassandraNodeSettingsRouteKey.class)
-    VertxRoute v2CassandraNodeSettings(RouteBuilder.Factory factory, V2NodeSettingsHandler v2NodeSettingsHandler)
-    {
-        return factory.buildRouteWithHandler(v2NodeSettingsHandler);
-    }
-
     @ProvidesIntoMap
     @KeyClassMapKey(VertxRouteMapKeys.AllKeyspacesSchemaRouteKey.class)
     VertxRoute cassandraSchemaRoute(RouteBuilder.Factory factory,

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/multibindings/VertxRouteMapKeys.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/multibindings/VertxRouteMapKeys.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.sidecar.modules.multibindings;
 
 import io.vertx.core.http.HttpMethod;
 import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV2;
 
 /**
  * Class keys in the {@link com.google.inject.multibindings.MapBinder} to {@link org.apache.cassandra.sidecar.routes.VertxRoute} objects
@@ -82,6 +83,11 @@ public interface VertxRouteMapKeys
     {
         HttpMethod HTTP_METHOD = HttpMethod.GET;
         String ROUTE_URI = ApiEndpointsV1.NODE_SETTINGS_ROUTE;
+    }
+    interface V2CassandraNodeSettingsRouteKey extends RouteClassKey
+    {
+        HttpMethod HTTP_METHOD = HttpMethod.GET;
+        String ROUTE_URI = ApiEndpointsV2.NODE_SETTINGS_ROUTE;
     }
     interface CassandraOperationalJobRouteKey extends RouteClassKey
     {

--- a/server/src/test/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegateTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegateTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.sidecar.cluster;
 
 import java.net.InetSocketAddress;

--- a/server/src/test/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegateTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cluster/CassandraAdapterDelegateTest.java
@@ -1,0 +1,144 @@
+package org.apache.cassandra.sidecar.cluster;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Host;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
+import org.apache.cassandra.sidecar.common.server.JmxClient;
+import org.apache.cassandra.sidecar.common.server.utils.DriverUtils;
+import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
+import org.apache.cassandra.sidecar.metrics.instance.InstanceHealthMetrics;
+import org.apache.cassandra.sidecar.utils.CassandraVersionProvider;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * The CassandraAdapterDelegateTest is responsible for testing the functionality of the CassandraAdapterDelegate with
+ * isolated dependencies.
+ */
+public class CassandraAdapterDelegateTest
+{
+    private CassandraAdapterDelegate cassandraAdapterDelegate;
+
+    @BeforeEach
+    public void setUp()
+    {
+        Vertx mockVertx = getMockVertx();
+        int cassandraInstanceId = 0;
+        CassandraVersionProvider cassandraVersionProvider = Mockito.mock(CassandraVersionProvider.class);
+        Metadata metadata = Mockito.mock(Metadata.class);
+        CQLSessionProvider cqlSessionProvider = getMockCqlSessionProvider(metadata);
+        JmxClient jmxClient = Mockito.mock(JmxClient.class);
+        String host = "localhost";
+        int port = 9042;
+        DriverUtils driverUtils = getMockDriverUtils(host, port, metadata);
+        String sidecarVersion = "0.2.0-SNAPSHOT";
+        InstanceHealthMetrics instanceHealthMetrics = new InstanceHealthMetrics(new MetricRegistry());
+        cassandraAdapterDelegate = new CassandraAdapterDelegate(mockVertx,
+                                                                cassandraInstanceId,
+                                                                cassandraVersionProvider,
+                                                                cqlSessionProvider,
+                                                                jmxClient,
+                                                                driverUtils,
+                                                                sidecarVersion,
+                                                                host,
+                                                                port,
+                                                                instanceHealthMetrics
+        );
+    }
+
+    private static @NotNull DriverUtils getMockDriverUtils(String host, int port, Metadata metadata)
+    {
+        DriverUtils driverUtils = Mockito.mock(DriverUtils.class);
+        Host mockHost = Mockito.mock(Host.class);
+        InetSocketAddress mockAddress = new InetSocketAddress(host, port);
+        when(driverUtils.getHost(metadata, mockAddress)).thenReturn(mockHost);
+        return driverUtils;
+    }
+
+    private static @NotNull CQLSessionProvider getMockCqlSessionProvider(Metadata metadata)
+    {
+        Session session = Mockito.mock(Session.class);
+        Cluster cluster = Mockito.mock(Cluster.class);
+        when(cluster.isClosed()).thenReturn(false);
+        when(cluster.getMetadata()).thenReturn(metadata);
+        when(session.getCluster()).thenReturn(cluster);
+        PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        when(preparedStatement.bind()).thenReturn(Mockito.mock(BoundStatement.class));
+        when(session.prepare(any(String.class))).thenReturn(preparedStatement);
+        Row row = Mockito.mock(Row.class);
+        when(row.getString("name")).thenReturn("concurrent_reads");
+        when(row.getString("value")).thenReturn("16");
+        ResultSet resultSet = Mockito.mock(ResultSet.class);
+        when(resultSet.all()).thenReturn(List.of(row));
+        when(resultSet.one()).thenReturn(row);
+        SimpleStatement mockHealthCheckStatement = new SimpleStatement("SELECT release_version FROM system.local");
+        Row healthCheckResponse = Mockito.mock(Row.class);
+        ResultSet healthCheckResultSet = Mockito.mock(ResultSet.class);
+        when(healthCheckResultSet.one()).thenReturn(healthCheckResponse);
+        when(session.execute(mockHealthCheckStatement))
+        .thenReturn(healthCheckResultSet)
+        .thenThrow(NoHostAvailableException.class);
+        when(session.execute(any(Statement.class))).thenReturn(resultSet);
+        CQLSessionProvider cqlSessionProvider = Mockito.mock(CQLSessionProvider.class);
+        when(cqlSessionProvider.get()).thenReturn(session);
+        when(cqlSessionProvider.getIfConnected()).thenReturn(session);
+        return cqlSessionProvider;
+    }
+
+    private static @NotNull Vertx getMockVertx()
+    {
+        Vertx mockVertx = Mockito.mock(Vertx.class);
+        EventBus mockEventBus = Mockito.mock(EventBus.class);
+        when(mockVertx.eventBus()).thenReturn(mockEventBus);
+        return mockVertx;
+    }
+
+    @Test
+    public void nativeProtocolHealthCheckWhenHealthCheckSucceedsShouldSetNodeSettingsFromCql()
+    {
+        cassandraAdapterDelegate.nativeProtocolHealthCheck();
+        Map<String, String> actual = cassandraAdapterDelegate.cqlNodeSettings();
+        Map<String, String> expected = Map.of("concurrent_reads", "16");
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void cqlNodeSettingsWhenHealthCheckHasNotRanShouldThrowCassandraUnavailableException()
+    {
+        Assertions.assertThrows(CassandraUnavailableException.class, () -> cassandraAdapterDelegate.cqlNodeSettings());
+    }
+
+    @Test
+    public void cqlNodeSettingsWhenHealthCheckSucceedsThenFailsShouldUnsetCqlNodeSettings()
+    {
+        cassandraAdapterDelegate.nativeProtocolHealthCheck();
+        Map<String, String> actual = cassandraAdapterDelegate.cqlNodeSettings();
+        Map<String, String> expected = Map.of("concurrent_reads", "16");
+        Assertions.assertEquals(expected, actual);
+        cassandraAdapterDelegate.nativeProtocolHealthCheck();
+        Assertions.assertThrows(CassandraUnavailableException.class, () -> cassandraAdapterDelegate.cqlNodeSettings());
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -207,6 +207,8 @@ public class SidecarSchemaTest
 
             "SELECT name, value FROM system_views.settings WHERE name IN ?",
 
+            "SELECT name, value FROM system_views.settings",
+
             "SELECT * FROM system_views.clients",
 
             "SELECT username, COUNT(*) AS connection_count FROM system_views.clients"

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandlerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.cassandra.sidecar.handlers.v2.cassandra;
 
 import java.net.InetAddress;

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/v2/cassandra/V2NodeSettingsHandlerTest.java
@@ -1,0 +1,116 @@
+package org.apache.cassandra.sidecar.handlers.v2.cassandra;
+
+import java.net.InetAddress;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
+import org.apache.cassandra.sidecar.common.response.NodeSettings;
+import org.apache.cassandra.sidecar.common.response.v2.JmxNodeSettings;
+import org.apache.cassandra.sidecar.common.response.v2.V2NodeSettings;
+import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
+import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.config.ServiceConfiguration;
+import org.apache.cassandra.sidecar.config.WorkerPoolConfiguration;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.Mockito;
+
+/**
+ * The V2NodeSettingsHandlerTest is responsible for verifying that we are able to properly construct a V2NodeSettings
+ * response in the V2NodeSettings#handle function.
+ */
+public class V2NodeSettingsHandlerTest
+{
+    @Test
+    public void handleShouldWriteNodeSettingsJson()
+    {
+        CassandraAdapterDelegate adapter = buildMockAdapterDelegate();
+        InstanceMetadataFetcher metadataFetcher = Mockito.mock(InstanceMetadataFetcher.class);
+        Mockito.when(metadataFetcher.delegate(Mockito.any())).thenReturn(adapter);
+        ExecutorPools executorPools = buildMockExecutorPools();
+        V2NodeSettingsHandler v2NodeSettingsHandler = new V2NodeSettingsHandler(metadataFetcher, executorPools);
+        RoutingContext context = buildMockContext();
+        v2NodeSettingsHandler.handle(context);
+        JmxNodeSettings expectedJmxNodeSettings = buildJmxNodeSettings();
+        V2NodeSettings v2NodeSettings = V2NodeSettings.builder()
+                                                      .jmx(expectedJmxNodeSettings)
+                                                      .cassandra(Map.of("concurrent_reads", "16"))
+                                                      .sidecarVersion("0.2.0-SNAPSHOT")
+                                                      .build();
+        Mockito.verify(context, Mockito.times(1)).json(v2NodeSettings);
+    }
+
+
+
+    private CassandraAdapterDelegate buildMockAdapterDelegate()
+    {
+        CassandraAdapterDelegate cassandraAdapterDelegate = Mockito.mock(CassandraAdapterDelegate.class);
+        Mockito.when(cassandraAdapterDelegate.cqlNodeSettings()).thenReturn(Map.of("concurrent_reads", "16"));
+        NodeSettings nodeSettings = getNodeSettings();
+        Mockito.when(cassandraAdapterDelegate.nodeSettings()).thenReturn(nodeSettings);
+        return cassandraAdapterDelegate;
+    }
+
+    private JmxNodeSettings buildJmxNodeSettings()
+    {
+        NodeSettings nodeSettings = getNodeSettings();
+        return JmxNodeSettings.builder()
+               .releaseVersion(nodeSettings.releaseVersion())
+               .partitioner(nodeSettings.partitioner())
+               .datacenter(nodeSettings.datacenter())
+               .rpcAddress(nodeSettings.rpcAddress())
+               .rpcPort(nodeSettings.rpcPort())
+               .tokens(nodeSettings.tokens())
+               .build();
+    }
+
+    private static @NotNull NodeSettings getNodeSettings()
+    {
+        return NodeSettings.builder()
+                           .releaseVersion("4.1.10")
+                           .partitioner("Murmur3Partitioner")
+                           .datacenter("dc1")
+                           .rpcAddress(InetAddress.getLoopbackAddress())
+                           .rpcPort(9042)
+                           .sidecarVersion("0.2.0-SNAPSHOT")
+                           .tokens(Set.of("-00040404", "11101010"))
+                           .build();
+    }
+
+    private ExecutorPools buildMockExecutorPools()
+    {
+        ServiceConfiguration sidecarConfig = Mockito.mock(ServiceConfiguration.class);
+        WorkerPoolConfiguration workerPoolConfiguration = Mockito.mock(WorkerPoolConfiguration.class);
+        Mockito.when(workerPoolConfiguration.workerPoolName()).thenReturn("name");
+        Mockito.when(workerPoolConfiguration.workerPoolSize()).thenReturn(1);
+        Mockito.when(workerPoolConfiguration.workerMaxExecutionTime())
+               .thenReturn(new MillisecondBoundConfiguration(500, TimeUnit.MILLISECONDS));
+        Mockito.when(sidecarConfig.serverWorkerPoolConfiguration()).thenReturn(workerPoolConfiguration);
+        Mockito.when(sidecarConfig.serverInternalWorkerPoolConfiguration()).thenReturn(workerPoolConfiguration);
+        Vertx vertx = Mockito.mock(Vertx.class);
+        Mockito.when(vertx.createSharedWorkerExecutor(Mockito.any()))
+               .thenReturn(Mockito.mock(WorkerExecutor.class));
+        return new ExecutorPools(vertx, sidecarConfig);
+    }
+
+    private RoutingContext buildMockContext()
+    {
+        RoutingContext context = Mockito.mock(RoutingContext.class);
+        HttpServerRequest request = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(request.remoteAddress()).thenReturn(Mockito.mock(SocketAddress.class));
+        Mockito.when(request.host()).thenReturn("127.0.0.1");
+        Mockito.when(request.params()).thenReturn(Mockito.mock(MultiMap.class));
+        Mockito.when(context.request()).thenReturn(request);
+        return context;
+    }
+}


### PR DESCRIPTION
This patch adds a new endpoint (`/api/v2/cassandra/settings`) which differs from `/api/v1/cassandra/settings` in the following ways:
1) Adds authorization onto endpoint
2) Gives the caller the ability to read the configurations from `system_views.settings`.
3) Reformats the object returned from the API to provide additional structure, like so:

```
{
    "cassandra": { } // Key-value pairs containing the data from system_view.settings.
    "jmx": {} // The settings available via JMX by querying storage service / gossip mbeans. This data was at the top level in the original api/v1/settings object.
    "sidecar": {} // This contains sidecar configuration information. 
}
```