### PR TITLE
CASSSIDECAR-395: Returning JSON response for live migration status endpoints when returning error status codes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.3.0
 -----
+ * Returning JSON responses for live migration status endpoints in case of errors (CASSSIDECAR-395)
  * Upgrade vertx to 4.5.23 (CASSSIDECAR-391)
  * Fix for deadlock during JMX reconnection (CASSSIDECAR-390)
  * Fix request execution continues on wrong thread (CASSSIDECAR-368)

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationStatusCompleteHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationStatusCompleteHandler.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.Json;
@@ -42,6 +41,10 @@ import org.apache.cassandra.sidecar.livemigration.LiveMigrationStatusTracker;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.jetbrains.annotations.NotNull;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
 /**
  * Handler to safely mark a live migration as COMPLETED for an instance.
@@ -113,15 +116,13 @@ public class LiveMigrationStatusCompleteHandler extends AbstractHandler<Void> im
                                       instanceMetadata.host(), e);
                          if (e instanceof IllegalStateException)
                          {
-                             routingContext.response()
-                                           .setStatusCode(HttpResponseStatus.BAD_REQUEST.code())
-                                           .end("Live migration marked as COMPLETED earlier.");
+                             routingContext.fail(wrapHttpException(BAD_REQUEST,
+                                                                   "Live migration marked as COMPLETED earlier."));
                          }
                          else
                          {
-                             routingContext.response()
-                                           .setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code())
-                                           .end("Could not update Live Migration as complete.");
+                             routingContext.fail(wrapHttpException(SERVICE_UNAVAILABLE,
+                                                                   "Could not update Live Migration as complete."));
                          }
                      });
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationStatusGetHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationStatusGetHandler.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.auth.authorization.Authorization;
@@ -36,6 +35,9 @@ import org.apache.cassandra.sidecar.livemigration.LiveMigrationStatusTracker;
 import org.apache.cassandra.sidecar.utils.CassandraInputValidator;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.jetbrains.annotations.NotNull;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
+import static org.apache.cassandra.sidecar.utils.HttpExceptions.wrapHttpException;
 
 /**
  * Handler to retrieve the current live migration status for an instance.
@@ -73,9 +75,8 @@ public class LiveMigrationStatusGetHandler extends AbstractHandler<Void> impleme
         InstanceMetadata instance = metadataFetcher.instance(host);
         statusTracker.getMigrationStatus(instance)
                      .compose(routingContext::json)
-                     .onFailure(e -> routingContext.response()
-                                                   .setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code())
-                                                   .end(e.getMessage()));
+                     .onFailure(e -> routingContext.fail(wrapHttpException(SERVICE_UNAVAILABLE,
+                                                                           e.getMessage())));
     }
 
     @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationStatusHandlersTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationStatusHandlersTest.java
@@ -164,6 +164,7 @@ class LiveMigrationStatusHandlersTest
                                   .send()
                                   .compose(response -> {
                                       assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+                                      assertThat(response.bodyAsJsonObject()).isNotNull();
                                       return Future.succeededFuture();
                                   }))
               .onSuccess(r -> context.completeNow())
@@ -251,6 +252,7 @@ class LiveMigrationStatusHandlersTest
               .send()
               .compose(response -> {
                   assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.SERVICE_UNAVAILABLE.code());
+                  assertThat(response.bodyAsJsonObject()).isNotNull();
                   return Future.succeededFuture();
               })
               .onSuccess(r -> context.completeNow())


### PR DESCRIPTION
CASSSIDECAR-395 Update live migration status endpoints error response format to JSON (from text)
