### PR TITLE
CASSSIDECAR-415: Support IAM instance profile credentials for S3 rest…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Support IAM instance profile credentials for S3 restore jobs (CASSSIDECAR-415)
  * Adding endpoint for verifying files post data copy during live migration (CASSSIDECAR-226)
  * SAI support in Sidecar (CASSSIDECAR-422)
  * Update OperationalJob to support cluster-wide operations (CASSSIDECAR-376)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,20 @@
 0.4
 ===
 
+Upgrading
+---------
+    - In CASSSIDECAR-415, a new internal table (restore_job_v6) is created to support IAM credential
+      tracking for restore jobs. Spark jobs performing S3 restores should be paused during sidecar
+      upgrade to ensure in-flight restore job state is not lost.
+
+New features
+------------
+    - IAM instance profile credential support for S3 restore jobs (CASSSIDECAR-415). Sidecar can now
+      resolve AWS credentials automatically from the platform (IMDS/ECS/EKS) without requiring key
+      material to be passed by the caller. Set credentialType to IAM when creating a restore job to
+      enable this mode.
+    - SAI (Storage Attached Index) support in Sidecar (CASSSIDECAR-422).
+
 0.3
 ===
 

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/CredentialType.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/CredentialType.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.data;
+
+/**
+ * Declares the credential type used by a restore job to authenticate with cloud storage.
+ */
+public enum CredentialType
+{
+    /** Static STS credentials: accessKeyId, secretAccessKey, and sessionToken must all be present. */
+    STATIC,
+    /** IAM instance profile (or ECS task role / IRSA): only region is required; key fields must be absent. */
+    IAM
+}

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobConstants.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobConstants.java
@@ -27,6 +27,7 @@ public class RestoreJobConstants
     public static final String JOB_AGENT = "jobAgent";
     public static final String JOB_STATUS = "status";
     public static final String JOB_SECRETS = "secrets";
+    public static final String JOB_CREDENTIAL_TYPE = "credentialType";
     public static final String JOB_EXPIRE_AT = "expireAt";
     public static final String JOB_SLICE_COUNT = "sliceCount";
     public static final String JOB_IMPORT_OPTIONS = "importOptions";

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobSecrets.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/RestoreJobSecrets.java
@@ -31,6 +31,26 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.SECRE
  */
 public class RestoreJobSecrets
 {
+    /**
+     * Creates a {@link RestoreJobSecrets} for IAM instance profile mode.
+     *
+     * <p>In IAM mode no static keys are provided; the AWS SDK resolves credentials via the default
+     * credential chain (IAM instance profile, ECS task role, environment variables, etc.). Only the
+     * region is required so the SDK can route requests to the correct S3 endpoint.
+     *
+     * <p>The same region-only {@link StorageCredentials} is used for both read and write because in
+     * IAM mode a single instance profile covers both operations.
+     *
+     * @param region the AWS region of the S3 bucket (e.g. {@code "us-east-1"})
+     * @return a region-only {@link RestoreJobSecrets} instance signalling IAM mode
+     */
+    public static RestoreJobSecrets iamMode(String region)
+    {
+        StorageCredentials regionOnly = StorageCredentials.builder().region(region).build();
+        return new RestoreJobSecrets(regionOnly, regionOnly);
+    }
+
+
     private final StorageCredentials writeCredentials;
     private final StorageCredentials readCredentials;
 

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/StorageCredentials.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/data/StorageCredentials.java
@@ -21,7 +21,9 @@ package org.apache.cassandra.sidecar.common.data;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDENTIALS_ACCESS_KEY_ID;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDENTIALS_REGION;
@@ -31,11 +33,12 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.CREDE
 /**
  * Used for storing credential details needed for either reading/writing to S3
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StorageCredentials
 {
-    private final String accessKeyId;
-    private final String secretAccessKey;
-    private final String sessionToken;
+    private final @Nullable String accessKeyId;
+    private final @Nullable String secretAccessKey;
+    private final @Nullable String sessionToken;
     private final String region;
 
     public static Builder builder()
@@ -44,14 +47,11 @@ public class StorageCredentials
     }
 
     @JsonCreator
-    public StorageCredentials(@JsonProperty(CREDENTIALS_ACCESS_KEY_ID) String accessKeyId,
-                              @JsonProperty(CREDENTIALS_SECRET_ACCESS_KEY) String secretAccessKey,
-                              @JsonProperty(CREDENTIALS_SESSION_TOKEN) String sessionToken,
+    public StorageCredentials(@JsonProperty(CREDENTIALS_ACCESS_KEY_ID) @Nullable String accessKeyId,
+                              @JsonProperty(CREDENTIALS_SECRET_ACCESS_KEY) @Nullable String secretAccessKey,
+                              @JsonProperty(CREDENTIALS_SESSION_TOKEN) @Nullable String sessionToken,
                               @JsonProperty(CREDENTIALS_REGION) String region)
     {
-        Objects.requireNonNull(accessKeyId, "accessKeyId must be supplied");
-        Objects.requireNonNull(secretAccessKey, "secretAccessKey must be supplied");
-        Objects.requireNonNull(sessionToken, "sessionToken must be supplied");
         Objects.requireNonNull(region, "region must be supplied");
         this.accessKeyId = accessKeyId;
         this.secretAccessKey = secretAccessKey;
@@ -60,19 +60,19 @@ public class StorageCredentials
     }
 
     @JsonProperty(CREDENTIALS_ACCESS_KEY_ID)
-    public String accessKeyId()
+    public @Nullable String accessKeyId()
     {
         return accessKeyId;
     }
 
     @JsonProperty(CREDENTIALS_SECRET_ACCESS_KEY)
-    public String secretAccessKey()
+    public @Nullable String secretAccessKey()
     {
         return secretAccessKey;
     }
 
     @JsonProperty(CREDENTIALS_SESSION_TOKEN)
-    public String sessionToken()
+    public @Nullable String sessionToken()
     {
         return sessionToken;
     }
@@ -84,7 +84,28 @@ public class StorageCredentials
     }
 
     /**
-     * @return secrets string with redacted values
+     * Returns true if all three key fields ({@code accessKeyId}, {@code secretAccessKey}, {@code sessionToken})
+     * are non-null, indicating that static AWS credentials are present and should be used.
+     *
+     * <p>All three fields are required together because the sidecar exclusively uses
+     * {@code AwsSessionCredentials} — STS-issued short-lived
+     * credentials that include a session token. Long-term IAM user keys (key + secret without a token)
+     * are intentionally unsupported: they cannot expire, carry broader permissions, and pose a higher
+     * blast radius if leaked. Callers that want permanent access should use IAM instance profiles instead.
+     *
+     * <p>A return value of {@code false} means the key fields are absent. Callers that have already validated
+     * credentials via {@link org.apache.cassandra.sidecar.common.request.data.CreateRestoreJobRequestPayload}
+     * can treat this as an indication to use the AWS default credential chain (IAM instance profile, etc.).
+     * Callers that have not performed that validation should not assume {@code false} implies a valid IAM state —
+     * it could also mean partially-populated credentials that were not yet rejected.
+     */
+    public boolean hasStaticCredentials()
+    {
+        return accessKeyId != null && secretAccessKey != null && sessionToken != null;
+    }
+
+    /**
+     * @return credentials string with all secret values redacted; safe for logging
      */
     @Override
     public String toString()
@@ -119,13 +140,13 @@ public class StorageCredentials
     }
 
     /**
-     * Builds the RestoreJobSecrets
+     * Builds a {@link StorageCredentials} instance
      */
     public static class Builder
     {
-        private String accessKeyId;
-        private String secretAccessKey;
-        private String sessionToken;
+        private @Nullable String accessKeyId;
+        private @Nullable String secretAccessKey;
+        private @Nullable String sessionToken;
         private String region;
 
         private Builder()

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/data/CreateRestoreJobRequestPayload.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/request/data/CreateRestoreJobRequestPayload.java
@@ -29,15 +29,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.sidecar.common.DataObjectBuilder;
 import org.apache.cassandra.sidecar.common.data.ConsistencyConfig;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
+import org.apache.cassandra.sidecar.common.data.StorageCredentials;
 import org.apache.cassandra.sidecar.common.utils.Preconditions;
 import org.apache.cassandra.sidecar.common.utils.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_AGENT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_CONSISTENCY_LEVEL;
+import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_CREDENTIAL_TYPE;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_EXPIRE_AT;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_ID;
 import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_IMPORT_OPTIONS;
@@ -47,6 +50,19 @@ import static org.apache.cassandra.sidecar.common.data.RestoreJobConstants.JOB_S
 
 /**
  * Request payload for creating restore jobs.
+ *
+ * <p>Two credential modes are supported, selected by the {@code credentialType} field:
+ * <ul>
+ *   <li><b>{@link CredentialType#STATIC}</b> (default when {@code credentialType} is absent): all three key
+ *       fields ({@code accessKeyId}, {@code secretAccessKey}, {@code sessionToken}) must be present on both
+ *       {@code readCredentials} and {@code writeCredentials}.</li>
+ *   <li><b>{@link CredentialType#IAM}</b>: key fields must be absent; only {@code region} is required so
+ *       the AWS SDK can route requests to the correct S3 endpoint. Use
+ *       {@link RestoreJobSecrets#iamMode(String)} to build the secrets object for this mode.</li>
+ * </ul>
+ *
+ * <p>The {@code credentialType} field drives validation: passing credentials that do not match the declared
+ * type is rejected at construction time to surface misconfigurations before they reach the AWS SDK.
  */
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class CreateRestoreJobRequestPayload
@@ -54,16 +70,25 @@ public class CreateRestoreJobRequestPayload
     private final UUID jobId;
     private final String jobAgent;
     private final RestoreJobSecrets secrets;
+    private final CredentialType credentialType;
     private final SSTableImportOptions importOptions;
     private final long expireAtInMillis;
     private final ConsistencyConfig consistencyConfig;
     private final boolean localDatacenterOnly;
 
     /**
-     * Builder to build a CreateRestoreJobRequest
+     * Builder to build a {@link CreateRestoreJobRequestPayload}.
      *
-     * @param secrets          secrets for access objects on storage cloud
-     * @param expireAtInMillis time in future that the job expires,
+     * <p>For IAM instance profile mode set {@code credentialType} to {@link CredentialType#IAM} and use
+     * {@link RestoreJobSecrets#iamMode(String)} to construct the secrets argument:
+     * <pre>
+     *     CreateRestoreJobRequestPayload.builder(RestoreJobSecrets.iamMode("us-east-1"), expireAt)
+     *                                   .credentialType(CredentialType.IAM)
+     *                                   .build();
+     * </pre>
+     *
+     * @param secrets          secrets for accessing objects on the storage cloud
+     * @param expireAtInMillis time in the future that the job expires,
      *                         i.e. fail the restore job if it is not in a final {@link RestoreJobStatus} yet
      * @return builder
      */
@@ -75,19 +100,21 @@ public class CreateRestoreJobRequestPayload
     /**
      * CreateRestoreJobRequest deserializer
      *
-     * @param jobId            job id of restore job
-     * @param jobAgent         arbitrary text a job can put, which can be used to identity itself during Http request
-     * @param secrets          secrets to be used by restore job to download data
-     * @param importOptions    the configured options for SSTable import
-     * @param expireAtInMillis a timestamp in the future when the job is considered expired
-     * @param consistencyLevel consistency level a job should satisfy
-     * @param localDatacenter  the local datacenter name; required if using local consistency level and localDatacenterOnly is specified
+     * @param jobId               job id of restore job
+     * @param jobAgent            arbitrary text a job can put, which can be used to identity itself during Http request
+     * @param secrets             secrets to be used by restore job to download data
+     * @param credentialType      the credential mode; {@code null} is treated as {@link CredentialType#STATIC}
+     * @param importOptions       the configured options for SSTable import
+     * @param expireAtInMillis    a timestamp in the future when the job is considered expired
+     * @param consistencyLevel    consistency level a job should satisfy
+     * @param localDatacenter     the local datacenter name; required if using local consistency level and localDatacenterOnly is specified
      * @param localDatacenterOnly whether the job should restore to the specified local datacenter only
      */
     @JsonCreator
     public CreateRestoreJobRequestPayload(@JsonProperty(JOB_ID) UUID jobId,
                                           @JsonProperty(JOB_AGENT) String jobAgent,
                                           @JsonProperty(JOB_SECRETS) RestoreJobSecrets secrets,
+                                          @JsonProperty(JOB_CREDENTIAL_TYPE) @Nullable CredentialType credentialType,
                                           @JsonProperty(JOB_IMPORT_OPTIONS) SSTableImportOptions importOptions,
                                           @JsonProperty(JOB_EXPIRE_AT) long expireAtInMillis,
                                           @JsonProperty(JOB_CONSISTENCY_LEVEL) String consistencyLevel,
@@ -98,30 +125,23 @@ public class CreateRestoreJobRequestPayload
                                     "Only time based UUIDs allowed for jobId");
         Preconditions.checkArgument(expireAtInMillis != 0 && expireAtInMillis > System.currentTimeMillis(),
                                     "expireAt cannot be absent or a time in past");
-        Objects.requireNonNull(secrets, "secrets cannot be null");
+        Objects.requireNonNull(secrets, "secrets must be provided");
+        CredentialType effectiveType = credentialType == null ? CredentialType.STATIC : credentialType;
+        validateCredentials(secrets.readCredentials(), "readCredentials", effectiveType);
+        validateCredentials(secrets.writeCredentials(), "writeCredentials", effectiveType);
         this.jobId = jobId;
         this.jobAgent = jobAgent;
         this.secrets = secrets;
-        this.importOptions = importOptions == null
-                             ? SSTableImportOptions.defaults()
-                             : importOptions;
+        this.credentialType = effectiveType;
+        SSTableImportOptions base = importOptions == null ? SSTableImportOptions.defaults() : importOptions;
+        SSTableImportOptions importOptionsCopy = SSTableImportOptions.defaults();
+        importOptionsCopy.putAll(base);
+        this.importOptions = importOptionsCopy;
         this.expireAtInMillis = expireAtInMillis;
         this.consistencyConfig = ConsistencyConfig.parseString(consistencyLevel, localDatacenter);
         Preconditions.checkArgument(!localDatacenterOnly || StringUtils.isNotEmpty(localDatacenter),
                                     "Must specify a localDatacenter when restoreToLocalDatacenterOnly is true");
         this.localDatacenterOnly = localDatacenterOnly;
-    }
-
-    private CreateRestoreJobRequestPayload(Builder builder)
-    {
-        this(builder.jobId,
-             builder.jobAgent,
-             builder.secrets,
-             builder.importOptions,
-             builder.expireAtInMillis,
-             nameOrNull(builder.consistencyLevel),
-             builder.localDc,
-             builder.localDatacenterOnly);
     }
 
     /**
@@ -149,6 +169,15 @@ public class CreateRestoreJobRequestPayload
     public RestoreJobSecrets secrets()
     {
         return secrets;
+    }
+
+    /**
+     * @return the credential type for this job; defaults to {@link CredentialType#STATIC} when absent from the request
+     */
+    @JsonProperty(JOB_CREDENTIAL_TYPE)
+    public CredentialType credentialType()
+    {
+        return credentialType;
     }
 
     /**
@@ -213,6 +242,14 @@ public class CreateRestoreJobRequestPayload
         return consistencyConfig;
     }
 
+    /**
+     * @return the AWS region of the S3 bucket, derived from {@code secrets.readCredentials().region()}
+     */
+    public String storageRegion()
+    {
+        return secrets.readCredentials().region();
+    }
+
     @Override
     public String toString()
     {
@@ -238,6 +275,7 @@ public class CreateRestoreJobRequestPayload
 
         private UUID jobId = null;
         private String jobAgent = null;
+        private CredentialType credentialType = null;
         private ConsistencyLevel consistencyLevel = null;
         private String localDc = null;
         private boolean localDatacenterOnly = false;
@@ -256,6 +294,11 @@ public class CreateRestoreJobRequestPayload
         public Builder jobAgent(String jobAgent)
         {
             return update(b -> b.jobAgent = jobAgent);
+        }
+
+        public Builder credentialType(CredentialType credentialType)
+        {
+            return update(b -> b.credentialType = credentialType);
         }
 
         public Builder updateImportOptions(Consumer<SSTableImportOptions> updater)
@@ -297,8 +340,45 @@ public class CreateRestoreJobRequestPayload
         }
     }
 
