### PR TITLE
CASSSIDECAR-420 Add manual approval step to CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,8 +333,14 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build-dtest-jdk11
-      - client_only_unit_java8
+      - approve-build:
+          type: approval
+      - build-dtest-jdk11:
+          requires:
+            - approve-build
+      - client_only_unit_java8:
+          requires:
+            - approve-build
       - unit_java11:
           requires:
             - build-dtest-jdk11


### PR DESCRIPTION
CASSSIDECAR-420: Added manual approval step to CircleCI pipeline so that they can be started when needed.

After this change, the user needs to give one-time approval to start the CI pipelines.

<img width="523" height="591" alt="image" src="https://github.com/user-attachments/assets/a2ee4b15-a275-4a37-95ac-c4fd5c5d7033" />
