### PR TITLE
CASSSIDECAR-342: Sidecar endpoint for draining a node

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.3.0
 -----
+ * Sidecar endpoint for draining a node (CASSSIDECAR-342)
  * Sidecar endpoint for vending statistics related to compaction (CASSSIDECAR-329)
  * Update logging dependencies (CASSSIDECAR-337)
 

--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraStorageOperations.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraStorageOperations.java
@@ -240,6 +240,16 @@ public class CassandraStorageOperations implements StorageOperations
      * {@inheritDoc}
      */
     @Override
+    public void drain() throws IOException, InterruptedException, ExecutionException
+    {
+        jmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME)
+                 .drain();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean isGossipRunning()
     {
         return jmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME)

--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/jmx/GossipDependentStorageJmxOperations.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/jmx/GossipDependentStorageJmxOperations.java
@@ -173,6 +173,12 @@ public class GossipDependentStorageJmxOperations implements StorageJmxOperations
     }
 
     @Override
+    public void drain() throws IOException, InterruptedException, ExecutionException
+    {
+        delegate.drain();
+    }
+
+    @Override
     public String getClusterName()
     {
         return delegate.getClusterName();

--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/jmx/StorageJmxOperations.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/jmx/StorageJmxOperations.java
@@ -169,6 +169,11 @@ public interface StorageJmxOperations
     void decommission(boolean force) throws IllegalStateException, IllegalArgumentException, UnsupportedOperationException;
 
     /**
+     * Triggers the node drain operation
+     */
+    void drain() throws IOException, InterruptedException, ExecutionException;
+
+    /**
      * Fetch the operation-mode of the node
      *
      * @return string representation of the operation-mode

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV1.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/ApiEndpointsV1.java
@@ -140,6 +140,7 @@ public final class ApiEndpointsV1
     public static final String LIST_OPERATIONAL_JOBS_ROUTE = API_V1 + CASSANDRA + OPERATIONAL_JOBS;
     public static final String OPERATIONAL_JOB_ROUTE = API_V1 + CASSANDRA + PER_OPERATIONAL_JOB;
     public static final String NODE_DECOMMISSION_ROUTE = API_V1 + CASSANDRA + "/operations/decommission";
+    public static final String NODE_DRAIN_ROUTE = API_V1 + CASSANDRA + "/operations/drain";
     public static final String STREAM_STATS_ROUTE = API_V1 + CASSANDRA + "/stats/streams";
     public static final String TABLE_STATS_ROUTE = API_V1 + CASSANDRA + PER_KEYSPACE + PER_TABLE + "/stats";
 

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/NodeDrainRequest.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/NodeDrainRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.request;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.response.OperationalJobResponse;
+
+/**
+ * Represents a request to execute node drain operation
+ */
+public class NodeDrainRequest extends JsonRequest<OperationalJobResponse>
+{
+    /**
+     * Constructs a request to execute a node drain operation
+     */
+    public NodeDrainRequest()
+    {
+        super(ApiEndpointsV1.NODE_DRAIN_ROUTE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethod method()
+    {
+        return HttpMethod.PUT;
+    }
+}

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/RequestContext.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/RequestContext.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.sidecar.common.request.ListOperationalJobsRequest;
 import org.apache.cassandra.sidecar.common.request.ListSnapshotFilesRequest;
 import org.apache.cassandra.sidecar.common.request.NativeUpdateRequest;
 import org.apache.cassandra.sidecar.common.request.NodeDecommissionRequest;
+import org.apache.cassandra.sidecar.common.request.NodeDrainRequest;
 import org.apache.cassandra.sidecar.common.request.NodeSettingsRequest;
 import org.apache.cassandra.sidecar.common.request.OperationalJobRequest;
 import org.apache.cassandra.sidecar.common.request.ReportSchemaRequest;
@@ -87,6 +88,7 @@ public class RequestContext
     protected static final GossipInfoRequest GOSSIP_INFO_REQUEST = new GossipInfoRequest();
     protected static final ListOperationalJobsRequest LIST_JOBS_REQUEST = new ListOperationalJobsRequest();
     protected static final NodeDecommissionRequest NODE_DECOMMISSION_REQUEST = new NodeDecommissionRequest();
+    protected static final NodeDrainRequest NODE_DRAIN_REQUEST = new NodeDrainRequest();
 
     protected static final StreamStatsRequest STREAM_STATS_REQUEST = new StreamStatsRequest();
     protected static final RetryPolicy DEFAULT_NO_RETRY_POLICY = new NoRetryPolicy();
@@ -577,6 +579,17 @@ public class RequestContext
         public Builder nodeDecommissionRequest()
         {
             return request(NODE_DECOMMISSION_REQUEST);
+        }
+
+        /**
+         * Sets the {@code request} to be a {@link NodeDrainRequest} and returns a reference to this Builder
+         * enabling method chaining.
+         *
+         * @return a reference to this Builder
+         */
+        public Builder nodeDrainRequest()
+        {
+            return request(NODE_DRAIN_REQUEST);
         }
 
         /**

--- a/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
+++ b/client/src/main/java/org/apache/cassandra/sidecar/client/SidecarClient.java
@@ -823,6 +823,20 @@ public class SidecarClient implements AutoCloseable, SidecarClientBlobRestoreExt
     }
 
     /**
+     * Executes the node drain request using the default retry policy and configured selection policy
+     *
+     * @param instance the instance where the request will be executed
+     * @return a completable future of the jobs list
+     */
+    public CompletableFuture<OperationalJobResponse> nodeDrain(SidecarInstance instance)
+    {
+        return executor.executeRequestAsync(requestBuilder()
+                                            .singleInstanceSelectionPolicy(instance)
+                                            .nodeDrainRequest()
+                                            .build());
+    }
+
+    /**
      * Sends a request to start or stop Cassandra gossiping on the provided instance.
      * <p>
      * This operation asynchronously triggers start or stop of gossip via Cassandra's JMX interface.

--- a/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
+++ b/client/src/testFixtures/java/org/apache/cassandra/sidecar/client/SidecarClientTest.java
@@ -1391,6 +1391,25 @@ abstract class SidecarClientTest
     }
 
     @Test
+    public void testNodeDrain() throws Exception
+    {
+        UUID jobId = UUID.randomUUID();
+        String nodeDrainString = "{\"jobId\":\"" + jobId + "\",\"jobStatus\":\"SUCCEEDED\",\"instance\":\"127.0.0.1\"}";
+
+        MockResponse response = new MockResponse()
+                                .setResponseCode(OK.code())
+                                .setHeader("content-type", "application/json")
+                                .setBody(nodeDrainString);
+        enqueue(response);
+
+        SidecarInstanceImpl sidecarInstance = RequestExecutorTest.newSidecarInstance(servers.get(0));
+        OperationalJobResponse result = client.nodeDrain(sidecarInstance).get(30, TimeUnit.SECONDS);
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo(OperationalJobStatus.SUCCEEDED);
+        validateResponseServed(ApiEndpointsV1.NODE_DRAIN_ROUTE);
+    }
+
+    @Test
     void testFailsWithOneAttemptPerServer()
     {
         for (MockWebServer server : servers)

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CassandraNodeOperationsIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CassandraNodeOperationsIntegrationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.routes;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import org.apache.cassandra.sidecar.common.ApiEndpointsV1;
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.testing.SharedClusterSidecarIntegrationTestBase;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.apache.cassandra.testing.utils.AssertionUtils.getBlocking;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for Cassandra node drain operations
+ */
+public class CassandraNodeOperationsIntegrationTest extends SharedClusterSidecarIntegrationTestBase
+{
+    @Override
+    protected void initializeSchemaForTest()
+    {
+        // No schema init needed
+    }
+
+    @Override
+    protected void beforeTestStart()
+    {
+        // wait for the schema initialization
+        waitForSchemaReady(30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testNodeDrainOperationSuccess()
+    {
+        // Initiate drain operation
+        HttpResponse<Buffer> drainResponse = getBlocking(
+        trustedClient().put(serverWrapper.serverPort, "localhost", ApiEndpointsV1.NODE_DRAIN_ROUTE)
+                       .send());
+
+        assertThat(drainResponse.statusCode()).isEqualTo(OK.code());
+
+        JsonObject responseBody = drainResponse.bodyAsJsonObject();
+        assertThat(responseBody).isNotNull();
+        assertThat(responseBody.getString("jobId")).isNotNull();
+        assertThat(responseBody.getString("jobStatus")).isIn(
+        OperationalJobStatus.CREATED.name(),
+        OperationalJobStatus.RUNNING.name(),
+        OperationalJobStatus.SUCCEEDED.name()
+        );
+
+        // Wait 30 seconds for drain operation to complete
+        try
+        {
+            Thread.sleep(30000);
+        }
+        catch (InterruptedException e)
+        {
+            throw new RuntimeException(e);
+        }
+
+        // Verify node status is DRAINED by checking the operationMode via stream stats endpoint
+        HttpResponse<Buffer> streamStatsResponse = getBlocking(
+        trustedClient().get(serverWrapper.serverPort, "localhost", ApiEndpointsV1.STREAM_STATS_ROUTE)
+                       .send());
+
+        assertThat(streamStatsResponse.statusCode()).isEqualTo(OK.code());
+
+        JsonObject streamStats = streamStatsResponse.bodyAsJsonObject();
+        assertThat(streamStats).isNotNull();
+        assertThat(streamStats.getString("operationMode")).isEqualTo("DRAINED");
+    }
+}

--- a/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/StorageOperations.java
+++ b/server-common/src/main/java/org/apache/cassandra/sidecar/common/server/StorageOperations.java
@@ -119,6 +119,11 @@ public interface StorageOperations
     void decommission(boolean force);
 
     /**
+     * Triggers the node drain operation
+     */
+    void drain() throws IOException, InterruptedException, ExecutionException;
+
+    /**
      * @return returns true if gossip is running, false otherwise
      */
     boolean isGossipRunning();

--- a/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/BasicPermissions.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/acl/authorization/BasicPermissions.java
@@ -62,6 +62,7 @@ public class BasicPermissions
     // sidecar operation related permissions
     public static final Permission READ_OPERATIONAL_JOB = new DomainAwarePermission("OPERATIONAL_JOB:READ", OPERATION_SCOPE);
     public static final Permission DECOMMISSION_NODE = new DomainAwarePermission("NODE:DECOMMISSION", OPERATION_SCOPE);
+    public static final Permission DRAIN_NODE = new DomainAwarePermission("NODE:DRAIN", OPERATION_SCOPE);
 
     // Permissions related to Schema Reporting
     public static final Permission REPORT_SCHEMA = new DomainAwarePermission("SCHEMA:PUBLISH", CLUSTER_SCOPE);

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/AbstractHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/AbstractHandler.java
@@ -29,14 +29,21 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.HttpException;
 import org.apache.cassandra.sidecar.adapters.base.exception.OperationUnavailableException;
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.common.response.OperationalJobResponse;
 import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.common.server.data.QualifiedTableName;
 import org.apache.cassandra.sidecar.common.server.exceptions.JmxAuthenticationException;
 import org.apache.cassandra.sidecar.common.utils.Preconditions;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.config.ServiceConfiguration;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
+import org.apache.cassandra.sidecar.exceptions.OperationalJobConflictException;
+import org.apache.cassandra.sidecar.job.OperationalJob;
+import org.apache.cassandra.sidecar.job.OperationalJobManager;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.apache.cassandra.sidecar.utils.OperationalJobUtils;
 import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
@@ -316,5 +323,33 @@ public abstract class AbstractHandler<T> implements Handler<RoutingContext>
                    : hostWithoutPort; // return ipv4 directly
         }
         return host;
+    }
+
+    /**
+     * Handles the submission and execution of an operational job.
+     * 
+     * @param jobManager the manager responsible for submitting and tracking operational jobs
+     * @param config the service configuration containing execution parameters
+     * @param context the routing context for the HTTP request/response
+     * @param job the operational job to be executed
+     */
+    protected void handleOperationalJob(OperationalJobManager jobManager, ServiceConfiguration config, RoutingContext context, OperationalJob job)
+    {
+        try
+        {
+            jobManager.trySubmitJob(job);
+        }
+        catch (OperationalJobConflictException oje)
+        {
+            String reason = oje.getMessage();
+            logger.error("Conflicting job encountered. reason={}", reason);
+            context.response().setStatusCode(HttpResponseStatus.CONFLICT.code());
+            context.json(new OperationalJobResponse(job.jobId(), OperationalJobStatus.FAILED, job.name(), reason));
+            return;
+        }
+
+        // Get the result, waiting for the specified wait time for result
+        job.asyncResult(executorPools.service(), config.operationalJobExecutionMaxWaitTime())
+           .onComplete(v -> OperationalJobUtils.sendStatusBasedResponse(context, job));
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/NodeDrainHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/NodeDrainHandler.java
@@ -31,18 +31,16 @@ import org.apache.cassandra.sidecar.acl.authorization.BasicPermissions;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.ServiceConfiguration;
-import org.apache.cassandra.sidecar.job.NodeDecommissionJob;
+import org.apache.cassandra.sidecar.job.NodeDrainJob;
 import org.apache.cassandra.sidecar.job.OperationalJobManager;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.jetbrains.annotations.NotNull;
 
-import static org.apache.cassandra.sidecar.utils.RequestUtils.parseBooleanQueryParam;
-
 /**
- * Provides REST API for asynchronously decommissioning the corresponding Cassandra node
+ * Provides REST API for asynchronously draining the corresponding Cassandra node
  */
-public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements AccessProtected
+public class NodeDrainHandler extends AbstractHandler<Void> implements AccessProtected
 {
     private final OperationalJobManager jobManager;
     private final ServiceConfiguration config;
@@ -55,11 +53,11 @@ public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements
      * @param validator       a validator instance to validate Cassandra-specific input
      */
     @Inject
-    protected NodeDecommissionHandler(InstanceMetadataFetcher metadataFetcher,
-                                      ExecutorPools executorPools,
-                                      ServiceConfiguration serviceConfiguration,
-                                      CassandraInputValidator validator,
-                                      OperationalJobManager jobManager)
+    protected NodeDrainHandler(InstanceMetadataFetcher metadataFetcher,
+                               ExecutorPools executorPools,
+                               ServiceConfiguration serviceConfiguration,
+                               CassandraInputValidator validator,
+                               OperationalJobManager jobManager)
     {
         super(metadataFetcher, executorPools, validator);
         this.jobManager = jobManager;
@@ -69,7 +67,7 @@ public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements
     @Override
     public Set<Authorization> requiredAuthorizations()
     {
-        return Collections.singleton(BasicPermissions.DECOMMISSION_NODE.toAuthorization());
+        return Collections.singleton(BasicPermissions.DRAIN_NODE.toAuthorization());
     }
 
     /**
@@ -80,10 +78,10 @@ public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements
                                HttpServerRequest httpRequest,
                                @NotNull String host,
                                SocketAddress remoteAddress,
-                               Boolean isForce)
+                               Void unused)
     {
         StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
-        NodeDecommissionJob job = new NodeDecommissionJob(UUIDs.timeBased(), operations, isForce);
+        NodeDrainJob job = new NodeDrainJob(UUIDs.timeBased(), operations);
         handleOperationalJob(this.jobManager, this.config, context, job);
     }
 
@@ -91,8 +89,9 @@ public class NodeDecommissionHandler extends AbstractHandler<Boolean> implements
      * {@inheritDoc}
      */
     @Override
-    protected Boolean extractParamsOrThrow(RoutingContext context)
+    protected Void extractParamsOrThrow(RoutingContext context)
     {
-        return parseBooleanQueryParam(context.request(), "force", false);
+        // No parameters needed for drain operation
+        return null;
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/NodeDrainJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/NodeDrainJob.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
+
+/**
+ * Implementation of {@link OperationalJob} to perform node drain operation.
+ */
+public class NodeDrainJob extends OperationalJob
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeDrainJob.class);
+    private static final String OPERATION = "drain";
+    protected StorageOperations storageOperations;
+
+    /**
+     * Enum representing the various drain states of a Cassandra node.
+     */
+    public enum NodeDrainStateEnum
+    {
+        DRAINING(OperationalJobStatus.RUNNING),
+        DRAINED(OperationalJobStatus.SUCCEEDED);
+
+        final OperationalJobStatus jobStatus;
+
+        NodeDrainStateEnum(OperationalJobStatus jobStatus)
+        {
+            this.jobStatus = jobStatus;
+        }
+
+        /**
+         * Converts a string operation mode to a DrainState enum.
+         *
+         * @param operationMode the operation mode string
+         * @return the corresponding DrainState, or null if not a drain state
+         */
+        public static NodeDrainStateEnum fromOperationMode(String operationMode)
+        {
+            try
+            {
+                return valueOf(operationMode);
+            }
+            catch (IllegalArgumentException | NullPointerException e)
+            {
+                return null;
+            }
+        }
+    }
+
+    public NodeDrainJob(UUID jobId, StorageOperations storageOps)
+    {
+        super(jobId);
+        this.storageOperations = storageOps;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isRunningOnCassandra()
+    {
+        String operationMode = storageOperations.operationMode();
+        NodeDrainStateEnum nodeDrainStateEnum = NodeDrainStateEnum.fromOperationMode(operationMode);
+        return nodeDrainStateEnum != null && nodeDrainStateEnum.jobStatus == OperationalJobStatus.RUNNING;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OperationalJobStatus status()
+    {
+        String operationMode = storageOperations.operationMode();
+        NodeDrainStateEnum nodeDrainStateEnum = NodeDrainStateEnum.fromOperationMode(operationMode);
+
+        if (nodeDrainStateEnum != null)
+        {
+            return nodeDrainStateEnum.jobStatus;
+        }
+        return super.status();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void executeInternal()
+    {
+        if (isRunningOnCassandra())
+        {
+            LOGGER.info("Not executing job as an ongoing drain operation was found jobId={}", this.jobId());
+            return;
+        }
+
+        LOGGER.info("Executing drain operation. jobId={}", this.jobId());
+        try
+        {
+            storageOperations.drain();
+        }
+        catch (IOException | ExecutionException | InterruptedException ex)
+        {
+            LOGGER.error("Job execution failed. jobId={} reason='{}'", this.jobId(), ex.getMessage(), ex);
+            throw OperationalJobException.wraps(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String name()
+    {
+        return OPERATION;
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.sidecar.handlers.KeyspaceSchemaHandler;
 import org.apache.cassandra.sidecar.handlers.ListOperationalJobsHandler;
 import org.apache.cassandra.sidecar.handlers.NativeUpdateHandler;
 import org.apache.cassandra.sidecar.handlers.NodeDecommissionHandler;
+import org.apache.cassandra.sidecar.handlers.NodeDrainHandler;
 import org.apache.cassandra.sidecar.handlers.OperationalJobHandler;
 import org.apache.cassandra.sidecar.handlers.RingHandler;
 import org.apache.cassandra.sidecar.handlers.SchemaHandler;
@@ -154,6 +155,22 @@ public class CassandraOperationsModule extends AbstractModule
                                               NodeDecommissionHandler nodeDecommissionHandler)
     {
         return factory.buildRouteWithHandler(nodeDecommissionHandler);
+    }
+
+    @PUT
+    @Path(ApiEndpointsV1.NODE_DRAIN_ROUTE)
+    @Operation(summary = "Drain node",
+               description = "Drains the Cassandra node by flushing memtables and stopping writes")
+    @APIResponse(description = "Node drain operation initiated successfully",
+                 responseCode = "200",
+                 content = @Content(mediaType = "application/json",
+                 schema = @Schema(implementation = OperationalJobResponse.class)))
+    @ProvidesIntoMap
+    @KeyClassMapKey(VertxRouteMapKeys.CassandraNodeDrainRouteKey.class)
+    VertxRoute cassandraNodeDrainRoute(RouteBuilder.Factory factory,
+                                       NodeDrainHandler nodeDrainHandler)
+    {
+        return factory.buildRouteWithHandler(nodeDrainHandler);
     }
 
     @GET

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/multibindings/VertxRouteMapKeys.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/multibindings/VertxRouteMapKeys.java
@@ -83,6 +83,11 @@ public interface VertxRouteMapKeys
         HttpMethod HTTP_METHOD = HttpMethod.PUT;
         String ROUTE_URI = ApiEndpointsV1.NODE_DECOMMISSION_ROUTE;
     }
+    interface CassandraNodeDrainRouteKey extends RouteClassKey
+    {
+        HttpMethod HTTP_METHOD = HttpMethod.PUT;
+        String ROUTE_URI = ApiEndpointsV1.NODE_DRAIN_ROUTE;
+    }
     interface CassandraNodeSettingsRouteKey extends RouteClassKey
     {
         HttpMethod HTTP_METHOD = HttpMethod.GET;

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/NodeDrainHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/NodeDrainHandlerTest.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.handlers;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.util.Modules;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.TestModule;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
+import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.apache.cassandra.sidecar.common.response.OperationalJobResponse;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+import org.apache.cassandra.sidecar.modules.SidecarModules;
+import org.apache.cassandra.sidecar.server.Server;
+import org.mockito.AdditionalAnswers;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED;
+import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCCEEDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the {@link NodeDrainHandler}
+ */
+@ExtendWith(VertxExtension.class)
+public class NodeDrainHandlerTest
+{
+    static final Logger LOGGER = LoggerFactory.getLogger(NodeDrainHandlerTest.class);
+    static final String TEST_ROUTE = "/api/v1/cassandra/operations/drain";
+    static final String OPERATION_MODE_NORMAL = "NORMAL";
+    static final String OPERATION_MODE_DRAINING = "DRAINING";
+    static final String OPERATION_MODE_JOINING = "JOINING";
+    static final String EXPECTED_OPERATION_NAME = "drain";
+    static final String SIMULATED_DRAIN_FAILURE = "Simulated drain failure";
+
+    Vertx vertx;
+    Server server;
+    StorageOperations mockStorageOperations = mock(StorageOperations.class);
+
+    @BeforeEach
+    void before() throws InterruptedException
+    {
+        Injector injector;
+        Module testOverride = Modules.override(new TestModule())
+                                     .with(new NodeDrainHandlerTest.NodeDrainTestModule());
+        injector = Guice.createInjector(Modules.override(SidecarModules.all())
+                                               .with(testOverride));
+        vertx = injector.getInstance(Vertx.class);
+        server = injector.getInstance(Server.class);
+        VertxTestContext context = new VertxTestContext();
+        server.start()
+              .onSuccess(s -> context.completeNow())
+              .onFailure(context::failNow);
+        context.awaitCompletion(5, TimeUnit.SECONDS);
+    }
+
+    @AfterEach
+    void after() throws InterruptedException
+    {
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        server.close().onSuccess(res -> closeLatch.countDown());
+        if (closeLatch.await(60, TimeUnit.SECONDS))
+            LOGGER.info("Close event received before timeout.");
+        else
+            LOGGER.error("Close event timed out.");
+    }
+
+    @Test
+    void testDrainLongRunning(VertxTestContext context) throws Exception
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        doAnswer(AdditionalAnswers.answersWithDelay(6000, invocation -> null))
+        .when(mockStorageOperations).drain();
+
+        WebClient client = WebClient.create(vertx);
+        client.put(server.actualPort(), "127.0.0.1", TEST_ROUTE)
+              .expect(ResponsePredicate.SC_ACCEPTED)
+              .send(context.succeeding(response -> {
+                  assertThat(response.statusCode()).isEqualTo(ACCEPTED.code());
+                  OperationalJobResponse drainResponse = response.bodyAsJson(OperationalJobResponse.class);
+                  assertThat(drainResponse).isNotNull();
+                  assertThat(drainResponse.status()).isEqualTo(RUNNING);
+                  assertThat(drainResponse.jobId()).isNotNull();
+                  assertThat(drainResponse.operation()).isEqualTo(EXPECTED_OPERATION_NAME);
+                  context.completeNow();
+              }));
+    }
+
+    @Test
+    void testDrainCompleted(VertxTestContext context)
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+
+        WebClient client = WebClient.create(vertx);
+        client.put(server.actualPort(), "127.0.0.1", TEST_ROUTE)
+              .send(context.succeeding(response -> {
+                  assertThat(response.statusCode()).isEqualTo(OK.code());
+                  LOGGER.info("Drain Response: {}", response.bodyAsString());
+
+                  OperationalJobResponse drainResponse = response.bodyAsJson(OperationalJobResponse.class);
+                  assertThat(drainResponse).isNotNull();
+                  assertThat(drainResponse.status()).isEqualTo(SUCCEEDED);
+                  assertThat(drainResponse.jobId()).isNotNull();
+                  assertThat(drainResponse.operation()).isEqualTo(EXPECTED_OPERATION_NAME);
+                  context.completeNow();
+              }));
+    }
+
+    @Test
+    void testDrainFailed(VertxTestContext context) throws Exception
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        doThrow(new RuntimeException(SIMULATED_DRAIN_FAILURE)).when(mockStorageOperations).drain();
+
+        WebClient client = WebClient.create(vertx);
+        client.put(server.actualPort(), "127.0.0.1", TEST_ROUTE)
+              .expect(ResponsePredicate.SC_OK)
+              .send(context.succeeding(response -> {
+                  assertThat(response.statusCode()).isEqualTo(OK.code());
+                  LOGGER.info("Drain Response: {}", response.bodyAsString());
+
+                  OperationalJobResponse drainResponse = response.bodyAsJson(OperationalJobResponse.class);
+                  assertThat(drainResponse).isNotNull();
+                  assertThat(drainResponse.jobId()).isNotNull();
+                  assertThat(drainResponse.operation()).isEqualTo(EXPECTED_OPERATION_NAME);
+                  context.completeNow();
+              }));
+    }
+
+    @Test
+    void testDrainConflictWhenDraining(VertxTestContext context)
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_DRAINING);
+
+        WebClient client = WebClient.create(vertx);
+        client.put(server.actualPort(), "127.0.0.1", TEST_ROUTE)
+              .expect(ResponsePredicate.SC_CONFLICT)
+              .send(context.succeeding(response -> {
+                  assertThat(response.statusCode()).isEqualTo(CONFLICT.code());
+                  LOGGER.info("Drain Response: {}", response.bodyAsString());
+
+                  OperationalJobResponse drainResponse = response.bodyAsJson(OperationalJobResponse.class);
+                  assertThat(drainResponse).isNotNull();
+                  assertThat(drainResponse.jobId()).isNotNull();
+                  assertThat(drainResponse.operation()).isEqualTo(EXPECTED_OPERATION_NAME);
+                  context.completeNow();
+              }));
+    }
+
+    @Test
+    void testDrainAllowedWhenJoining(VertxTestContext context)
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_JOINING);
+
+        WebClient client = WebClient.create(vertx);
+        client.put(server.actualPort(), "127.0.0.1", TEST_ROUTE)
+              .send(context.succeeding(response -> {
+                  assertThat(response.statusCode()).isEqualTo(OK.code());
+                  LOGGER.info("Drain Response: {}", response.bodyAsString());
+
+                  OperationalJobResponse drainResponse = response.bodyAsJson(OperationalJobResponse.class);
+                  assertThat(drainResponse).isNotNull();
+                  assertThat(drainResponse.status()).isEqualTo(SUCCEEDED);
+                  assertThat(drainResponse.jobId()).isNotNull();
+                  assertThat(drainResponse.operation()).isEqualTo(EXPECTED_OPERATION_NAME);
+                  context.completeNow();
+              }));
+    }
+
+    /**
+     * Test guice module for Node Drain handler tests
+     */
+    class NodeDrainTestModule extends AbstractModule
+    {
+        @Provides
+        @Singleton
+        public InstancesMetadata instanceMetadata()
+        {
+            final int instanceId = 100;
+            final String host = "127.0.0.1";
+            final InstanceMetadata instanceMetadata = mock(InstanceMetadata.class);
+            when(instanceMetadata.host()).thenReturn(host);
+            when(instanceMetadata.port()).thenReturn(9042);
+            when(instanceMetadata.id()).thenReturn(instanceId);
+            when(instanceMetadata.stagingDir()).thenReturn("");
+
+            CassandraAdapterDelegate delegate = mock(CassandraAdapterDelegate.class);
+
+            when(delegate.storageOperations()).thenReturn(mockStorageOperations);
+            when(instanceMetadata.delegate()).thenReturn(delegate);
+
+            InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
+            when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
+            when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
+
+            return mockInstancesMetadata;
+        }
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/NodeDrainJobTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/NodeDrainJobTest.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.datastax.driver.core.utils.UUIDs;
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NodeDrainJob}
+ */
+class NodeDrainJobTest
+{
+    private static final String OPERATION_MODE_DRAINING = "DRAINING";
+    private static final String OPERATION_MODE_DRAINED = "DRAINED";
+    private static final String OPERATION_MODE_NORMAL = "NORMAL";
+    private static final String OPERATION_MODE_UNKNOWN = "UNKNOWN";
+    private static final String JOB_NAME_DRAIN = "drain";
+    
+    private StorageOperations mockStorageOperations;
+    private NodeDrainJob nodeDrainJob;
+    private UUID jobId;
+
+    @BeforeEach
+    void setup()
+    {
+        mockStorageOperations = mock(StorageOperations.class);
+        jobId = UUIDs.timeBased();
+        nodeDrainJob = new NodeDrainJob(jobId, mockStorageOperations);
+    }
+
+    @Test
+    void testJobIdAndName()
+    {
+        assertThat(nodeDrainJob.jobId()).isEqualTo(jobId);
+        assertThat(nodeDrainJob.name()).isEqualTo(JOB_NAME_DRAIN);
+    }
+
+    @Test
+    void testIsRunningOnCassandra_WhenDraining()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_DRAINING);
+        
+        assertThat(nodeDrainJob.isRunningOnCassandra()).isTrue();
+    }
+
+    @Test
+    void testIsRunningOnCassandra_WhenDrained()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_DRAINED);
+        
+        assertThat(nodeDrainJob.isRunningOnCassandra()).isFalse();
+    }
+
+    @Test
+    void testIsRunningOnCassandra_WhenNormal()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        
+        assertThat(nodeDrainJob.isRunningOnCassandra()).isFalse();
+    }
+
+    @Test
+    void testIsRunningOnCassandra_WhenUnknownState()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_UNKNOWN);
+        
+        assertThat(nodeDrainJob.isRunningOnCassandra()).isFalse();
+    }
+
+    @Test
+    void testIsRunningOnCassandra_WhenNull()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(null);
+        
+        assertThat(nodeDrainJob.isRunningOnCassandra()).isFalse();
+    }
+
+    @Test
+    void testStatus_WhenDraining()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_DRAINING);
+        
+        assertThat(nodeDrainJob.status()).isEqualTo(OperationalJobStatus.RUNNING);
+    }
+
+    @Test
+    void testStatus_WhenDrained()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_DRAINED);
+        
+        assertThat(nodeDrainJob.status()).isEqualTo(OperationalJobStatus.SUCCEEDED);
+    }
+
+    @Test
+    void testStatus_WhenNormal()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        
+        assertThat(nodeDrainJob.status()).isEqualTo(OperationalJobStatus.CREATED);
+    }
+
+    @Test
+    void testStatus_WhenUnknownState()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_UNKNOWN);
+        
+        assertThat(nodeDrainJob.status()).isEqualTo(OperationalJobStatus.CREATED);
+    }
+
+    @Test
+    void testStatus_WhenNull()
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(null);
+        
+        assertThat(nodeDrainJob.status()).isEqualTo(OperationalJobStatus.CREATED);
+    }
+
+    @Test
+    void testExecuteInternal_WhenNotRunning() throws IOException, ExecutionException, InterruptedException
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        
+        nodeDrainJob.executeInternal();
+        
+        verify(mockStorageOperations).drain();
+    }
+
+    @Test
+    void testExecuteInternal_WhenAlreadyDraining() throws IOException, ExecutionException, InterruptedException
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_DRAINING);
+        
+        nodeDrainJob.executeInternal();
+        
+        verify(mockStorageOperations, never()).drain();
+    }
+
+    @Test
+    void testExecuteInternal_WhenDrainThrowsIOException() throws IOException, ExecutionException, InterruptedException
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        IOException ioException = new IOException("Drain failed due to IO error");
+        doThrow(ioException).when(mockStorageOperations).drain();
+        
+        assertThatThrownBy(() -> nodeDrainJob.executeInternal())
+            .isInstanceOf(OperationalJobException.class)
+            .hasCause(ioException);
+        
+        verify(mockStorageOperations).drain();
+    }
+
+    @Test
+    void testExecuteInternal_WhenDrainThrowsExecutionException() throws IOException, ExecutionException, InterruptedException
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        ExecutionException executionException = new ExecutionException("Drain failed during execution", new RuntimeException());
+        doThrow(executionException).when(mockStorageOperations).drain();
+        
+        assertThatThrownBy(() -> nodeDrainJob.executeInternal())
+            .isInstanceOf(OperationalJobException.class)
+            .hasCause(executionException);
+        
+        verify(mockStorageOperations).drain();
+    }
+
+    @Test
+    void testExecuteInternal_WhenDrainThrowsInterruptedException() throws IOException, ExecutionException, InterruptedException
+    {
+        when(mockStorageOperations.operationMode()).thenReturn(OPERATION_MODE_NORMAL);
+        InterruptedException interruptedException = new InterruptedException("Drain was interrupted");
+        doThrow(interruptedException).when(mockStorageOperations).drain();
+        
+        assertThatThrownBy(() -> nodeDrainJob.executeInternal())
+            .isInstanceOf(OperationalJobException.class)
+            .hasCause(interruptedException);
+        
+        verify(mockStorageOperations).drain();
+    }
+
+    @Test
+    void testNodeDrainStateEnum_FromOperationMode()
+    {
+        assertThat(NodeDrainJob.NodeDrainStateEnum.fromOperationMode(OPERATION_MODE_DRAINING))
+            .isEqualTo(NodeDrainJob.NodeDrainStateEnum.DRAINING);
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.fromOperationMode(OPERATION_MODE_DRAINED))
+            .isEqualTo(NodeDrainJob.NodeDrainStateEnum.DRAINED);
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.fromOperationMode(OPERATION_MODE_NORMAL))
+            .isNull();
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.fromOperationMode(OPERATION_MODE_UNKNOWN))
+            .isNull();
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.fromOperationMode(null))
+            .isNull();
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.fromOperationMode(""))
+            .isNull();
+    }
+
+    @Test
+    void testNodeDrainStateEnum_JobStatusMapping()
+    {
+        assertThat(NodeDrainJob.NodeDrainStateEnum.DRAINING.jobStatus)
+            .isEqualTo(OperationalJobStatus.RUNNING);
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.DRAINED.jobStatus)
+            .isEqualTo(OperationalJobStatus.SUCCEEDED);
+    }
+
+    @Test
+    void testNodeDrainStateEnum_Values()
+    {
+        NodeDrainJob.NodeDrainStateEnum[] expectedValues = {
+            NodeDrainJob.NodeDrainStateEnum.DRAINING,
+            NodeDrainJob.NodeDrainStateEnum.DRAINED
+        };
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.values()).containsExactly(expectedValues);
+    }
+
+    @Test
+    void testNodeDrainStateEnum_ValueOf()
+    {
+        assertThat(NodeDrainJob.NodeDrainStateEnum.valueOf(OPERATION_MODE_DRAINING))
+            .isEqualTo(NodeDrainJob.NodeDrainStateEnum.DRAINING);
+        
+        assertThat(NodeDrainJob.NodeDrainStateEnum.valueOf(OPERATION_MODE_DRAINED))
+            .isEqualTo(NodeDrainJob.NodeDrainStateEnum.DRAINED);
+        
+        assertThatThrownBy(() -> NodeDrainJob.NodeDrainStateEnum.valueOf(OPERATION_MODE_NORMAL))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
### Sidecar endpoint for draining a node

These changes are part of the effort to introduce bespoke Sidecar APIs to support key operational functionality currently managed through nodetool commands. Changes in the commit:

* API for draining a node
* Unit tests
* Integration tests