+    private CreateRestoreJobRequestPayload(Builder builder)
+    {
+        this(builder.jobId,
+             builder.jobAgent,
+             builder.secrets,
+             builder.credentialType,
+             builder.importOptions,
+             builder.expireAtInMillis,
+             nameOrNull(builder.consistencyLevel),
+             builder.localDc,
+             builder.localDatacenterOnly);
+    }
+
     private static String nameOrNull(ConsistencyLevel cl)
     {
         return cl == null ? null : cl.name();
+    }
+
+    /**
+     * Validates credentials against the declared {@link CredentialType}.
+     * For {@link CredentialType#STATIC}: all three key fields must be present.
+     * For {@link CredentialType#IAM}: all three key fields must be absent (only region is allowed).
+     */
+    private static void validateCredentials(StorageCredentials credentials, String fieldName, CredentialType credentialType)
+    {
+        boolean hasAccessKey = credentials.accessKeyId() != null;
+        boolean hasSecretKey = credentials.secretAccessKey() != null;
+        boolean hasSessionToken = credentials.sessionToken() != null;
+        if (credentialType == CredentialType.IAM)
+        {
+            Preconditions.checkArgument(!hasAccessKey && !hasSecretKey && !hasSessionToken,
+                                        "IAM credentials must not contain key fields for " + fieldName +
+                                        ": accessKeyId, secretAccessKey, and sessionToken must all be absent");
+        }
+        else
+        {
+            Preconditions.checkArgument(hasAccessKey && hasSecretKey && hasSessionToken,
+                                        "Static credentials must have all key fields present for " + fieldName +
+                                        ": accessKeyId, secretAccessKey, and sessionToken are all required");
+        }
     }
 }

--- a/client-common/src/test/java/org/apache/cassandra/sidecar/common/request/CreateRestoreJobRequestPayloadTest.java
+++ b/client-common/src/test/java/org/apache/cassandra/sidecar/common/request/CreateRestoreJobRequestPayloadTest.java
@@ -31,8 +31,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
+import org.apache.cassandra.sidecar.common.data.StorageCredentials;
 import org.apache.cassandra.sidecar.common.request.data.CreateRestoreJobRequestPayload;
 import org.apache.cassandra.sidecar.foundation.RestoreJobSecretsGen;
 
@@ -64,6 +66,7 @@ class CreateRestoreJobRequestPayloadTest
                         .isEqualTo("{\"jobId\":\"e870e5dc-d25e-11ed-afa1-0242ac120002\"," +
                                    "\"jobAgent\":\"agent\"," +
                                    "\"secrets\":" + MAPPER.writeValueAsString(secrets) + "," +
+                                   "\"credentialType\":\"STATIC\"," +
                                    "\"importOptions\":{" +
                                    "\"resetLevel\":\"true\"," +
                                    "\"clearRepaired\":\"true\"," +
@@ -87,6 +90,7 @@ class CreateRestoreJobRequestPayloadTest
         assertThat(test.consistencyLevel()).isEqualTo("LOCAL_QUORUM");
         assertThat(test.localDatacenter()).isEqualTo("DC1");
         assertThat(test.shouldRestoreToLocalDatacenterOnly()).isFalse();
+        assertThat(test.storageRegion()).isEqualTo(secrets.readCredentials().region());
     }
 
     @Test
@@ -96,7 +100,7 @@ class CreateRestoreJobRequestPayloadTest
         String json = "{\"jobId\":\"" + uuid + "\"," +
                       "\"jobAgent\":\"Spark Bulk Analytics\"," +
                       "\"status\":\"Completed\"," +
-                      "\"expireAt\":" + System.currentTimeMillis() + 1000 +
+                      "\"expireAt\":" + (System.currentTimeMillis() + 1000) +
                       ",\"secrets\":" + MAPPER.writeValueAsString(RestoreJobSecretsGen.genRestoreJobSecrets()) + "}";
         assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
         .isInstanceOf(UnrecognizedPropertyException.class)
@@ -106,12 +110,14 @@ class CreateRestoreJobRequestPayloadTest
     @Test
     void testReadFromJsonWithInvalidSecrets()
     {
+        // Credentials with accessKeyId but no region — StorageCredentials requires region
         String json = "{\"secrets\":" +
                       "{\"readCredentials\":{\"accessKeyId\":\"accessKeyId\"}," +
                       "\"writeCredentials\":{\"accessKeyId\":\"accessKeyId\"}}}";
         assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
         .isInstanceOf(ValueInstantiationException.class)
-        .hasMessageContaining("Cannot construct instance");
+        .hasCauseInstanceOf(NullPointerException.class)
+        .hasMessageContaining("region must be supplied");
     }
 
     @Test
@@ -119,7 +125,7 @@ class CreateRestoreJobRequestPayloadTest
     {
         RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
         String json = "{\"secrets\":" + MAPPER.writeValueAsString(secrets) +
-                      ", \"expireAt\":" + System.currentTimeMillis() + 1000 + "}";
+                      ", \"expireAt\":" + (System.currentTimeMillis() + 1000) + "}";
         CreateRestoreJobRequestPayload req = MAPPER.readValue(json, CreateRestoreJobRequestPayload.class);
         assertThat(req).isNotNull();
         assertThat(req.jobId()).isNull();
@@ -131,11 +137,12 @@ class CreateRestoreJobRequestPayloadTest
     @Test
     void testReadFromJsonFailsWithoutSecrets()
     {
-        String json = "{\"expireAt\":" + System.currentTimeMillis() + 1000 + "}";
+        // secrets is always required; there is no sentinel fallback field
+        String json = "{\"expireAt\":" + (System.currentTimeMillis() + 1000) + "}";
         assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
         .isInstanceOf(ValueInstantiationException.class)
         .hasCauseInstanceOf(NullPointerException.class)
-        .hasMessageContaining("secrets cannot be null");
+        .hasMessageContaining("secrets must be provided");
     }
 
     @Test
@@ -165,7 +172,7 @@ class CreateRestoreJobRequestPayloadTest
     void testReadFromJsonFailsWithInvalidJobId() throws JsonProcessingException
     {
         String json = "{\"jobId\":\"12951f25-d393-4158-9e90-ec0cbe05af21\"," +
-                      "\"expireAt\":\"" + System.currentTimeMillis() + 1000 + "\"," +
+                      "\"expireAt\":\"" + (System.currentTimeMillis() + 1000) + "\"," +
                       "\"secrets\":" + MAPPER.writeValueAsString(RestoreJobSecretsGen.genRestoreJobSecrets()) + "}";
         assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
         .isInstanceOf(ValueInstantiationException.class);
@@ -221,12 +228,12 @@ class CreateRestoreJobRequestPayloadTest
 
         for (ConsistencyLevel localCL : Arrays.asList(ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_ONE))
         {
-            assertThatThrownBy(() -> CreateRestoreJobRequestPayload.builder(secrets, System.currentTimeMillis())
+            assertThatThrownBy(() -> CreateRestoreJobRequestPayload.builder(secrets, System.currentTimeMillis() + 10000)
                                                                    .consistencyLevel(localCL)
                                                                    .build())
             .hasMessage("Must specify a non-empty localDatacenter for consistency level: " + localCL.name());
 
-            assertThatThrownBy(() -> CreateRestoreJobRequestPayload.builder(secrets, System.currentTimeMillis())
+            assertThatThrownBy(() -> CreateRestoreJobRequestPayload.builder(secrets, System.currentTimeMillis() + 10000)
                                                                    .consistencyLevel(localCL, "")
                                                                    .build())
             .hasMessage("Must specify a non-empty localDatacenter for consistency level: " + localCL.name());
@@ -258,5 +265,137 @@ class CreateRestoreJobRequestPayloadTest
                                  .build())
         .isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessage("Must specify a localDatacenter when restoreToLocalDatacenterOnly is true");
+    }
+
+    @Test
+    void testIamModeWithRegionOnly()
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        RestoreJobSecrets iamSecrets = RestoreJobSecrets.iamMode("us-east-1");
+        CreateRestoreJobRequestPayload req = CreateRestoreJobRequestPayload
+                                             .builder(iamSecrets, expireAt)
+                                             .credentialType(CredentialType.IAM)
+                                             .jobAgent("agent")
+                                             .build();
+        assertThat(req.credentialType()).isEqualTo(CredentialType.IAM);
+        assertThat(req.secrets()).isNotNull();
+        assertThat(req.storageRegion()).isEqualTo("us-east-1");
+        assertThat(req.secrets().readCredentials().region()).isEqualTo("us-east-1");
+        assertThat(req.secrets().readCredentials().accessKeyId()).isNull();
+        assertThat(req.secrets().readCredentials().secretAccessKey()).isNull();
+        assertThat(req.secrets().readCredentials().sessionToken()).isNull();
+        assertThat(req.secrets().readCredentials().hasStaticCredentials()).isFalse();
+    }
+
+    @Test
+    void testIamModeSerDeser() throws JsonProcessingException
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        CreateRestoreJobRequestPayload req = CreateRestoreJobRequestPayload
+                                             .builder(RestoreJobSecrets.iamMode("us-west-2"), expireAt)
+                                             .credentialType(CredentialType.IAM)
+                                             .build();
+        String json = MAPPER.writeValueAsString(req);
+        assertThat(json).contains("\"us-west-2\"")
+                        .contains("\"credentialType\":\"IAM\"")
+                        .doesNotContain("\"accessKeyId\"")
+                        .doesNotContain("\"secretAccessKey\"")
+                        .doesNotContain("\"sessionToken\"");
+
+        CreateRestoreJobRequestPayload deserialized = MAPPER.readValue(json, CreateRestoreJobRequestPayload.class);
+        assertThat(deserialized.credentialType()).isEqualTo(CredentialType.IAM);
+        assertThat(deserialized.storageRegion()).isEqualTo("us-west-2");
+        assertThat(deserialized.secrets().readCredentials().hasStaticCredentials()).isFalse();
+        assertThat(deserialized.secrets().readCredentials().accessKeyId()).isNull();
+        assertThat(deserialized.secrets().readCredentials().secretAccessKey()).isNull();
+        assertThat(deserialized.secrets().readCredentials().sessionToken()).isNull();
+    }
+
+    @Test
+    void testIamModeFromJson() throws JsonProcessingException
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        String json = "{\"credentialType\":\"IAM\"," +
+                      "\"secrets\":{\"readCredentials\":{\"region\":\"eu-west-1\"}," +
+                      "\"writeCredentials\":{\"region\":\"eu-west-1\"}}," +
+                      "\"expireAt\":" + expireAt + "}";
+        CreateRestoreJobRequestPayload req = MAPPER.readValue(json, CreateRestoreJobRequestPayload.class);
+        assertThat(req.credentialType()).isEqualTo(CredentialType.IAM);
+        assertThat(req.storageRegion()).isEqualTo("eu-west-1");
+        assertThat(req.secrets().readCredentials().hasStaticCredentials()).isFalse();
+        assertThat(req.secrets().readCredentials().accessKeyId()).isNull();
+        assertThat(req.secrets().readCredentials().secretAccessKey()).isNull();
+        assertThat(req.secrets().readCredentials().sessionToken()).isNull();
+    }
+
+    @Test
+    void testIamModeWithStaticCredentialsIsRejected() throws JsonProcessingException
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        StorageCredentials fullCreds = RestoreJobSecretsGen.genReadStorageCredentials();
+        String json = "{\"credentialType\":\"IAM\"," +
+                      "\"secrets\":{\"readCredentials\":" + MAPPER.writeValueAsString(fullCreds) + "," +
+                      "\"writeCredentials\":" + MAPPER.writeValueAsString(fullCreds) + "}," +
+                      "\"expireAt\":" + expireAt + "}";
+        assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
+        .isInstanceOf(ValueInstantiationException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("IAM credentials must not contain key fields");
+    }
+
+    @Test
+    void testIamModeFactoryRequiresRegion()
+    {
+        // RestoreJobSecrets.iamMode requires a non-null region; null means StorageCredentials constructor
+        // will throw because region is the only required field in that class
+        assertThatThrownBy(() -> RestoreJobSecrets.iamMode(null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("region must be supplied");
+    }
+
+    @Test
+    void testPartialStaticCredentialsAreRejected()
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        // readCredentials has only accessKeyId — secretAccessKey and sessionToken absent
+        String json = "{\"secrets\":" +
+                      "{\"readCredentials\":{\"accessKeyId\":\"key\",\"region\":\"us-east-1\"}," +
+                      "\"writeCredentials\":{\"accessKeyId\":\"key\",\"region\":\"us-east-1\"}}," +
+                      "\"expireAt\":" + expireAt + "}";
+        assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
+        .isInstanceOf(ValueInstantiationException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Static credentials must have all key fields present");
+    }
+
+    @Test
+    void testExplicitStaticCredentialTypeWithPartialCredentialsIsRejected() throws JsonProcessingException
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        // credentialType is explicitly STATIC but credentials are partial — should still be rejected
+        String json = "{\"credentialType\":\"STATIC\"," +
+                      "\"secrets\":{\"readCredentials\":{\"accessKeyId\":\"key\",\"region\":\"us-east-1\"}," +
+                      "\"writeCredentials\":{\"accessKeyId\":\"key\",\"region\":\"us-east-1\"}}," +
+                      "\"expireAt\":" + expireAt + "}";
+        assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
+        .isInstanceOf(ValueInstantiationException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Static credentials must have all key fields present");
+    }
+
+    @Test
+    void testPartialWriteCredentialsAreRejected() throws JsonProcessingException
+    {
+        long expireAt = System.currentTimeMillis() + 10000;
+        // readCredentials is fully populated, writeCredentials is partial — both must be validated
+        StorageCredentials fullRead = RestoreJobSecretsGen.genReadStorageCredentials();
+        String json = "{\"secrets\":" +
+                      "{\"readCredentials\":" + MAPPER.writeValueAsString(fullRead) + "," +
+                      "\"writeCredentials\":{\"accessKeyId\":\"key\",\"region\":\"us-east-1\"}}," +
+                      "\"expireAt\":" + expireAt + "}";
+        assertThatThrownBy(() -> MAPPER.readValue(json, CreateRestoreJobRequestPayload.class))
+        .isInstanceOf(ValueInstantiationException.class)
+        .hasCauseInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Static credentials must have all key fields present for writeCredentials");
     }
 }

--- a/docs/src/container-registry.adoc
+++ b/docs/src/container-registry.adoc
@@ -1,0 +1,71 @@
+= Publishing a Container Image to a Custom Registry
+
+Cassandra Sidecar uses https://github.com/GoogleContainerTools/jib[Jib] to build and publish container images without requiring a local Docker daemon. You can push to any OCI-compatible registry by passing the target image and credentials as system properties on the command line — no changes to `build.gradle` are needed.
+
+== Basic Usage
+
+[source,shell]
+----
+./gradlew :server:jib \
+  -Djib.to.image=<registry>/<repository>:<tag> \
+  -Djib.to.auth.username=<username> \
+  -Djib.to.auth.password=<password>
+----
+
+To apply multiple tags, use the `jib.to.tags` property (comma-separated):
+
+[source,shell]
+----
+./gradlew :server:jib \
+  -Djib.to.image=<registry>/<repository>:<tag> \
+  -Djib.to.tags=latest,stable
+----
+
+== Examples
+
+=== Amazon Elastic Container Registry (ECR)
+
+==== Prerequisites
+
+The AWS identity pushing the image must have the following IAM permissions:
+`sts:GetCallerIdentity`, `ecr:GetAuthorizationToken`, `ecr:BatchCheckLayerAvailability`,
+`ecr:InitiateLayerUpload`, `ecr:UploadLayerPart`, `ecr:CompleteLayerUpload`, `ecr:PutImage`.
+The AWS managed policy `AmazonEC2ContainerRegistryPowerUser` grants all of these.
+
+==== Pushing the image
+
+Use the `scripts/publish-ecr.sh` script. The repository name defaults to `cassandra-sidecar` and can be overridden with the `-r` flag or the `REPO_NAME` environment variable:
+
+[source,shell]
+----
+# no namespace — publishes as cassandra-sidecar
+./scripts/publish-ecr.sh
+
+# with namespace via flag — publishes as my-namespace/cassandra-sidecar
+./scripts/publish-ecr.sh -n my-namespace
+
+# with namespace via env var
+REPO_NAMESPACE=my-namespace ./scripts/publish-ecr.sh
+----
+
+The script will prompt to create the repository if it does not already exist.
+
+=== Docker Hub
+
+[source,shell]
+----
+./gradlew :server:jib \
+  -Djib.to.image=docker.io/<username>/cassandra-sidecar:<tag> \
+  -Djib.to.auth.username=<dockerhub-username> \
+  -Djib.to.auth.password=<dockerhub-access-token>
+----
+
+=== GitHub Container Registry (GHCR)
+
+[source,shell]
+----
+./gradlew :server:jib \
+  -Djib.to.image=ghcr.io/<org>/cassandra-sidecar:<tag> \
+  -Djib.to.auth.username=<github-username> \
+  -Djib.to.auth.password=<github-personal-access-token>
+----

--- a/docs/src/spark.adoc
+++ b/docs/src/spark.adoc
@@ -1,0 +1,178 @@
+////
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+////
+
+= S3 Restore Jobs from Spark
+
+This document describes how Spark jobs create S3 restore jobs through the sidecar client and
+explains the two supported credential modes.
+
+== Credential Modes
+
+Two modes are supported, selected by `credentialType` on the request payload.
+
+[cols="1,3"]
+|===
+| Mode | How credentials are resolved
+
+| `STATIC` (default)
+| Short-lived STS key fields are passed in the request. The sidecar uses them directly.
+Rotate them by calling `updateRestoreJob` before they expire.
+
+| `IAM`
+| No key fields are passed. The sidecar resolves credentials from the AWS default chain:
+instance profile on EC2, task role on ECS, or IRSA on EKS.
+|===
+
+[[static-flow]]
+== Static Credentials Flow
+
+Use static mode when Spark runs outside AWS, or when credentials are issued by an STS
+vending service that your job controls.
+
+....
+  Spark Job                     Credential Vending Service              Sidecar
+     |                                    |                                |
+     |--- request STS credentials ------->|                                |
+     |<-- accessKeyId / secretAccessKey --|                                |
+     |       sessionToken                 |                                |
+     |                                                                     |
+     |--- createRestoreJob(STATIC, keys) --------------------------------->|
+     |                                                          stores keys in DB
+     |                                                          uses StaticCredentialsProvider
+     |                                                          downloads slices from S3
+     |
+     | (credentials near expiry)
+     |--- updateRestoreJob(new keys) ------------------------------------->|
+     |                                                          replaces cached provider
+     |
+....
+
+=== Code Example
+
+[source,java]
+----
+StorageCredentials readCredentials = StorageCredentials.builder()
+                                                       .accessKeyId("ASIA...")
+                                                       .secretAccessKey("wJalr...")
+                                                       .sessionToken("AQoX...")
+                                                       .region("us-east-1")
+                                                       .build();
+
+StorageCredentials writeCredentials = StorageCredentials.builder()
+                                                        .accessKeyId("ASIA...")
+                                                        .secretAccessKey("wJalr...")
+                                                        .sessionToken("AQoX...")
+                                                        .region("us-east-1")
+                                                        .build();
+
+RestoreJobSecrets secrets = new RestoreJobSecrets(readCredentials, writeCredentials);
+
+long jobDeadline = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(4);
+
+CreateRestoreJobRequestPayload payload =
+    CreateRestoreJobRequestPayload.builder(secrets, jobDeadline)
+                                  .jobAgent("Spark Bulk Analytics")
+                                  .credentialType(CredentialType.STATIC)
+                                  .consistencyLevel(ConsistencyLevel.QUORUM)
+                                  .build();
+
+CreateRestoreJobResponsePayload response =
+    sidecarClient.createRestoreJob("my_keyspace", "my_table", payload).get();
+
+UUID jobId = response.jobId();
+----
+
+
+[[iam-flow]]
+== IAM Instance Profile Flow
+
+Use IAM mode when the sidecar runs on AWS infrastructure with an IAM role attached. No key
+material is passed. The sidecar resolves credentials automatically from the platform.
+
+....
+  Spark Job                     Sidecar                        AWS (IMDS / ECS / EKS)
+     |                             |                                    |
+     |--- createRestoreJob(IAM) -->|                                    |
+     |                    stores region in DB                           |
+     |                    (no key fields stored)                        |
+     |                             |                                    |
+     |                             |--- describe instance profile ----->|
+     |                             |<-- temporary credentials ----------|
+     |                             |    (refreshed automatically)       |
+     |                             |                                    |
+     |                             |--- downloads slices from S3 ------>|
+     |
+....
+
+
+=== Code Example
+
+Use `RestoreJobSecrets.iamMode(region)` to build the secrets object. Only `region` is
+required; all key fields must be absent.
+
+[source,java]
+----
+RestoreJobSecrets secrets = RestoreJobSecrets.iamMode("us-east-1");
+
+long jobDeadline = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(4);
+
+CreateRestoreJobRequestPayload payload =
+    CreateRestoreJobRequestPayload.builder(secrets, jobDeadline)
+                                  .jobAgent("Spark Bulk Analytics")
+                                  .credentialType(CredentialType.IAM)
+                                  .consistencyLevel(ConsistencyLevel.QUORUM)
+                                  .build();
+
+CreateRestoreJobResponsePayload response =
+    sidecarClient.createRestoreJob("my_keyspace", "my_table", payload).get();
+
+UUID jobId = response.jobId();
+----
+
+NOTE: `expireAt` (the `jobDeadline` above) is the restore job deadline — how long the sidecar
+will attempt the restore before aborting. It is not related to credential lifetime and must
+always be provided regardless of credential mode.
+
+[[choosing-a-mode]]
+== Choosing a Mode
+
+[cols="1,1,1"]
+|===
+| | STATIC | IAM
+
+| Spark runs inside AWS
+| Works, but requires credential vending
+| Recommended
+
+| Spark runs outside AWS
+| Required
+| Not applicable
+
+| Credential rotation
+| Caller calls `updateRestoreJob`
+| AWS SDK handles automatically
+
+| Key fields in request
+| Required
+| Must be absent — use `RestoreJobSecrets.iamMode(region)`
+
+| Sidecar requires IAM role
+| No
+| Yes
+|===

--- a/scripts/publish-ecr.sh
+++ b/scripts/publish-ecr.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Usage: ./publish-ecr.sh [-n <namespace>]
+#   -n  ECR namespace prefix (optional). When provided, the image is pushed as
+#       <namespace>/cassandra-sidecar. Without it, the image is cassandra-sidecar.
+#       Can also be set via REPO_NAMESPACE env var. Flag takes precedence.
+#
+# Prerequisites:
+#   1. The ECR repository will be created automatically if it does not exist.
+#
+#   2. The AWS identity must have the following IAM permissions:
+#        sts:GetCallerIdentity
+#        ecr:GetAuthorizationToken
+#        ecr:BatchCheckLayerAvailability
+#        ecr:InitiateLayerUpload
+#        ecr:UploadLayerPart
+#        ecr:CompleteLayerUpload
+#        ecr:PutImage
+#      The AWS managed policy AmazonEC2ContainerRegistryPowerUser grants all of these.
+
+set -euo pipefail
+
+export AWS_PAGER=""
+
+REGION="us-west-2"
+REPO_NAMESPACE="${REPO_NAMESPACE:-}"
+
+while getopts "n:" opt; do
+    case "${opt}" in
+        n) REPO_NAMESPACE="${OPTARG}" ;;
+        *) echo "Usage: $0 [-n <namespace>]"; exit 1 ;;
+    esac
+done
+
+REPO_NAME="${REPO_NAMESPACE:+${REPO_NAMESPACE}/}cassandra-sidecar"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGISTRY="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+IMAGE="${REGISTRY}/${REPO_NAME}"
+
+if ! aws ecr describe-repositories --repository-names "${REPO_NAME}" --region "${REGION}" &>/dev/null; then
+    echo "ECR repository '${REPO_NAME}' does not exist in ${REGISTRY}."
+    read -r -p "Create it now? [y/N] " answer
+    case "${answer}" in
+        [yY]) aws ecr create-repository --repository-name "${REPO_NAME}" --region "${REGION}" ;;
+        *) echo "Aborting."; exit 1 ;;
+    esac
+fi
+
+PASSWORD=$(aws ecr get-login-password --region "${REGION}")
+
+SCRIPT_DIR=$(dirname -- "$(readlink -f -- "$0")")
+cd "${SCRIPT_DIR}/.."
+
+./gradlew :server:jib \
+  -Djib.to.image="${IMAGE}" \
+  -Djib.to.auth.username=AWS \
+  "-Djib.to.auth.password=${PASSWORD}"

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJob.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.cassandra.sidecar.common.DataObjectBuilder;
 import org.apache.cassandra.sidecar.common.data.ConsistencyConfig;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
@@ -58,6 +59,7 @@ public class RestoreJob
     public final String jobAgent;
     public final RestoreJobStatus status;
     public final RestoreJobSecrets secrets;
+    public final CredentialType credentialType;
     public final SSTableImportOptions importOptions;
     public final Date expireAt;
     public final short bucketCount;
@@ -92,6 +94,7 @@ public class RestoreJob
                .keyspace(row.getString("keyspace_name")).table(row.getString("table_name"))
                .jobStatusText(row.getString("status"))
                .jobSecrets(decodeJobSecrets(row.getBytes("blob_secrets")))
+               .credentialType(decodeCredentialType(row.getString("credential_type")))
                .expireAt(row.getTimestamp("expire_at"))
                .sstableImportOptions(decodeSSTableImportOptions(row.getBytes("import_options")))
                .consistencyLevel(consistencyConfig.consistencyLevel)
@@ -120,6 +123,18 @@ public class RestoreJob
                : deserializeJsonBytes(secretsBytes,
                                       RestoreJobSecrets.class,
                                       "secrets");
+    }
+
+    private static CredentialType decodeCredentialType(String value)
+    {
+        try
+        {
+            return CredentialType.valueOf(value);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new DataObjectMappingException("Failed to decode credentialType: " + value, e);
+        }
     }
 
     private static SSTableImportOptions decodeSSTableImportOptions(ByteBuffer importOptionsBytes)
@@ -164,6 +179,7 @@ public class RestoreJob
         this.status = builder.status;
         this.statusText = builder.statusText;
         this.secrets = builder.secrets;
+        this.credentialType = builder.credentialType;
         this.importOptions = builder.importOptions == null
                              ? SSTableImportOptions.defaults()
                              : builder.importOptions;
@@ -268,6 +284,7 @@ public class RestoreJob
         private RestoreJobStatus status;
         private String statusText;
         private RestoreJobSecrets secrets;
+        private CredentialType credentialType;
         private SSTableImportOptions importOptions;
         private Date expireAt;
         private short bucketCount;
@@ -292,6 +309,7 @@ public class RestoreJob
             this.status = restoreJob.status;
             this.statusText = restoreJob.statusText;
             this.secrets = restoreJob.secrets;
+            this.credentialType = restoreJob.credentialType;
             this.importOptions = restoreJob.importOptions;
             this.expireAt = restoreJob.expireAt;
             this.bucketCount = restoreJob.bucketCount;
@@ -350,6 +368,11 @@ public class RestoreJob
         public Builder jobSecrets(RestoreJobSecrets jobSecrets)
         {
             return update(b -> b.secrets = jobSecrets);
+        }
+
+        public Builder credentialType(CredentialType credentialType)
+        {
+            return update(b -> b.credentialType = credentialType);
         }
 
         public Builder sstableImportOptions(SSTableImportOptions options)

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessor.java
@@ -81,6 +81,7 @@ public class RestoreJobDatabaseAccessor extends DatabaseAccessor<RestoreJobsSche
                                    .jobAgent(payload.jobAgent())
                                    .jobStatus(RestoreJobStatus.CREATED)
                                    .jobSecrets(payload.secrets())
+                                   .credentialType(payload.credentialType())
                                    .sstableImportOptions(payload.importOptions())
                                    .expireAt(payload.expireAtAsDate())
                                    .consistencyLevel(payload.consistencyConfig().consistencyLevel)
@@ -101,6 +102,7 @@ public class RestoreJobDatabaseAccessor extends DatabaseAccessor<RestoreJobsSche
                                                     job.consistencyLevelText(),
                                                     job.localDatacenter,
                                                     job.shouldRestoreToLocalDatacenterOnly,
+                                                    job.credentialType.name(),
                                                     job.expireAt);
 
         execute(statement);

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/schema/RestoreJobsSchema.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/schema/RestoreJobsSchema.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class RestoreJobsSchema extends TableSchema implements ExecuteOnClusterLeaseholderOnly
 {
-    private static final String RESTORE_JOB_TABLE_NAME = "restore_job_v5";
+    private static final String RESTORE_JOB_TABLE_NAME = "restore_job_v6";
 
     private final SchemaKeyspaceConfiguration keyspaceConfig;
     private final SecondBoundConfiguration tableTtl;
@@ -96,6 +96,7 @@ public class RestoreJobsSchema extends TableSchema implements ExecuteOnClusterLe
                              "  consistency_level text," +
                              "  local_datacenter text," +
                              "  local_datacenter_only boolean," +
+                             "  credential_type text," +
                              "  PRIMARY KEY (created_at, job_id)" +
                              ") WITH default_time_to_live = %s",
                              keyspaceConfig.keyspace(), RESTORE_JOB_TABLE_NAME, tableTtl.toSeconds());
@@ -157,8 +158,9 @@ public class RestoreJobsSchema extends TableSchema implements ExecuteOnClusterLe
                              "  consistency_level," +
                              "  local_datacenter," +
                              "  local_datacenter_only," +
+                             "  credential_type," +
                              "  expire_at" +
-                             ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", config);
+                             ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", config);
         }
 
         static String updateBlobSecrets(SchemaKeyspaceConfiguration config)
@@ -220,6 +222,7 @@ public class RestoreJobsSchema extends TableSchema implements ExecuteOnClusterLe
                              "consistency_level, " +
                              "local_datacenter, " +
                              "local_datacenter_only, " +
+                             "credential_type, " +
                              "expire_at, " +
                              "slice_count " +
                              "FROM %s.%s " +
@@ -239,6 +242,7 @@ public class RestoreJobsSchema extends TableSchema implements ExecuteOnClusterLe
                              "consistency_level, " +
                              "local_datacenter, " +
                              "local_datacenter_only, " +
+                             "credential_type, " +
                              "expire_at, " +
                              "slice_count " +
                              "FROM %s.%s " +

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/restore/UpdateRestoreJobHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/restore/UpdateRestoreJobHandler.java
@@ -34,6 +34,7 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.cassandra.sidecar.acl.authorization.BasicPermissions;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.request.data.UpdateRestoreJobRequestPayload;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
@@ -94,6 +95,16 @@ public class UpdateRestoreJobHandler extends AbstractHandler<UpdateRestoreJobReq
                 logger.debug("The job has completed already. job={}", job);
                 return Future.failedFuture(wrapHttpException(HttpResponseStatus.CONFLICT,
                                                              "Job is already in final state: " + job.status));
+            }
+
+            // IAM jobs derive credentials from the instance profile / task role at runtime.
+            // There are no static credentials to supply or rotate, so any attempt to update
+            // credentials on an IAM job is always invalid.
+            if (job.credentialType == CredentialType.IAM && requestPayload.secrets() != null)
+            {
+                logger.warn("Credential update rejected for IAM job. job={}", job);
+                return Future.failedFuture(wrapHttpException(HttpResponseStatus.BAD_REQUEST,
+                                                             "Credentials cannot be updated for IAM jobs"));
             }
 
             return executorPools.service()

--- a/server/src/main/java/org/apache/cassandra/sidecar/restore/StorageClient.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/restore/StorageClient.java
@@ -50,6 +50,7 @@ import org.apache.cassandra.sidecar.exceptions.RestoreJobFatalException;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -91,7 +92,14 @@ public class StorageClient
     }
 
     /**
-     * Authenticate and cache the credentials of a {@link RestoreJob}
+     * Authenticate and cache the credentials of a {@link RestoreJob}.
+     *
+     * <p>Credentials are only replaced when the job's secrets have changed (determined by
+     * {@link #matches}), avoiding redundant re-initialization on every polling cycle.
+     *
+     * <p><b>Threading note</b>: the update runs inside {@link java.util.concurrent.ConcurrentHashMap#compute},
+     * which holds a per-bucket lock for its duration. {@link Credentials#init()} must therefore remain
+     * non-blocking — no I/O, no external calls, and no locks that could form a cycle.
      */
     public StorageClient authenticate(RestoreJob restoreJob) throws RestoreJobFatalException
     {
@@ -321,13 +329,41 @@ public class StorageClient
         return failure;
     }
 
+    /**
+     * Holds the AWS credential provider for a specific restore job.
+     *
+     * <p>Two credential modes are supported:
+     * <ul>
+     *   <li><b>Static credentials</b>: {@code accessKeyId}, {@code secretAccessKey}, and {@code sessionToken}
+     *       are all non-null in the job's {@link StorageCredentials}. A {@link StaticCredentialsProvider}
+     *       is used, wrapping {@link AwsSessionCredentials}.</li>
+     *   <li><b>IAM instance profile</b>: the job's {@link StorageCredentials} contains only a region.
+     *       A shared {@link DefaultCredentialsProvider} is used, which resolves credentials via the
+     *       standard AWS chain: IAM instance profile → ECS task role → environment variables → etc.
+     *       This is the AWS-recommended approach for workloads running on EC2/ECS/EKS.</li>
+     * </ul>
+     *
+     * <p>{@link #init()} must be called after construction and before {@link #awsCredentialsProvider()}.
+     * This two-phase pattern exists so that the caller (see {@link StorageClient#authenticate}) can
+     * compare old and new credentials before deciding whether to re-initialize, avoiding unnecessary
+     * re-creation when secrets have not changed.
+     */
     private static class Credentials
     {
+        // package-private so authenticate() can compare old vs new credentials via matches() without a getter
         final StorageCredentials readCredentials;
         private AwsCredentialsProvider awsCredential;
 
+        // Shared across all IAM-mode jobs. DefaultCredentialsProvider.create() initializes a thread pool
+        // for async credential refresh; creating one per job would waste threads and resources.
+        private static final DefaultCredentialsProvider DEFAULT_CREDENTIALS_PROVIDER =
+        DefaultCredentialsProvider.create();
+
         Credentials(RestoreJob restoreJob) throws RestoreJobFatalException
         {
+            // RestoreJobFatalException is used here (rather than NullPointerException) so that the
+            // restore pipeline can treat a missing-secrets job as a terminal failure and update job
+            // status accordingly, rather than propagating an unchecked exception up through the scheduler.
             if (restoreJob.secrets == null)
             {
                 throw new RestoreJobFatalException("Restore job is missing credentials. JobId: " + restoreJob.jobId);
@@ -338,14 +374,29 @@ public class StorageClient
 
         void init()
         {
-            AwsCredentials credentials = AwsSessionCredentials.create(readCredentials.accessKeyId(),
-                                                                      readCredentials.secretAccessKey(),
-                                                                      readCredentials.sessionToken());
-            this.awsCredential = StaticCredentialsProvider.create(credentials);
+            if (readCredentials.hasStaticCredentials())
+            {
+                AwsCredentials credentials = AwsSessionCredentials.create(readCredentials.accessKeyId(),
+                                                                          readCredentials.secretAccessKey(),
+                                                                          readCredentials.sessionToken());
+                this.awsCredential = StaticCredentialsProvider.create(credentials);
+            }
+            else
+            {
+                // No static credentials provided; delegate to the AWS default credential chain.
+                // The shared singleton is used to avoid re-initializing the chain per job.
+                this.awsCredential = DEFAULT_CREDENTIALS_PROVIDER;
+            }
         }
 
         AwsCredentialsProvider awsCredentialsProvider()
         {
+            if (awsCredential == null)
+            {
+                // init() must be called before awsCredentialsProvider(); see class-level Javadoc.
+                throw new IllegalStateException("Credentials have not been initialized. " +
+                                                "Call init() before awsCredentialsProvider().");
+            }
             return awsCredential;
         }
     }

--- a/server/src/test/integration/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessorIntTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/db/RestoreJobDatabaseAccessorIntTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.datastax.driver.core.utils.UUIDs;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.request.data.CreateRestoreJobRequestPayload;
@@ -95,6 +96,48 @@ class RestoreJobDatabaseAccessorIntTest extends IntegrationTestBase
         assertThat(restoreToLocalDcOnlyJob.get().shouldRestoreToLocalDatacenterOnly).isTrue();
     }
 
+    @CassandraIntegrationTest
+    void testIamCredentialTypeRoundTrips()
+    {
+        waitForSchemaReady(10, TimeUnit.SECONDS);
+
+        RestoreJobDatabaseAccessor accessor = injector.getInstance(RestoreJobDatabaseAccessor.class);
+        RestoreJobSecrets iamSecrets = RestoreJobSecrets.iamMode("us-east-1");
+        UUID jobId = UUIDs.timeBased();
+        CreateRestoreJobRequestPayload payload = CreateRestoreJobRequestPayload.builder(iamSecrets, expiresAtMillis)
+                                                                               .jobId(jobId)
+                                                                               .jobAgent("agent")
+                                                                               .credentialType(CredentialType.IAM)
+                                                                               .build();
+        accessor.create(payload, qualifiedTableName);
+
+        RestoreJob found = accessor.find(jobId);
+        assertThat(found).isNotNull();
+        assertThat(found.credentialType).isEqualTo(CredentialType.IAM);
+        assertThat(found.secrets.readCredentials().region()).isEqualTo("us-east-1");
+        assertThat(found.secrets.readCredentials().accessKeyId()).isNull();
+        assertThat(found.secrets.readCredentials().secretAccessKey()).isNull();
+        assertThat(found.secrets.readCredentials().sessionToken()).isNull();
+    }
+
+    @CassandraIntegrationTest
+    void testStaticCredentialTypeRoundTrips()
+    {
+        waitForSchemaReady(10, TimeUnit.SECONDS);
+
+        RestoreJobDatabaseAccessor accessor = injector.getInstance(RestoreJobDatabaseAccessor.class);
+        UUID jobId = UUIDs.timeBased();
+        CreateRestoreJobRequestPayload payload = CreateRestoreJobRequestPayload.builder(secrets, expiresAtMillis)
+                                                                               .jobId(jobId)
+                                                                               .jobAgent("agent")
+                                                                               .build();
+        accessor.create(payload, qualifiedTableName);
+
+        RestoreJob found = accessor.find(jobId);
+        assertThat(found).isNotNull();
+        assertThat(found.credentialType).isEqualTo(CredentialType.STATIC);
+    }
+
     private UUID createJob(RestoreJobDatabaseAccessor accessor)
     {
         return createJob(accessor, false);
@@ -138,5 +181,6 @@ class RestoreJobDatabaseAccessorIntTest extends IntegrationTestBase
         assertThat(job.status).isEqualTo(status);
         assertThat(job.expireAt.getTime()).isEqualTo(expiresAtMillis);
         assertThat(job.secrets).isEqualTo(secrets);
+        assertThat(job.credentialType).isEqualTo(CredentialType.STATIC);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/RestoreJobTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/RestoreJobTest.java
@@ -27,10 +27,12 @@ import org.junit.jupiter.api.Test;
 
 import com.datastax.driver.core.utils.UUIDs;
 import org.apache.cassandra.sidecar.common.data.ConsistencyLevel;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
 import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
 import org.apache.cassandra.sidecar.common.server.data.RestoreRangeStatus;
+import org.apache.cassandra.sidecar.foundation.RestoreJobSecretsGen;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -161,6 +163,39 @@ public class RestoreJobTest
             RestoreJob job = createTestingJob(jobId, "ks", RestoreJobStatus.CREATED, cl, dcName);
             assertThat(job.isManagedBySidecar()).isTrue();
         }
+    }
+
+    @Test
+    void testCredentialTypePreservedThroughUnbuild()
+    {
+        UUID jobId = UUIDs.timeBased();
+        RestoreJobSecrets iamSecrets = RestoreJobSecrets.iamMode("us-east-1");
+        RestoreJob job = RestoreJob.builder()
+                                   .jobId(jobId)
+                                   .jobSecrets(iamSecrets)
+                                   .credentialType(CredentialType.IAM)
+                                   .build();
+
+        assertThat(job.credentialType).isEqualTo(CredentialType.IAM);
+
+        RestoreJob rebuilt = job.unbuild().build();
+        assertThat(rebuilt.credentialType).isEqualTo(CredentialType.IAM);
+    }
+
+    @Test
+    void testStaticCredentialTypePreservedThroughUnbuild()
+    {
+        UUID jobId = UUIDs.timeBased();
+        RestoreJob job = RestoreJob.builder()
+                                   .jobId(jobId)
+                                   .jobSecrets(RestoreJobSecretsGen.genRestoreJobSecrets())
+                                   .credentialType(CredentialType.STATIC)
+                                   .build();
+
+        assertThat(job.credentialType).isEqualTo(CredentialType.STATIC);
+
+        RestoreJob rebuilt = job.unbuild().build();
+        assertThat(rebuilt.credentialType).isEqualTo(CredentialType.STATIC);
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/db/SidecarSchemaTest.java
@@ -137,7 +137,7 @@ public class SidecarSchemaTest
             assertThat(interceptedExecStmts.get(0)).as("Create keyspace should be executed the first")
                                                    .contains("CREATE KEYSPACE IF NOT EXISTS sidecar_internal");
             assertThat(interceptedExecStmts).as("Create table should be executed for job table")
-                                            .anyMatch(stmt -> stmt.contains("CREATE TABLE IF NOT EXISTS sidecar_internal.restore_job_v5"));
+                                            .anyMatch(stmt -> stmt.contains("CREATE TABLE IF NOT EXISTS sidecar_internal.restore_job_v6"));
             assertThat(interceptedExecStmts).as("Create table should be executed for slice table")
                                             .anyMatch(stmt -> stmt.contains("CREATE TABLE IF NOT EXISTS sidecar_internal.restore_slice_v3"));
             assertThat(interceptedExecStmts).as("Create table should be executed for range table")
@@ -154,27 +154,27 @@ public class SidecarSchemaTest
                                             .anyMatch(stmt -> stmt.contains("CREATE TABLE IF NOT EXISTS sidecar_internal.sidecar_lease_v1"));
 
             List<String> expectedPrepStatements = Arrays.asList(
-            "INSERT INTO sidecar_internal.restore_job_v5 (  created_at,  job_id,  keyspace_name,  table_name,  " +
-            "job_agent,  status,  blob_secrets,  import_options,  consistency_level,  local_datacenter,  local_datacenter_only,  expire_at) " +
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v6 (  created_at,  job_id,  keyspace_name,  table_name,  " +
+            "job_agent,  status,  blob_secrets,  import_options,  consistency_level,  local_datacenter,  local_datacenter_only,  credential_type,  expire_at) " +
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v5 (  created_at,  job_id,  blob_secrets) VALUES (?, ? ,?)",
+            "INSERT INTO sidecar_internal.restore_job_v6 (  created_at,  job_id,  blob_secrets) VALUES (?, ? ,?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v5 (  created_at,  job_id,  status) VALUES (?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v6 (  created_at,  job_id,  status) VALUES (?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v5 (  created_at,  job_id,  job_agent) VALUES (?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v6 (  created_at,  job_id,  job_agent) VALUES (?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v5 (  created_at,  job_id,  expire_at) VALUES (?, ?, ?)",
+            "INSERT INTO sidecar_internal.restore_job_v6 (  created_at,  job_id,  expire_at) VALUES (?, ?, ?)",
 
-            "INSERT INTO sidecar_internal.restore_job_v5 (  created_at,  job_id,  slice_count) VALUES (?, ?, ?)",
-
-            "SELECT created_at, job_id, keyspace_name, table_name, job_agent, status, blob_secrets, import_options, " +
-            "consistency_level, local_datacenter, local_datacenter_only, expire_at, slice_count " +
-            "FROM sidecar_internal.restore_job_v5 WHERE created_at = ? AND job_id = ?",
+            "INSERT INTO sidecar_internal.restore_job_v6 (  created_at,  job_id,  slice_count) VALUES (?, ?, ?)",
 
             "SELECT created_at, job_id, keyspace_name, table_name, job_agent, status, blob_secrets, import_options, " +
-            "consistency_level, local_datacenter, local_datacenter_only, expire_at, slice_count " +
-            "FROM sidecar_internal.restore_job_v5 WHERE created_at = ?",
+            "consistency_level, local_datacenter, local_datacenter_only, credential_type, expire_at, slice_count " +
+            "FROM sidecar_internal.restore_job_v6 WHERE created_at = ? AND job_id = ?",
+
+            "SELECT created_at, job_id, keyspace_name, table_name, job_agent, status, blob_secrets, import_options, " +
+            "consistency_level, local_datacenter, local_datacenter_only, credential_type, expire_at, slice_count " +
+            "FROM sidecar_internal.restore_job_v6 WHERE created_at = ?",
 
             "INSERT INTO sidecar_internal.restore_slice_v3 (  job_id,  bucket_id,  slice_id,  bucket,  key,  " +
             "checksum,  start_token,  end_token,  compressed_size,  uncompressed_size) " +
@@ -232,7 +232,7 @@ public class SidecarSchemaTest
                                             .containsExactlyInAnyOrderElementsOf(expectedPrepStatements);
 
             assertThat(sidecarSchema.isInitialized()).as("Schema is successfully initialized").isTrue();
-            assertTableSchema(sidecarSchema.tableSchema(RestoreJobsSchema.class), "sidecar_internal.restore_job_v5");
+            assertTableSchema(sidecarSchema.tableSchema(RestoreJobsSchema.class), "sidecar_internal.restore_job_v6");
             assertTableSchema(sidecarSchema.tableSchema(RestoreRangesSchema.class), "sidecar_internal.restore_range_v1");
             assertTableSchema(sidecarSchema.tableSchema(RestoreSlicesSchema.class), "sidecar_internal.restore_slice_v3");
             assertTableSchema(sidecarSchema.tableSchema(SidecarLeaseSchema.class), "sidecar_internal.sidecar_lease_v1");

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/restore/CreateRestoreJobHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/restore/CreateRestoreJobHandlerTest.java
@@ -30,6 +30,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
 import org.apache.cassandra.sidecar.db.RestoreJob;
 import org.apache.cassandra.sidecar.db.RestoreJobTest;
@@ -113,6 +114,22 @@ class CreateRestoreJobHandlerTest extends BaseRestoreJobTests
     }
 
     @Test
+    void testIamModeRequest(VertxTestContext context) throws Throwable
+    {
+        mockCreateRestoreJob(x -> createTestNewJob("8e5799a4-d277-11ed-8d85-6916bb9b8056"));
+        mockLookupRestoreJob(id -> null);
+        JsonObject regionOnlyCredentials = new JsonObject().put("region", "us-east-1");
+        JsonObject secrets = new JsonObject()
+                             .put("readCredentials", regionOnlyCredentials)
+                             .put("writeCredentials", regionOnlyCredentials);
+        JsonObject payload = new JsonObject();
+        payload.put("credentialType", "IAM");
+        payload.put("secrets", secrets);
+        payload.put("expireAt", System.currentTimeMillis() + 10000L);
+        sendCreateRestoreJobRequestAndVerify("ks", "table", payload, context, HttpResponseStatus.OK.code());
+    }
+
+    @Test
     void testExceptionThrownDuringExecution(VertxTestContext context) throws Throwable
     {
         JsonObject payload = getRequestPayload("8e5799a4-d277-11ed-8d85-6916bb9b8056");
@@ -174,6 +191,7 @@ class CreateRestoreJobHandlerTest extends BaseRestoreJobTests
                                  {
                                      assertThat(responseBody.getString(JOB_ID)).isEqualTo(expectedJobId);
                                  }
+                                 assertThat(responseBody.getString(STATUS)).isEqualTo(RestoreJobStatus.CREATED.name());
                              }
                          });
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/restore/UpdateRestoreJobHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/restore/UpdateRestoreJobHandlerTest.java
@@ -33,6 +33,8 @@ import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
+import org.apache.cassandra.sidecar.common.data.CredentialType;
+import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.common.data.RestoreJobStatus;
 import org.apache.cassandra.sidecar.common.data.SSTableImportOptions;
 import org.apache.cassandra.sidecar.db.RestoreJob;
@@ -147,6 +149,47 @@ class UpdateRestoreJobHandlerTest extends BaseRestoreJobTests
         String jobId = "8e5799a4-d277-11ed-8d85-6916bb9b8056";
         long sliceCount = 100;
         mockLookupRestoreJob(RestoreJobTest::createNewTestingJob);
+        mockUpdateRestoreJob(payload -> {
+            assertThat(payload.sliceCount()).isEqualTo(sliceCount);
+            return createTestNewJob(jobId);
+        });
+        JsonObject payload = new JsonObject();
+        payload.put("sliceCount", sliceCount);
+        sendUpdateRestoreJobRequestAndVerify("ks", "table", jobId,
+                                             payload, context, HttpResponseStatus.OK.code());
+    }
+
+    @Test
+    void testUpdateCredentialsRejectedForIamJob(VertxTestContext context) throws Throwable
+    {
+        mockLookupRestoreJob(id -> RestoreJob.builder()
+                                            .jobId(id)
+                                            .keyspace("ks").table("table")
+                                            .jobAgent("agent")
+                                            .jobStatus(RestoreJobStatus.CREATED)
+                                            .jobSecrets(RestoreJobSecrets.iamMode("us-east-1"))
+                                            .credentialType(CredentialType.IAM)
+                                            .sstableImportOptions(SSTableImportOptions.defaults())
+                                            .build());
+        JsonObject payload = getRequestPayload(); // contains secrets
+        sendUpdateRestoreJobRequestAndVerify("ks", "table", "8e5799a4-d277-11ed-8d85-6916bb9b8056",
+                                             payload, context, HttpResponseStatus.BAD_REQUEST.code());
+    }
+
+    @Test
+    void testUpdateSliceCountAllowedForIamJob(VertxTestContext context) throws Throwable
+    {
+        String jobId = "8e5799a4-d277-11ed-8d85-6916bb9b8056";
+        long sliceCount = 100;
+        mockLookupRestoreJob(id -> RestoreJob.builder()
+                                            .jobId(id)
+                                            .keyspace("ks").table("table")
+                                            .jobAgent("agent")
+                                            .jobStatus(RestoreJobStatus.CREATED)
+                                            .jobSecrets(RestoreJobSecrets.iamMode("us-east-1"))
+                                            .credentialType(CredentialType.IAM)
+                                            .sstableImportOptions(SSTableImportOptions.defaults())
+                                            .build());
         mockUpdateRestoreJob(payload -> {
             assertThat(payload.sliceCount()).isEqualTo(sliceCount);
             return createTestNewJob(jobId);

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/StorageClientCredentialsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/StorageClientCredentialsTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.restore;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.datastax.driver.core.utils.UUIDs;
+import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
+import org.apache.cassandra.sidecar.common.data.StorageCredentials;
+import org.apache.cassandra.sidecar.db.RestoreJob;
+import org.apache.cassandra.sidecar.db.RestoreRange;
+import org.apache.cassandra.sidecar.exceptions.RestoreJobFatalException;
+import org.apache.cassandra.sidecar.foundation.RestoreJobSecretsGen;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link StorageClient} selects the correct AWS credential provider based on the restore job's
+ * credentials.
+ *
+ * <p>Two modes are exercised:
+ * <ul>
+ *   <li>Static credentials: all three key fields present → {@link StaticCredentialsProvider}</li>
+ *   <li>IAM instance profile: only region present → {@link DefaultCredentialsProvider}</li>
+ * </ul>
+ *
+ * <p>The provider type is verified by capturing the {@link HeadObjectRequest} passed to the mocked
+ * {@link S3AsyncClient} and inspecting the {@code overrideConfiguration.credentialsProvider}.
+ * This works because {@link StorageClient} injects the per-job provider at request build time
+ * (see {@code objectExists} and {@code rangeGetObject}).
+ */
+class StorageClientCredentialsTest
+{
+    private S3AsyncClient mockS3;
+    private ArgumentCaptor<HeadObjectRequest> requestCaptor;
+
+    @BeforeEach
+    void setUp()
+    {
+        mockS3 = mock(S3AsyncClient.class);
+        requestCaptor = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        when(mockS3.headObject(requestCaptor.capture()))
+            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().build()));
+    }
+
+    @Test
+    void testStaticCredentialsSelectsStaticProvider() throws RestoreJobFatalException
+    {
+        UUID jobId = UUIDs.timeBased();
+        RestoreJob job = RestoreJob.builder()
+                                   .jobId(jobId)
+                                   .jobSecrets(RestoreJobSecretsGen.genRestoreJobSecrets())
+                                   .build();
+        new StorageClient(mockS3).authenticate(job).objectExists(mockRange(jobId));
+
+        assertThat(captureCredentialProvider()).isInstanceOf(StaticCredentialsProvider.class);
+    }
+
+    @Test
+    void testIamModeSelectsDefaultCredentialsProvider() throws RestoreJobFatalException
+    {
+        UUID jobId = UUIDs.timeBased();
+        // Region-only credentials signal IAM mode; no accessKeyId/secretAccessKey/sessionToken
+        StorageCredentials regionOnly = StorageCredentials.builder().region("us-east-1").build();
+        RestoreJob job = RestoreJob.builder()
+                                   .jobId(jobId)
+                                   .jobSecrets(new RestoreJobSecrets(regionOnly, regionOnly))
+                                   .build();
+        new StorageClient(mockS3).authenticate(job).objectExists(mockRange(jobId));
+
+        assertThat(captureCredentialProvider()).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testIamJobsShareSingletonDefaultProvider() throws RestoreJobFatalException
+    {
+        // All IAM-mode jobs must share the same DefaultCredentialsProvider instance.
+        // DefaultCredentialsProvider.create() initializes a thread pool for async refresh;
+        // creating one per job would waste resources and is unnecessary.
+        StorageClient client = new StorageClient(mockS3);
+        StorageCredentials regionOnly = StorageCredentials.builder().region("us-east-1").build();
+
+        UUID jobId1 = UUIDs.timeBased();
+        client.authenticate(RestoreJob.builder()
+                                      .jobId(jobId1)
+                                      .jobSecrets(new RestoreJobSecrets(regionOnly, regionOnly))
+                                      .build());
+        client.objectExists(mockRange(jobId1));
+        AwsCredentialsProvider first = captureCredentialProvider();
+
+        UUID jobId2 = UUIDs.timeBased();
+        client.authenticate(RestoreJob.builder()
+                                      .jobId(jobId2)
+                                      .jobSecrets(new RestoreJobSecrets(regionOnly, regionOnly))
+                                      .build());
+        client.objectExists(mockRange(jobId2));
+        AwsCredentialsProvider second = captureCredentialProvider();
+
+        assertThat(second).isSameAs(first);
+        assertThat(first).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testIamJobsShareSingletonDefaultProviderAcrossClientInstances() throws RestoreJobFatalException
+    {
+        // The singleton must be shared across separate StorageClient instances (different regions
+        // in the pool each get their own StorageClient), not just within one client.
+        StorageCredentials regionOnly = StorageCredentials.builder().region("us-east-1").build();
+        UUID jobId1 = UUIDs.timeBased();
+        UUID jobId2 = UUIDs.timeBased();
+
+        S3AsyncClient mockS3b = mock(S3AsyncClient.class);
+        ArgumentCaptor<HeadObjectRequest> captorB = ArgumentCaptor.forClass(HeadObjectRequest.class);
+        when(mockS3b.headObject(captorB.capture()))
+            .thenReturn(CompletableFuture.completedFuture(HeadObjectResponse.builder().build()));
+
+        new StorageClient(mockS3).authenticate(RestoreJob.builder()
+                                                         .jobId(jobId1)
+                                                         .jobSecrets(new RestoreJobSecrets(regionOnly, regionOnly))
+                                                         .build())
+                                 .objectExists(mockRange(jobId1));
+        AwsCredentialsProvider first = captureCredentialProvider();
+
+        new StorageClient(mockS3b).authenticate(RestoreJob.builder()
+                                                          .jobId(jobId2)
+                                                          .jobSecrets(new RestoreJobSecrets(regionOnly, regionOnly))
+                                                          .build())
+                                  .objectExists(mockRange(jobId2));
+        AwsCredentialsProvider second = captorB.getValue()
+                                               .overrideConfiguration()
+                                               .flatMap(c -> c.credentialsProvider())
+                                               .orElseThrow(() -> new AssertionError("No credential provider on second request"));
+
+        assertThat(second).isSameAs(first);
+        assertThat(first).isInstanceOf(DefaultCredentialsProvider.class);
+    }
+
+    @Test
+    void testCredentialsAreReplacedWhenSecretsChange() throws RestoreJobFatalException
+    {
+        StorageClient client = new StorageClient(mockS3);
+        UUID jobId = UUIDs.timeBased();
+
+        RestoreJob job1 = RestoreJob.builder()
+                                    .jobId(jobId)
+                                    .jobSecrets(RestoreJobSecretsGen.genRestoreJobSecrets())
+                                    .build();
+        client.authenticate(job1);
+        client.objectExists(mockRange(jobId));
+        AwsCredentialsProvider first = captureCredentialProvider();
+
+        // Re-authenticate with different static credentials (new random keys).
+        // The credentials are guaranteed to differ because genRestoreJobSecrets uses random values.
+        RestoreJob job2 = RestoreJob.builder()
+                                    .jobId(jobId)
+                                    .jobSecrets(RestoreJobSecretsGen.genRestoreJobSecrets())
+                                    .build();
+        client.authenticate(job2);
+        client.objectExists(mockRange(jobId));
+        AwsCredentialsProvider second = captureCredentialProvider();
+
+        // The provider instances must differ, confirming the old credentials were replaced
+        assertThat(second).isNotSameAs(first);
+        assertThat(second).isInstanceOf(StaticCredentialsProvider.class);
+    }
+
+    @Test
+    void testObjectExistsWithoutAuthenticateFails()
+    {
+        // objectExists before any authenticate() call must return a failed future with a clear error,
+        // not a NullPointerException or other unexpected runtime exception.
+        UUID jobId = UUIDs.timeBased();
+        CompletableFuture<HeadObjectResponse> result = new StorageClient(mockS3).objectExists(mockRange(jobId));
+        assertThat(result).isCompletedExceptionally();
+        assertThatThrownBy(result::join)
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("No credential available");
+    }
+
+    @Test
+    void testCredentialsAreNotReplacedWhenSecretsUnchanged() throws RestoreJobFatalException
+    {
+        // When authenticate is called twice with identical secrets, the cached provider must not change.
+        // This avoids redundant StaticCredentialsProvider re-creation on every poll cycle.
+        StorageClient client = new StorageClient(mockS3);
+        UUID jobId = UUIDs.timeBased();
+        RestoreJobSecrets secrets = RestoreJobSecretsGen.genRestoreJobSecrets();
+
+        RestoreJob job = RestoreJob.builder().jobId(jobId).jobSecrets(secrets).build();
+        client.authenticate(job);
+        client.objectExists(mockRange(jobId));
+        AwsCredentialsProvider first = captureCredentialProvider();
+
+        // Authenticate again with an equal (but not same) RestoreJob — secrets are equal so no replacement
+        client.authenticate(RestoreJob.builder().jobId(jobId).jobSecrets(secrets).build());
+        client.objectExists(mockRange(jobId));
+        AwsCredentialsProvider second = captureCredentialProvider();
+
+        assertThat(second).isSameAs(first);
+    }
+
+    private RestoreRange mockRange(UUID jobId)
+    {
+        RestoreRange range = mock(RestoreRange.class);
+        when(range.jobId()).thenReturn(jobId);
+        when(range.sliceBucket()).thenReturn("test-bucket");
+        when(range.sliceKey()).thenReturn("test-key");
+        when(range.sliceChecksum()).thenReturn("\"abc123\"");
+        return range;
+    }
+
+    private AwsCredentialsProvider captureCredentialProvider()
+    {
+        HeadObjectRequest captured = requestCaptor.getValue();
+        return captured.overrideConfiguration()
+                       .flatMap(c -> c.credentialsProvider())
+                       .orElseThrow(() -> new AssertionError("No credential provider set on request"));
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/restore/StorageClientPoolTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/restore/StorageClientPoolTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import org.apache.cassandra.sidecar.common.data.RestoreJobSecrets;
 import org.apache.cassandra.sidecar.config.yaml.SidecarConfigurationImpl;
 import org.apache.cassandra.sidecar.db.RestoreJob;
 import org.apache.cassandra.sidecar.exceptions.RestoreJobFatalException;
@@ -41,5 +42,53 @@ class StorageClientPoolTest
                                    .build();
         StorageClient client = pool.storageClient(job);
         assertThat(client).isNotNull();
+    }
+
+    @Test
+    void testRetrieveClientWithIamCredentials() throws RestoreJobFatalException
+    {
+        StorageClientPool pool = new StorageClientPool(new SidecarConfigurationImpl(), null);
+        RestoreJobSecrets iamSecrets = RestoreJobSecrets.iamMode("us-east-1");
+        RestoreJob job = RestoreJob.builder()
+                                   .jobId(UUID.randomUUID())
+                                   .jobSecrets(iamSecrets)
+                                   .build();
+        StorageClient client = pool.storageClient(job);
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    void testIamJobsInSameRegionShareStorageClient() throws RestoreJobFatalException
+    {
+        StorageClientPool pool = new StorageClientPool(new SidecarConfigurationImpl(), null);
+        RestoreJobSecrets iamSecrets = RestoreJobSecrets.iamMode("us-east-1");
+
+        RestoreJob job1 = RestoreJob.builder().jobId(UUID.randomUUID()).jobSecrets(iamSecrets).build();
+        RestoreJob job2 = RestoreJob.builder().jobId(UUID.randomUUID()).jobSecrets(iamSecrets).build();
+
+        StorageClient client1 = pool.storageClient(job1);
+        StorageClient client2 = pool.storageClient(job2);
+
+        assertThat(client1).isSameAs(client2);
+    }
+
+    @Test
+    void testIamJobsInDifferentRegionsGetDifferentStorageClients() throws RestoreJobFatalException
+    {
+        StorageClientPool pool = new StorageClientPool(new SidecarConfigurationImpl(), null);
+
+        RestoreJob job1 = RestoreJob.builder()
+                                    .jobId(UUID.randomUUID())
+                                    .jobSecrets(RestoreJobSecrets.iamMode("us-east-1"))
+                                    .build();
+        RestoreJob job2 = RestoreJob.builder()
+                                    .jobId(UUID.randomUUID())
+                                    .jobSecrets(RestoreJobSecrets.iamMode("eu-west-1"))
+                                    .build();
+
+        StorageClient client1 = pool.storageClient(job1);
+        StorageClient client2 = pool.storageClient(job2);
+
+        assertThat(client1).isNotSameAs(client2);
     }
 }


### PR DESCRIPTION
…ore jobs

Allow restore jobs to use IAM instance profiles, ECS task roles, or IRSA instead of requiring static AWS credentials on every API request. Static credentials remain supported for environments that need them.

- StorageCredentials: make key fields @Nullable; add hasStaticCredentials()
- RestoreJobSecrets: add iamMode(String region) factory for IAM mode
- CreateRestoreJobRequestPayload: always require secrets; validate both read/write credentials for partial keys
- StorageClient: select StaticCredentialsProvider or DefaultCredentialsProvider based on hasStaticCredentials(); singleton DefaultCredentialsProvider to avoid per-job thread-pool creation

Patch by: Jon Haddad <jon@jonhaddad.com>