### PR TITLE
CASSSIDECAR-451: Sidecar CDC should resolve real keyspace replication factors from the driver

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Sidecar CDC should resolve real keyspace replication factors from the driver (CASSSIDECAR-451)
  * SAI support in Sidecar (CASSSIDECAR-422)
  * Update OperationalJob to support cluster-wide operations (CASSSIDECAR-376)
  * Support column types not parseable by Java 3.x driver (CASSSIDECAR-443)

--- a/integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/TestCdcPublisher.java
+++ b/integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/TestCdcPublisher.java
@@ -24,6 +24,7 @@ import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.msg.CdcEvent;
 import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
+import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.stats.ICdcStats;
 import org.apache.cassandra.sidecar.cdc.CdcConfig;
@@ -33,6 +34,7 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
+import org.apache.cassandra.sidecar.db.SidecarRegistryCache;
 import org.apache.cassandra.sidecar.db.VirtualTablesDatabaseAccessor;
 import org.apache.cassandra.sidecar.tasks.ScheduleDecision;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
@@ -62,12 +64,14 @@ public class TestCdcPublisher extends CdcPublisher
                            VirtualTablesDatabaseAccessor virtualTables,
                            SidecarCdcStats sidecarCdcStats,
                            Serializer<CdcEvent> avroSerializer,
-                           Provider<RangeManager> rangeManagerProvider)
+                           Provider<RangeManager> rangeManagerProvider,
+                           SidecarRegistryCache sidecarRegistryCache)
     {
         super(vertx, sidecarConfiguration, executorPools, clusterConfigProvider,
               schemaSupplier, sidecarInstancesProvider, clientConfig,
               instanceMetadataFetcher, conf, databaseAccessor, cdcStats,
-              virtualTables, sidecarCdcStats, avroSerializer, rangeManagerProvider);
+              virtualTables, sidecarCdcStats, avroSerializer, rangeManagerProvider,
+              sidecarRegistryCache);
         this.databaseAccessor = databaseAccessor;
     }
 
@@ -75,6 +79,16 @@ public class TestCdcPublisher extends CdcPublisher
     public EventConsumer eventConsumer(CdcConfig conf, Serializer<CdcEvent> avroSerializer)
     {
         return testEventConsumer;
+    }
+
+    /**
+     * Use the library default (SimpleStrategy/RF=1) in tests to avoid live driver calls
+     * during peer discovery, which can race with schema propagation at test startup.
+     */
+    @Override
+    protected ReplicationFactorSupplier createReplicationFactorSupplier()
+    {
+        return ReplicationFactorSupplier.DEFAULT;
     }
 
     /**

--- a/integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/TestCdcPublisher.java
+++ b/integration-framework/src/main/java/org/apache/cassandra/sidecar/testing/TestCdcPublisher.java
@@ -34,7 +34,6 @@ import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
-import org.apache.cassandra.sidecar.db.SidecarRegistryCache;
 import org.apache.cassandra.sidecar.db.VirtualTablesDatabaseAccessor;
 import org.apache.cassandra.sidecar.tasks.ScheduleDecision;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
@@ -64,14 +63,12 @@ public class TestCdcPublisher extends CdcPublisher
                            VirtualTablesDatabaseAccessor virtualTables,
                            SidecarCdcStats sidecarCdcStats,
                            Serializer<CdcEvent> avroSerializer,
-                           Provider<RangeManager> rangeManagerProvider,
-                           SidecarRegistryCache sidecarRegistryCache)
+                           Provider<RangeManager> rangeManagerProvider)
     {
         super(vertx, sidecarConfiguration, executorPools, clusterConfigProvider,
               schemaSupplier, sidecarInstancesProvider, clientConfig,
               instanceMetadataFetcher, conf, databaseAccessor, cdcStats,
-              virtualTables, sidecarCdcStats, avroSerializer, rangeManagerProvider,
-              sidecarRegistryCache);
+              virtualTables, sidecarCdcStats, avroSerializer, rangeManagerProvider);
         this.databaseAccessor = databaseAccessor;
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcManager.java
@@ -18,8 +18,7 @@
 
 package org.apache.cassandra.sidecar.cdc;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +33,7 @@ import org.apache.cassandra.cdc.api.CdcOptions;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.api.TokenRangeSupplier;
+import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
 import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdc;
@@ -41,7 +41,7 @@ import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcStats;
 import org.apache.cassandra.cdc.sidecar.SidecarStatePersister;
 import org.apache.cassandra.cdc.stats.ICdcStats;
-import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.apache.cassandra.secrets.SecretsProvider;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.TokenRange;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
@@ -49,6 +49,7 @@ import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.spark.utils.AsyncExecutor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.VisibleForTesting;
 
 
 /**
@@ -76,13 +77,16 @@ import org.jetbrains.annotations.NotNull;
 public class CdcManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CdcManager.class);
+    private static final int UNKNOWN_INSTANCE = -1;
     private final CdcConfig conf;
     private final RangeManager rangeManager;
     private final InstanceMetadataFetcher instanceFetcher;
     private final EventConsumer eventConsumer;
     private final SchemaSupplier schemaSupplier;
     private final ClusterConfigProvider clusterConfigProvider;
-    private final SidecarCdcClient sidecarCdcClient;
+    private final CdcSidecarInstancesProvider sidecarInstancesProvider;
+    private final SecretsProvider secretsProvider;
+    private final SidecarCdcClient.ClientConfig clientConfig;
     private final ICdcStats cdcStats;
     private List<SidecarCdc> consumers = new ArrayList<>();
     private final TaskExecutorPool taskExecutorPool;
@@ -96,7 +100,9 @@ public class CdcManager
                       RangeManager rangeManager,
                       InstanceMetadataFetcher instanceFetcher,
                       ClusterConfigProvider clusterConfigProvider,
-                      SidecarCdcClient sidecarCdcClient,
+                      CdcSidecarInstancesProvider sidecarInstancesProvider,
+                      SecretsProvider secretsProvider,
+                      SidecarCdcClient.ClientConfig clientConfig,
                       ICdcStats cdcStats,
                       TaskExecutorPool taskExecutorPool,
                       CdcDatabaseAccessor cdcDatabaseAccessor,
@@ -108,7 +114,9 @@ public class CdcManager
         this.rangeManager = rangeManager;
         this.instanceFetcher = instanceFetcher;
         this.clusterConfigProvider = clusterConfigProvider;
-        this.sidecarCdcClient = sidecarCdcClient;
+        this.sidecarInstancesProvider = sidecarInstancesProvider;
+        this.secretsProvider = secretsProvider;
+        this.clientConfig = clientConfig;
         this.cdcStats = cdcStats;
         this.taskExecutorPool = taskExecutorPool;
         this.cdcDatabaseAccessor = cdcDatabaseAccessor;
@@ -138,15 +146,26 @@ public class CdcManager
                                                                  range.endAsBigInt());
 
                                 // Only create consumer if not already created for this (instance, range)
-                                return uniqueConsumers.computeIfAbsent(uniqueKey, k ->
-                                    loadOrBuildCdcConsumer(instanceId,
-                                                          clusterConfigProvider,
-                                                          eventConsumer,
-                                                          schemaSupplier,
-                                                          () -> org.apache.cassandra.bridge.TokenRange.openClosed(range.startAsBigInt(), range.endAsBigInt()),
-                                                          conf,
-                                                          cdcStats,
-                                                          taskExecutorPool));
+                                return uniqueConsumers.computeIfAbsent(uniqueKey, k -> {
+                                    try
+                                    {
+                                        return loadOrBuildCdcConsumer(instanceId,
+                                                                      clusterConfigProvider,
+                                                                      eventConsumer,
+                                                                      schemaSupplier,
+                                                                      () -> org.apache.cassandra.bridge.TokenRange.openClosed(range.startAsBigInt(), range.endAsBigInt()),
+                                                                      sidecarInstancesProvider,
+                                                                      secretsProvider,
+                                                                      clientConfig,
+                                                                      conf,
+                                                                      cdcStats,
+                                                                      taskExecutorPool);
+                                    }
+                                    catch (IOException e)
+                                    {
+                                        throw new RuntimeException(e);
+                                    }
+                                });
                             }))
                    .collect(Collectors.toList());
 
@@ -159,9 +178,12 @@ public class CdcManager
                                       EventConsumer eventConsumer,
                                       SchemaSupplier schemaSupplier,
                                       TokenRangeSupplier tokenRangeSupplier,
+                                      CdcSidecarInstancesProvider sidecarInstancesProvider,
+                                      SecretsProvider secretsProvider,
+                                      SidecarCdcClient.ClientConfig clientConfig,
                                       CdcConfig conf,
                                       ICdcStats cdcStats,
-                                      TaskExecutorPool taskExecutorPool)
+                                      TaskExecutorPool taskExecutorPool) throws IOException
     {
         return buildConsumer(conf.jobId(),
                              instanceId,
@@ -170,6 +192,9 @@ public class CdcManager
                              eventConsumer,
                              schemaSupplier,
                              tokenRangeSupplier,
+                             sidecarInstancesProvider,
+                             clientConfig,
+                             secretsProvider,
                              cdcStats,
                              taskExecutorPool);
     }
@@ -183,51 +208,21 @@ public class CdcManager
     public void stopConsumers()
     {
         consumers.forEach(SidecarCdc::stop);
+    }
+
+    @VisibleForTesting
+    Integer getInstanceId(String instanceIp)
+    {
         try
         {
-            sidecarCdcClient.close();
+            return instanceFetcher.instance(instanceIp).id();
         }
         catch (Exception e)
         {
-            LOGGER.warn("Failed to close SidecarCdcClient", e);
+            LOGGER.warn("Requested IP {} does not match with any instances", instanceIp);
+            return UNKNOWN_INSTANCE;
         }
     }
-
-    private Integer getInstanceId(String instanceIp)
-    {
-        for (InstanceMetadata instance : instanceFetcher.allLocalInstances())
-        {
-            String configuredIpAddress = instance.ipAddress();
-
-            // Option 1a: Normalize both to InetAddress and compare
-            if (resolveToSameAddress(instanceIp, configuredIpAddress) || resolveToSameAddress(instanceIp, instance.host()))
-            {
-                return instance.id();
-            }
-        }
-        LOGGER.warn("Requested IP {} does not match any instance: {}",
-                instanceIp,
-                instanceFetcher.allLocalInstances().stream()
-                        .map(i -> "id=" + i.id() + " host=" + i.host() + " ipAddress=" + i.ipAddress())
-                        .collect(Collectors.toList()));
-        return -1;
-    }
-
-    public static boolean resolveToSameAddress(String address1, String address2)
-    {
-        try
-        {
-            InetAddress addr1 = InetAddress.getByName(address1);
-            InetAddress addr2 = InetAddress.getByName(address2);
-            return addr1.equals(addr2);
-        }
-        catch (UnknownHostException e)
-        {
-            LOGGER.warn("Could not resolve hostname: {}", e.getMessage());
-            return address1.equals(address2); // Fallback to string comparison
-        }
-    }
-
 
     public SidecarCdc buildConsumer(@NotNull String jobId,
                                     int partitionId,
@@ -236,8 +231,11 @@ public class CdcManager
                                     EventConsumer eventConsumer,
                                     SchemaSupplier schemaSupplier,
                                     TokenRangeSupplier tokenRangeSupplier,
+                                    CdcSidecarInstancesProvider sidecarInstancesProvider,
+                                    SidecarCdcClient.ClientConfig clientConfig,
+                                    SecretsProvider secretsProvider,
                                     ICdcStats cdcStats,
-                                    TaskExecutorPool taskExecutorPool)
+                                    TaskExecutorPool taskExecutorPool) throws IOException
     {
         AsyncExecutor asyncExecutor = new ExecutorPoolsExecutor(taskExecutorPool);
 
@@ -249,7 +247,9 @@ public class CdcManager
                                                eventConsumer,
                                                schemaSupplier,
                                                tokenRangeSupplier,
-                                               sidecarCdcClient,
+                                               sidecarInstancesProvider,
+                                               clientConfig,
+                                               secretsProvider,
                                                cdcStats)
                                         .withReplicationFactorSupplier(replicationFactorSupplier)
                                         .withExecutor(asyncExecutor)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcManager.java
@@ -18,7 +18,8 @@
 
 package org.apache.cassandra.sidecar.cdc;
 
-import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,14 +34,14 @@ import org.apache.cassandra.cdc.api.CdcOptions;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.api.TokenRangeSupplier;
-import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
+import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdc;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcStats;
 import org.apache.cassandra.cdc.sidecar.SidecarStatePersister;
 import org.apache.cassandra.cdc.stats.ICdcStats;
-import org.apache.cassandra.secrets.SecretsProvider;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.TokenRange;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
@@ -48,7 +49,6 @@ import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.cassandra.spark.utils.AsyncExecutor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.VisibleForTesting;
 
 
 /**
@@ -76,20 +76,18 @@ import org.jetbrains.annotations.VisibleForTesting;
 public class CdcManager
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(CdcManager.class);
-    private static final int UNKNOWN_INSTANCE = -1;
     private final CdcConfig conf;
     private final RangeManager rangeManager;
     private final InstanceMetadataFetcher instanceFetcher;
     private final EventConsumer eventConsumer;
     private final SchemaSupplier schemaSupplier;
     private final ClusterConfigProvider clusterConfigProvider;
-    private final CdcSidecarInstancesProvider sidecarInstancesProvider;
-    private final SecretsProvider secretsProvider;
-    private final SidecarCdcClient.ClientConfig clientConfig;
+    private final SidecarCdcClient sidecarCdcClient;
     private final ICdcStats cdcStats;
     private List<SidecarCdc> consumers = new ArrayList<>();
     private final TaskExecutorPool taskExecutorPool;
     private final CdcDatabaseAccessor cdcDatabaseAccessor;
+    private final ReplicationFactorSupplier replicationFactorSupplier;
 
 
     public CdcManager(EventConsumer eventConsumer,
@@ -98,12 +96,11 @@ public class CdcManager
                       RangeManager rangeManager,
                       InstanceMetadataFetcher instanceFetcher,
                       ClusterConfigProvider clusterConfigProvider,
-                      CdcSidecarInstancesProvider sidecarInstancesProvider,
-                      SecretsProvider secretsProvider,
-                      SidecarCdcClient.ClientConfig clientConfig,
+                      SidecarCdcClient sidecarCdcClient,
                       ICdcStats cdcStats,
                       TaskExecutorPool taskExecutorPool,
-                      CdcDatabaseAccessor cdcDatabaseAccessor)
+                      CdcDatabaseAccessor cdcDatabaseAccessor,
+                      ReplicationFactorSupplier replicationFactorSupplier)
     {
         this.eventConsumer = eventConsumer;
         this.schemaSupplier = schemaSupplier;
@@ -111,12 +108,11 @@ public class CdcManager
         this.rangeManager = rangeManager;
         this.instanceFetcher = instanceFetcher;
         this.clusterConfigProvider = clusterConfigProvider;
-        this.sidecarInstancesProvider = sidecarInstancesProvider;
-        this.secretsProvider = secretsProvider;
-        this.clientConfig = clientConfig;
+        this.sidecarCdcClient = sidecarCdcClient;
         this.cdcStats = cdcStats;
         this.taskExecutorPool = taskExecutorPool;
         this.cdcDatabaseAccessor = cdcDatabaseAccessor;
+        this.replicationFactorSupplier = replicationFactorSupplier;
     }
 
     List<SidecarCdc> buildCdcConsumers()
@@ -142,26 +138,15 @@ public class CdcManager
                                                                  range.endAsBigInt());
 
                                 // Only create consumer if not already created for this (instance, range)
-                                return uniqueConsumers.computeIfAbsent(uniqueKey, k -> {
-                                    try
-                                    {
-                                        return loadOrBuildCdcConsumer(instanceId,
-                                                                      clusterConfigProvider,
-                                                                      eventConsumer,
-                                                                      schemaSupplier,
-                                                                      () -> org.apache.cassandra.bridge.TokenRange.openClosed(range.startAsBigInt(), range.endAsBigInt()),
-                                                                      sidecarInstancesProvider,
-                                                                      secretsProvider,
-                                                                      clientConfig,
-                                                                      conf,
-                                                                      cdcStats,
-                                                                      taskExecutorPool);
-                                    }
-                                    catch (IOException e)
-                                    {
-                                        throw new RuntimeException(e);
-                                    }
-                                });
+                                return uniqueConsumers.computeIfAbsent(uniqueKey, k ->
+                                    loadOrBuildCdcConsumer(instanceId,
+                                                          clusterConfigProvider,
+                                                          eventConsumer,
+                                                          schemaSupplier,
+                                                          () -> org.apache.cassandra.bridge.TokenRange.openClosed(range.startAsBigInt(), range.endAsBigInt()),
+                                                          conf,
+                                                          cdcStats,
+                                                          taskExecutorPool));
                             }))
                    .collect(Collectors.toList());
 
@@ -174,12 +159,9 @@ public class CdcManager
                                       EventConsumer eventConsumer,
                                       SchemaSupplier schemaSupplier,
                                       TokenRangeSupplier tokenRangeSupplier,
-                                      CdcSidecarInstancesProvider sidecarInstancesProvider,
-                                      SecretsProvider secretsProvider,
-                                      SidecarCdcClient.ClientConfig clientConfig,
                                       CdcConfig conf,
                                       ICdcStats cdcStats,
-                                      TaskExecutorPool taskExecutorPool) throws IOException
+                                      TaskExecutorPool taskExecutorPool)
     {
         return buildConsumer(conf.jobId(),
                              instanceId,
@@ -188,9 +170,6 @@ public class CdcManager
                              eventConsumer,
                              schemaSupplier,
                              tokenRangeSupplier,
-                             sidecarInstancesProvider,
-                             clientConfig,
-                             secretsProvider,
                              cdcStats,
                              taskExecutorPool);
     }
@@ -204,19 +183,48 @@ public class CdcManager
     public void stopConsumers()
     {
         consumers.forEach(SidecarCdc::stop);
-    }
-
-    @VisibleForTesting
-    Integer getInstanceId(String instanceIp)
-    {
         try
         {
-            return instanceFetcher.instance(instanceIp).id();
+            sidecarCdcClient.close();
         }
         catch (Exception e)
         {
-            LOGGER.warn("Requested IP {} does not match with any instances", instanceIp);
-            return UNKNOWN_INSTANCE;
+            LOGGER.warn("Failed to close SidecarCdcClient", e);
+        }
+    }
+
+    private Integer getInstanceId(String instanceIp)
+    {
+        for (InstanceMetadata instance : instanceFetcher.allLocalInstances())
+        {
+            String configuredIpAddress = instance.ipAddress();
+
+            // Option 1a: Normalize both to InetAddress and compare
+            if (resolveToSameAddress(instanceIp, configuredIpAddress) || resolveToSameAddress(instanceIp, instance.host()))
+            {
+                return instance.id();
+            }
+        }
+        LOGGER.warn("Requested IP {} does not match any instance: {}",
+                instanceIp,
+                instanceFetcher.allLocalInstances().stream()
+                        .map(i -> "id=" + i.id() + " host=" + i.host() + " ipAddress=" + i.ipAddress())
+                        .collect(Collectors.toList()));
+        return -1;
+    }
+
+    public static boolean resolveToSameAddress(String address1, String address2)
+    {
+        try
+        {
+            InetAddress addr1 = InetAddress.getByName(address1);
+            InetAddress addr2 = InetAddress.getByName(address2);
+            return addr1.equals(addr2);
+        }
+        catch (UnknownHostException e)
+        {
+            LOGGER.warn("Could not resolve hostname: {}", e.getMessage());
+            return address1.equals(address2); // Fallback to string comparison
         }
     }
 
@@ -228,13 +236,9 @@ public class CdcManager
                                     EventConsumer eventConsumer,
                                     SchemaSupplier schemaSupplier,
                                     TokenRangeSupplier tokenRangeSupplier,
-                                    CdcSidecarInstancesProvider sidecarInstancesProvider,
-                                    SidecarCdcClient.ClientConfig clientConfig,
-                                    SecretsProvider secretsProvider,
                                     ICdcStats cdcStats,
-                                    TaskExecutorPool taskExecutorPool) throws IOException
+                                    TaskExecutorPool taskExecutorPool)
     {
-
         AsyncExecutor asyncExecutor = new ExecutorPoolsExecutor(taskExecutorPool);
 
         final SidecarStatePersister sidecarStatePersister = getSidecarStatePersister(cdcOptions, asyncExecutor);
@@ -245,10 +249,12 @@ public class CdcManager
                                                eventConsumer,
                                                schemaSupplier,
                                                tokenRangeSupplier,
-                                               sidecarInstancesProvider,
-                                               clientConfig,
-                                               secretsProvider,
-                                               cdcStats).withExecutor(asyncExecutor).withStatePersister(sidecarStatePersister).build();
+                                               sidecarCdcClient,
+                                               cdcStats)
+                                        .withReplicationFactorSupplier(replicationFactorSupplier)
+                                        .withExecutor(asyncExecutor)
+                                        .withStatePersister(sidecarStatePersister)
+                                        .build();
     }
 
     private @NotNull SidecarStatePersister getSidecarStatePersister(CdcOptions cdcOptions, AsyncExecutor asyncExecutor)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -18,9 +18,11 @@
 
 package org.apache.cassandra.sidecar.cdc;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +35,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
+import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.cdc.CdcLogMode;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
@@ -41,6 +44,7 @@ import org.apache.cassandra.cdc.kafka.TopicSupplier;
 import org.apache.cassandra.cdc.msg.CdcEvent;
 import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
+import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdc;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.stats.ICdcStats;
@@ -56,13 +60,16 @@ import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.config.SslConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
+import org.apache.cassandra.sidecar.db.SidecarRegistryCache;
 import org.apache.cassandra.sidecar.db.VirtualTablesDatabaseAccessor;
 import org.apache.cassandra.sidecar.tasks.PeriodicTask;
 import org.apache.cassandra.sidecar.tasks.ScheduleDecision;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.Serializer;
 
+import static org.apache.cassandra.bridge.BaseCassandraBridgeFactory.getCassandraVersion;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CACHE_WARMED_UP;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CONFIGURATION_CHANGED;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
@@ -91,6 +98,7 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
     private final SidecarCdcClient.ClientConfig clientConfig;
     private final ICdcStats cdcStats;
     private final SidecarConfiguration sidecarConfiguration;
+    private final SidecarRegistryCache sidecarRegistryCache;
     private CdcManager cdcManager;
     private final Serializer<CdcEvent> avroSerializer;
     private final Provider<RangeManager> rangeManagerProvider;
@@ -112,7 +120,8 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
                         VirtualTablesDatabaseAccessor virtualTables,
                         SidecarCdcStats sidecarCdcStats,
                         Serializer<CdcEvent> avroSerializer,
-                        Provider<RangeManager> rangeManagerProvider)
+                        Provider<RangeManager> rangeManagerProvider,
+                        SidecarRegistryCache sidecarRegistryCache)
     {
         this.sidecarCdcStats = sidecarCdcStats;
         this.executorPools = executorPools.internal();
@@ -129,6 +138,7 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         this.sidecarConfiguration = sidecarConfiguration;
         this.avroSerializer = avroSerializer;
         this.rangeManagerProvider = rangeManagerProvider;
+        this.sidecarRegistryCache = sidecarRegistryCache;
 
         if (conf.cdcEnabled())
         {
@@ -184,7 +194,11 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
             this.kafkaPublisher.close();
         }
         this.producer = new KafkaProducer<>(conf.kafkaConfigs());
-        this.kafkaPublisher = new KafkaPublisher(TopicSupplier.staticTopicSupplier(conf.kafkaTopic()),
+        String releaseVersion = instanceMetadataFetcher.callOnFirstAvailableInstance(
+            instance -> instance.delegate().nodeSettings().releaseVersion());
+        CassandraVersion cassandraVersion = getCassandraVersion(releaseVersion);
+        this.kafkaPublisher = new KafkaPublisher(cassandraVersion,
+                                                           TopicSupplier.staticTopicSupplier(conf.kafkaTopic()),
                                                            producer,
                                                            avroSerializer,
                                                            conf.maxRecordSizeBytes(),
@@ -192,6 +206,16 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
                                                            conf.failOnKafkaError(),
                                                            CdcLogMode.FULL);
         return new CdcEventConsumer(kafkaPublisher);
+    }
+
+    /**
+     * Returns the {@link ReplicationFactorSupplier} to use for CDC peer discovery.
+     * Override in tests to substitute a lightweight alternative (e.g. {@code ReplicationFactorSupplier.DEFAULT})
+     * without requiring a live Cassandra driver call.
+     */
+    protected ReplicationFactorSupplier createReplicationFactorSupplier()
+    {
+        return new SidecarReplicationFactorSupplier(instanceMetadataFetcher);
     }
 
     private class ConfigChangedHandler implements Handler<Message<Object>>
@@ -216,24 +240,84 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         }
         databaseAccessor.session();
 
+        SidecarCdcClient sidecarCdcClient = createSidecarCdcClient();
         cdcManager = new CdcManager(eventConsumer(conf, avroSerializer),
                                     schemaSupplier,
                                     conf,
                                     rangeManagerProvider.get(),
                                     instanceMetadataFetcher,
                                     clusterConfigProvider,
-                                    sidecarInstancesProvider,
-                                    secretsProvider(),
-                                    clientConfig,
+                                    sidecarCdcClient,
                                     cdcStats,
                                     this.executorPools,
-                                    databaseAccessor);
+                                    databaseAccessor,
+                                    createReplicationFactorSupplier());
 
         List<SidecarCdc> consumers = cdcManager.buildCdcConsumers();
         cdcManager.startConsumers();
         LOGGER.info("{} CDC iterators started successfully", consumers.size());
         isRunning = true;
         sidecarCdcStats.captureCdcStarted(consumers.size());
+    }
+
+    /**
+     * Resolves the sidecar port for a given Cassandra instance using the registry cache,
+     * falling back to {@code defaultPort} when no registry entry exists for the instance host.
+     *
+     * @param instance    the Cassandra instance whose sidecar port should be resolved
+     * @param defaultPort the port to return when the registry cache has no entry for the host
+     * @return the registry-cached port if known, otherwise {@code defaultPort}
+     */
+    Integer resolveSidecarPort(CassandraInstance instance, int defaultPort)
+    {
+        String host = instance.nodeName();
+        Integer port = sidecarRegistryCache.getPort(host);
+        if (port != null)
+        {
+            LOGGER.info("Resolved sidecar port from registry cache host={} port={}", host, port);
+            return port;
+        }
+        LOGGER.info("No registry entry for host={}, falling back to default port={} cacheSize={}",
+                    host, defaultPort, sidecarRegistryCache.size());
+        return defaultPort;
+    }
+
+    /**
+     * Builds the per-peer port-resolver {@link Function} handed to {@link SidecarCdcClient}.
+     * The returned function captures {@code defaultPort} so that each outbound CDC HTTP request
+     * to a peer can either use a registry-cached port or fall back to the default.
+     *
+     * @param defaultPort fallback port used when the registry cache has no entry for the peer
+     * @return a function mapping {@link CassandraInstance} -&gt; sidecar port
+     */
+    Function<CassandraInstance, Integer> portResolver(int defaultPort)
+    {
+        return instance -> resolveSidecarPort(instance, defaultPort);
+    }
+
+    /**
+     * Constructs the {@link SidecarCdcClient} used for CDC peer HTTP communication.
+     * Wraps the IO-throwing constructor so callers (notably {@link #run()}) get a
+     * single exception-handling site, and so unit tests can override the construction.
+     *
+     * @return a configured {@link SidecarCdcClient}
+     * @throws RuntimeException wrapping any {@link IOException} from the underlying client setup
+     */
+    SidecarCdcClient createSidecarCdcClient()
+    {
+        int defaultPort = clientConfig.effectivePort();
+        try
+        {
+            return new SidecarCdcClient(clientConfig,
+                                        sidecarInstancesProvider,
+                                        secretsProvider(),
+                                        cdcStats,
+                                        portResolver(defaultPort));
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Failed to create SidecarCdcClient", e);
+        }
     }
 
     protected synchronized void restart()

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -18,11 +18,9 @@
 
 package org.apache.cassandra.sidecar.cdc;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +33,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
-import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.cdc.CdcLogMode;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
@@ -60,16 +57,13 @@ import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.config.SslConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
-import org.apache.cassandra.sidecar.db.SidecarRegistryCache;
 import org.apache.cassandra.sidecar.db.VirtualTablesDatabaseAccessor;
 import org.apache.cassandra.sidecar.tasks.PeriodicTask;
 import org.apache.cassandra.sidecar.tasks.ScheduleDecision;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
-import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.serialization.Serializer;
 
-import static org.apache.cassandra.bridge.BaseCassandraBridgeFactory.getCassandraVersion;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CACHE_WARMED_UP;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CONFIGURATION_CHANGED;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
@@ -98,7 +92,6 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
     private final SidecarCdcClient.ClientConfig clientConfig;
     private final ICdcStats cdcStats;
     private final SidecarConfiguration sidecarConfiguration;
-    private final SidecarRegistryCache sidecarRegistryCache;
     private CdcManager cdcManager;
     private final Serializer<CdcEvent> avroSerializer;
     private final Provider<RangeManager> rangeManagerProvider;
@@ -120,8 +113,7 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
                         VirtualTablesDatabaseAccessor virtualTables,
                         SidecarCdcStats sidecarCdcStats,
                         Serializer<CdcEvent> avroSerializer,
-                        Provider<RangeManager> rangeManagerProvider,
-                        SidecarRegistryCache sidecarRegistryCache)
+                        Provider<RangeManager> rangeManagerProvider)
     {
         this.sidecarCdcStats = sidecarCdcStats;
         this.executorPools = executorPools.internal();
@@ -138,7 +130,6 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         this.sidecarConfiguration = sidecarConfiguration;
         this.avroSerializer = avroSerializer;
         this.rangeManagerProvider = rangeManagerProvider;
-        this.sidecarRegistryCache = sidecarRegistryCache;
 
         if (conf.cdcEnabled())
         {
@@ -194,11 +185,7 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
             this.kafkaPublisher.close();
         }
         this.producer = new KafkaProducer<>(conf.kafkaConfigs());
-        String releaseVersion = instanceMetadataFetcher.callOnFirstAvailableInstance(
-            instance -> instance.delegate().nodeSettings().releaseVersion());
-        CassandraVersion cassandraVersion = getCassandraVersion(releaseVersion);
-        this.kafkaPublisher = new KafkaPublisher(cassandraVersion,
-                                                           TopicSupplier.staticTopicSupplier(conf.kafkaTopic()),
+        this.kafkaPublisher = new KafkaPublisher(TopicSupplier.staticTopicSupplier(conf.kafkaTopic()),
                                                            producer,
                                                            avroSerializer,
                                                            conf.maxRecordSizeBytes(),
@@ -240,14 +227,15 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         }
         databaseAccessor.session();
 
-        SidecarCdcClient sidecarCdcClient = createSidecarCdcClient();
         cdcManager = new CdcManager(eventConsumer(conf, avroSerializer),
                                     schemaSupplier,
                                     conf,
                                     rangeManagerProvider.get(),
                                     instanceMetadataFetcher,
                                     clusterConfigProvider,
-                                    sidecarCdcClient,
+                                    sidecarInstancesProvider,
+                                    secretsProvider(),
+                                    clientConfig,
                                     cdcStats,
                                     this.executorPools,
                                     databaseAccessor,
@@ -258,66 +246,6 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         LOGGER.info("{} CDC iterators started successfully", consumers.size());
         isRunning = true;
         sidecarCdcStats.captureCdcStarted(consumers.size());
-    }
-
-    /**
-     * Resolves the sidecar port for a given Cassandra instance using the registry cache,
-     * falling back to {@code defaultPort} when no registry entry exists for the instance host.
-     *
-     * @param instance    the Cassandra instance whose sidecar port should be resolved
-     * @param defaultPort the port to return when the registry cache has no entry for the host
-     * @return the registry-cached port if known, otherwise {@code defaultPort}
-     */
-    Integer resolveSidecarPort(CassandraInstance instance, int defaultPort)
-    {
-        String host = instance.nodeName();
-        Integer port = sidecarRegistryCache.getPort(host);
-        if (port != null)
-        {
-            LOGGER.info("Resolved sidecar port from registry cache host={} port={}", host, port);
-            return port;
-        }
-        LOGGER.info("No registry entry for host={}, falling back to default port={} cacheSize={}",
-                    host, defaultPort, sidecarRegistryCache.size());
-        return defaultPort;
-    }
-
-    /**
-     * Builds the per-peer port-resolver {@link Function} handed to {@link SidecarCdcClient}.
-     * The returned function captures {@code defaultPort} so that each outbound CDC HTTP request
-     * to a peer can either use a registry-cached port or fall back to the default.
-     *
-     * @param defaultPort fallback port used when the registry cache has no entry for the peer
-     * @return a function mapping {@link CassandraInstance} -&gt; sidecar port
-     */
-    Function<CassandraInstance, Integer> portResolver(int defaultPort)
-    {
-        return instance -> resolveSidecarPort(instance, defaultPort);
-    }
-
-    /**
-     * Constructs the {@link SidecarCdcClient} used for CDC peer HTTP communication.
-     * Wraps the IO-throwing constructor so callers (notably {@link #run()}) get a
-     * single exception-handling site, and so unit tests can override the construction.
-     *
-     * @return a configured {@link SidecarCdcClient}
-     * @throws RuntimeException wrapping any {@link IOException} from the underlying client setup
-     */
-    SidecarCdcClient createSidecarCdcClient()
-    {
-        int defaultPort = clientConfig.effectivePort();
-        try
-        {
-            return new SidecarCdcClient(clientConfig,
-                                        sidecarInstancesProvider,
-                                        secretsProvider(),
-                                        cdcStats,
-                                        portResolver(defaultPort));
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException("Failed to create SidecarCdcClient", e);
-        }
     }
 
     protected synchronized void restart()

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/SidecarReplicationFactorSupplier.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/SidecarReplicationFactorSupplier.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.sidecar.cdc;
+
+import java.util.Comparator;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.apache.cassandra.spark.data.ReplicationFactor;
+
+/**
+ * Resolves a keyspace's actual {@link ReplicationFactor} from live Cassandra schema metadata
+ * via the driver. This replaces the analytics library's {@code ReplicationFactorSupplier.DEFAULT},
+ * which hard-codes {@code SimpleStrategy/RF=1} and would otherwise cause CDC peer discovery
+ * to find only one replica per token range.
+ */
+public class SidecarReplicationFactorSupplier implements ReplicationFactorSupplier
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(SidecarReplicationFactorSupplier.class);
+
+    private final InstanceMetadataFetcher instanceMetadataFetcher;
+
+    public SidecarReplicationFactorSupplier(InstanceMetadataFetcher instanceMetadataFetcher)
+    {
+        this.instanceMetadataFetcher = instanceMetadataFetcher;
+    }
+
+    @Override
+    public ReplicationFactor getReplicationFactor(String keyspace)
+    {
+        return instanceMetadataFetcher.callOnFirstAvailableInstance(instance -> {
+            KeyspaceMetadata ks = instance.delegate().metadata().getKeyspace(keyspace);
+            if (ks == null)
+            {
+                LOGGER.warn("Keyspace '{}' not found in driver metadata, falling back to SimpleStrategy/RF=1", keyspace);
+                return ReplicationFactor.simpleStrategy(1);
+            }
+            ReplicationFactor rf = new ReplicationFactor(ks.getReplication());
+            LOGGER.info("Resolved replicationFactor for keyspace={}: strategy={} totalRf={}",
+                         keyspace, rf.getReplicationStrategy(), rf.getTotalReplicationFactor());
+            return rf;
+        });
+    }
+
+    @Override
+    public ReplicationFactor getMaximalReplicationFactor()
+    {
+        // The analytics layer asks for the "maximal" RF across CDC-enabled keyspaces to size
+        // partition assignment; we approximate by taking the schema-wide max-total-RF keyspace.
+        // Falls back to SimpleStrategy/RF=1 if no keyspaces are visible (extreme edge case).
+        return instanceMetadataFetcher.callOnFirstAvailableInstance(instance -> {
+            KeyspaceMetadata maxKs = instance.delegate().metadata().getKeyspaces().stream()
+                                              .max(Comparator.comparingInt(SidecarReplicationFactorSupplier::totalRf))
+                                              .orElse(null);
+            if (maxKs == null)
+            {
+                LOGGER.warn("No keyspaces visible from driver; falling back to SimpleStrategy/RF=1");
+                return ReplicationFactor.simpleStrategy(1);
+            }
+            ReplicationFactor rf = new ReplicationFactor(maxKs.getReplication());
+            LOGGER.info("Resolved maximalReplicationFactor from keyspace={} totalRf={}",
+                         maxKs.getName(), rf.getTotalReplicationFactor());
+            return rf;
+        });
+    }
+
+    private static int totalRf(KeyspaceMetadata ks)
+    {
+        int total = 0;
+        for (Map.Entry<String, String> e : ks.getReplication().entrySet())
+        {
+            // Skip the "class" entry; only DC/replication-factor entries are integer-valued.
+            if ("class".equals(e.getKey()))
+            {
+                continue;
+            }
+            try
+            {
+                total += Integer.parseInt(e.getValue());
+            }
+            catch (NumberFormatException ignored)
+            {
+                LOGGER.warn("Non-integer replication option: {}", e.getValue());
+            }
+        }
+        return total;
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/SidecarReplicationFactorSupplier.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/SidecarReplicationFactorSupplier.java
@@ -57,10 +57,7 @@ public class SidecarReplicationFactorSupplier implements ReplicationFactorSuppli
                 LOGGER.warn("Keyspace '{}' not found in driver metadata, falling back to SimpleStrategy/RF=1", keyspace);
                 return ReplicationFactor.simpleStrategy(1);
             }
-            ReplicationFactor rf = new ReplicationFactor(ks.getReplication());
-            LOGGER.info("Resolved replicationFactor for keyspace={}: strategy={} totalRf={}",
-                         keyspace, rf.getReplicationStrategy(), rf.getTotalReplicationFactor());
-            return rf;
+            return new ReplicationFactor(ks.getReplication());
         });
     }
 
@@ -79,10 +76,7 @@ public class SidecarReplicationFactorSupplier implements ReplicationFactorSuppli
                 LOGGER.warn("No keyspaces visible from driver; falling back to SimpleStrategy/RF=1");
                 return ReplicationFactor.simpleStrategy(1);
             }
-            ReplicationFactor rf = new ReplicationFactor(maxKs.getReplication());
-            LOGGER.info("Resolved maximalReplicationFactor from keyspace={} totalRf={}",
-                         maxKs.getName(), rf.getTotalReplicationFactor());
-            return rf;
+            return new ReplicationFactor(maxKs.getReplication());
         });
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcManagerTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.cassandra.sidecar.cdc;
 
+import java.io.IOException;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.api.TokenRangeSupplier;
+import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
 import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdc;
@@ -40,11 +41,13 @@ import org.apache.cassandra.cdc.sidecar.SidecarCdcBuilder;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.sidecar.SidecarStatePersister;
 import org.apache.cassandra.cdc.stats.ICdcStats;
+import org.apache.cassandra.secrets.SecretsProvider;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.TokenRange;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
+import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.mockito.Answers;
 import org.mockito.Mock;
@@ -53,21 +56,17 @@ import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -88,7 +87,11 @@ public class CdcManagerTest
     @Mock
     private ClusterConfigProvider clusterConfigProvider;
     @Mock
-    private SidecarCdcClient sidecarCdcClient;
+    private CdcSidecarInstancesProvider sidecarInstancesProvider;
+    @Mock
+    private SecretsProvider secretsProvider;
+    @Mock
+    private SidecarCdcClient.ClientConfig clientConfig;
     @Mock
     private ICdcStats cdcStats;
     @Mock
@@ -110,7 +113,9 @@ public class CdcManagerTest
             rangeManager,
             instanceFetcher,
             clusterConfigProvider,
-            sidecarCdcClient,
+            sidecarInstancesProvider,
+            secretsProvider,
+            clientConfig,
             cdcStats,
             taskExecutorPool,
             cdcDatabaseAccessor,
@@ -139,7 +144,7 @@ public class CdcManagerTest
     }
 
     @Test
-    void testSingleInstanceSingleRangeCreatesOneConsumer()
+    void testSingleInstanceSingleRangeCreatesOneConsumer() throws IOException
     {
         String instanceIp = "127.0.0.1";
         int instanceId = 1;
@@ -151,24 +156,22 @@ public class CdcManagerTest
         InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
+        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
         when(cdcConfig.jobId()).thenReturn("test-job");
 
-        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer = mock(SidecarCdc.class);
         doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
-        // Assert
         assertThat(consumers).hasSize(1);
     }
 
     @Test
-    void testSingleInstanceMultipleRangesCreatesMultipleConsumers()
+    void testSingleInstanceMultipleRangesCreatesMultipleConsumers() throws IOException
     {
         String instanceIp = "127.0.0.1";
         int instanceId = 1;
@@ -184,25 +187,23 @@ public class CdcManagerTest
         InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
+        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
         when(cdcConfig.jobId()).thenReturn("test-job");
 
-        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer1 = mock(SidecarCdc.class);
         SidecarCdc mockConsumer2 = mock(SidecarCdc.class);
         doReturn(mockConsumer1, mockConsumer2).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
-        // Assert
         assertThat(consumers).hasSize(2);
     }
 
     @Test
-    void testMultipleInstancesMultipleRangesCreatesConsumers()
+    void testMultipleInstancesMultipleRangesCreatesConsumers() throws IOException
     {
         String instance1Ip = "127.0.0.1";
         String instance2Ip = "127.0.0.2";
@@ -219,35 +220,29 @@ public class CdcManagerTest
         InstanceMetadata instance1 = mockInstance(instance1Id, instance1Ip);
         InstanceMetadata instance2 = mockInstance(instance2Id, instance2Ip);
 
-        List<InstanceMetadata> instances = new ArrayList<>();
-        instances.add(instance1);
-        instances.add(instance2);
-
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(instances);
+        when(instanceFetcher.instance(instance1Ip)).thenReturn(instance1);
+        when(instanceFetcher.instance(instance2Ip)).thenReturn(instance2);
         when(cdcConfig.jobId()).thenReturn("test-job");
 
-        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer1 = mock(SidecarCdc.class);
         SidecarCdc mockConsumer2 = mock(SidecarCdc.class);
         doReturn(mockConsumer1, mockConsumer2).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
-        // Assert
         assertThat(consumers).hasSize(2);
     }
 
     @Test
-    void testDuplicateRangesDeduplicates()
+    void testDuplicateRangesDeduplicates() throws IOException
     {
         String instanceIp = "127.0.0.1";
         int instanceId = 1;
 
-        // Create two identical ranges
         TokenRange range1 = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
         TokenRange range2 = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
 
@@ -260,45 +255,41 @@ public class CdcManagerTest
         InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
+        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
         when(cdcConfig.jobId()).thenReturn("test-job");
 
-        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer = mock(SidecarCdc.class);
         doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
-        // Assert - Should deduplicate to 1 consumer
         assertThat(consumers).hasSize(1);
     }
 
     @Test
-    void testUnknownInstanceHandlesGracefully()
+    void testUnknownInstanceHandlesGracefully() throws IOException
     {
         String unknownIp = "192.168.1.100";
 
         TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
         Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(unknownIp, Collections.singleton(range));
 
-        // No matching instances
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.emptyList());
+        when(instanceFetcher.instance(unknownIp))
+            .thenThrow(new NoSuchCassandraInstanceException("Instance not found: " + unknownIp));
         when(cdcConfig.jobId()).thenReturn("test-job");
 
-        // Spy to mock loadOrBuildCdcConsumer - will be called with instanceId = -1
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer = mock(SidecarCdc.class);
         doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
-        // Assert - Should still create consumer with instanceId = -1
         assertThat(consumers).hasSize(1);
     }
 
@@ -308,7 +299,7 @@ public class CdcManagerTest
         ReplicationFactorSupplier customSupplier = mock(ReplicationFactorSupplier.class);
         CdcManager managerWithCustomSupplier = new CdcManager(
             eventConsumer, schemaSupplier, cdcConfig, rangeManager, instanceFetcher,
-            clusterConfigProvider, sidecarCdcClient,
+            clusterConfigProvider, sidecarInstancesProvider, secretsProvider, clientConfig,
             cdcStats, taskExecutorPool, cdcDatabaseAccessor, customSupplier);
 
         try (MockedStatic<SidecarCdc> mockedSidecarCdc = mockStatic(SidecarCdc.class);
@@ -316,7 +307,7 @@ public class CdcManagerTest
         {
             SidecarCdcBuilder mockBuilder = mock(SidecarCdcBuilder.class, Answers.RETURNS_SELF);
             mockedSidecarCdc.when(() -> SidecarCdc.builder(
-                anyString(), anyInt(), any(), any(), any(), any(), any(), any(), any()
+                anyString(), anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any()
             )).thenReturn(mockBuilder);
 
             when(cdcConfig.jobId()).thenReturn("test-job");
@@ -324,149 +315,12 @@ public class CdcManagerTest
             managerWithCustomSupplier.loadOrBuildCdcConsumer(
                 1, clusterConfigProvider, eventConsumer, schemaSupplier,
                 mock(TokenRangeSupplier.class),
+                sidecarInstancesProvider, secretsProvider, clientConfig,
                 cdcConfig, cdcStats, taskExecutorPool);
 
             verify(mockBuilder).withReplicationFactorSupplier(customSupplier);
         }
     }
-
-    @Test
-    void testResolveToSameAddressTrue()
-    {
-        String address1 = "127.0.0.1";
-        String address2 = "localhost";
-        assertThat(CdcManager.resolveToSameAddress(address1, address2)).isTrue();
-    }
-
-    @Test
-    void testResolveToSameAddressFalse()
-    {
-        String address1 = "127.0.0.1";
-        String address2 = "127.0.0.2";
-        assertThat(CdcManager.resolveToSameAddress(address1, address2)).isFalse();
-    }
-
-    @Test
-    void testStopConsumersWithEmptyConsumersClosesClient() throws Exception
-    {
-        // No consumers built yet; stopConsumers must still close the client and not throw.
-        assertThatCode(() -> cdcManager.stopConsumers()).doesNotThrowAnyException();
-
-        verify(sidecarCdcClient, times(1)).close();
-    }
-
-    @Test
-    void testStopConsumersInvokesStopOnEachConsumerAndClosesClient() throws Exception
-    {
-        // Arrange: populate consumers via buildCdcConsumers with two distinct ranges.
-        String instanceIp = "127.0.0.1";
-        int instanceId = 1;
-        TokenRange range1 = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
-        TokenRange range2 = mockTokenRange(BigInteger.TEN, new BigInteger("20"));
-        Set<TokenRange> ranges = new HashSet<>();
-        ranges.add(range1);
-        ranges.add(range2);
-        Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(instanceIp, ranges);
-
-        InstanceMetadata instance = mockInstance(instanceId, instanceIp);
-
-        when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
-        when(cdcConfig.jobId()).thenReturn("test-job");
-
-        CdcManager spyManager = spy(cdcManager);
-        SidecarCdc consumer1 = mock(SidecarCdc.class);
-        SidecarCdc consumer2 = mock(SidecarCdc.class);
-        doReturn(consumer1, consumer2).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
-        );
-
-        List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
-        assertThat(consumers).hasSize(2);
-
-        // Act
-        spyManager.stopConsumers();
-
-        // Assert: each consumer was stopped exactly once and the client was closed.
-        verify(consumer1, times(1)).stop();
-        verify(consumer2, times(1)).stop();
-        verify(sidecarCdcClient, times(1)).close();
-    }
-
-    @Test
-    void testStopConsumersSwallowsExceptionFromClientClose() throws Exception
-    {
-        // Arrange: build a single consumer, then make sidecarCdcClient.close() throw.
-        String instanceIp = "127.0.0.1";
-        int instanceId = 1;
-        TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
-        Map<String, Set<TokenRange>> ownedRanges =
-            Collections.singletonMap(instanceIp, Collections.singleton(range));
-        InstanceMetadata instance = mockInstance(instanceId, instanceIp);
-
-        when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
-        when(cdcConfig.jobId()).thenReturn("test-job");
-
-        CdcManager spyManager = spy(cdcManager);
-        SidecarCdc consumer = mock(SidecarCdc.class);
-        doReturn(consumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
-        );
-        spyManager.buildCdcConsumers();
-
-        doThrow(new RuntimeException("simulated client close failure"))
-            .when(sidecarCdcClient).close();
-
-        // Act + Assert: exception from close() must not propagate.
-        assertThatCode(() -> spyManager.stopConsumers()).doesNotThrowAnyException();
-
-        // Consumer must still have been stopped before the failing close() call.
-        verify(consumer, times(1)).stop();
-        verify(sidecarCdcClient, times(1)).close();
-    }
-
-    @Test
-    void testStopConsumersDoesNotInteractWithRangeManager() throws Exception
-    {
-        // stopConsumers() must not consult the RangeManager; it only operates on
-        // the previously built consumer list and the cdc client.
-        cdcManager.stopConsumers();
-
-        verifyNoInteractions(rangeManager);
-        verify(sidecarCdcClient, times(1)).close();
-    }
-
-    @Test
-    void testStopConsumersIsIdempotent() throws Exception
-    {
-        // Arrange: build a single consumer.
-        String instanceIp = "127.0.0.1";
-        TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
-        Map<String, Set<TokenRange>> ownedRanges =
-            Collections.singletonMap(instanceIp, Collections.singleton(range));
-        InstanceMetadata instance = mockInstance(1, instanceIp);
-        when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
-        when(cdcConfig.jobId()).thenReturn("test-job");
-
-        CdcManager spyManager = spy(cdcManager);
-        SidecarCdc consumer = mock(SidecarCdc.class);
-        doReturn(consumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any()
-        );
-        spyManager.buildCdcConsumers();
-
-        // Act: invoke twice.
-        spyManager.stopConsumers();
-        spyManager.stopConsumers();
-
-        // Assert: each call independently stops every consumer and closes the client.
-        verify(consumer, times(2)).stop();
-        verify(sidecarCdcClient, times(2)).close();
-    }
-
-    // Helper methods
 
     private TokenRange mockTokenRange(BigInteger start, BigInteger end)
     {

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcManagerTest.java
@@ -20,6 +20,8 @@ package org.apache.cassandra.sidecar.cdc;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -278,8 +281,7 @@ public class CdcManagerTest
         Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(unknownIp, Collections.singleton(range));
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(unknownIp))
-            .thenThrow(new NoSuchCassandraInstanceException("Instance not found: " + unknownIp));
+        when(instanceFetcher.instance(unknownIp)).thenThrow(new NoSuchCassandraInstanceException("Instance not found: " + unknownIp));
         when(cdcConfig.jobId()).thenReturn("test-job");
 
         CdcManager spyManager = spy(cdcManager);
@@ -291,6 +293,93 @@ public class CdcManagerTest
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
         assertThat(consumers).hasSize(1);
+    }
+
+    @Test
+    void testResolveToSameAddressTrue()
+    {
+        assertThat(resolveToSameAddress("127.0.0.1", "localhost")).isTrue();
+    }
+
+    @Test
+    void testResolveToSameAddressFalse()
+    {
+        assertThat(resolveToSameAddress("127.0.0.1", "127.0.0.2")).isFalse();
+    }
+
+    /**
+     * Verifies that the correct instanceId is propagated into {@code loadOrBuildCdcConsumer}
+     * during the full {@code buildCdcConsumers()} flow when {@code ipAddress()} is null.
+     * Complements {@code testGetInstanceIdReturnsCorrectIdWhenIpAddressIsNull}, which tests
+     * {@code getInstanceId} in isolation; this test confirms the fix is effective end-to-end.
+     */
+    @Test
+    void testGetInstanceIdResolvesCorrectlyWhenIpAddressIsNull() throws IOException
+    {
+        String instanceIp = "172.19.0.5";
+        int instanceId = 1000;
+
+        TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
+        Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(instanceIp, Collections.singleton(range));
+
+        InstanceMetadata instance = mock(InstanceMetadata.class, RETURNS_DEEP_STUBS);
+        when(instance.id()).thenReturn(instanceId);
+        when(instance.ipAddress()).thenReturn(null);
+
+        when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
+        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+        when(cdcConfig.jobId()).thenReturn("test-job");
+
+        CdcManager spyManager = spy(cdcManager);
+        SidecarCdc mockConsumer = mock(SidecarCdc.class);
+        doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
+            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+        );
+
+        List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
+
+        assertThat(consumers).hasSize(1);
+        verify(spyManager).loadOrBuildCdcConsumer(
+            eq(instanceId), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+        );
+    }
+
+    /**
+     * Unit test for the CASSSIDECAR-417 bug fix: {@code getInstanceId} must return the correct id
+     * even when {@code ipAddress()} is null (not yet refreshed). The old code passed {@code null}
+     * to {@code resolveToSameAddress}, which resolved to {@code 127.0.0.1} and returned {@code -1}.
+     * The fix resolves the instance via {@code instanceFetcher.instance(ip)} instead.
+     */
+    @Test
+    void testGetInstanceIdReturnsCorrectIdWhenIpAddressIsNull()
+    {
+        String instanceIp = "172.19.0.5";
+        int instanceId = 1;
+
+        InstanceMetadata instance = mock(InstanceMetadata.class);
+        when(instance.id()).thenReturn(instanceId);
+        when(instance.ipAddress()).thenReturn(null); // not yet refreshed — the key precondition
+
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
+        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+
+        assertThat(cdcManager.getInstanceId(instanceIp)).isEqualTo(instanceId);
+    }
+
+    /**
+     * Verifies that getInstanceId returns -1 when the IP is not known to any local instance.
+     * Both old and new code produce -1 here, but via different mechanisms.
+     */
+    @Test
+    void testGetInstanceIdReturnsMinusOneWhenInstanceNotFound()
+    {
+        String unknownIp = "192.168.1.100";
+
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.emptyList());
+        when(instanceFetcher.instance(unknownIp))
+            .thenThrow(new NoSuchCassandraInstanceException("Instance not found: " + unknownIp));
+
+        assertThat(cdcManager.getInstanceId(unknownIp)).isEqualTo(-1);
     }
 
     @Test
@@ -322,6 +411,8 @@ public class CdcManagerTest
         }
     }
 
+    // Helper methods
+
     private TokenRange mockTokenRange(BigInteger start, BigInteger end)
     {
         TokenRange range = mock(TokenRange.class, RETURNS_DEEP_STUBS);
@@ -336,5 +427,19 @@ public class CdcManagerTest
         when(instance.id()).thenReturn(id);
         when(instance.ipAddress()).thenReturn(ipAddress);
         return instance;
+    }
+
+    private static boolean resolveToSameAddress(String address1, String address2)
+    {
+        try
+        {
+            InetAddress addr1 = InetAddress.getByName(address1);
+            InetAddress addr2 = InetAddress.getByName(address2);
+            return addr1.equals(addr2);
+        }
+        catch (UnknownHostException e)
+        {
+            return address1.equals(address2);
+        }
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcManagerTest.java
@@ -18,10 +18,8 @@
 
 package org.apache.cassandra.sidecar.cdc;
 
-import java.io.IOException;
 import java.math.BigInteger;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,32 +32,42 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
-import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
+import org.apache.cassandra.cdc.api.TokenRangeSupplier;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
+import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdc;
+import org.apache.cassandra.cdc.sidecar.SidecarCdcBuilder;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
+import org.apache.cassandra.cdc.sidecar.SidecarStatePersister;
 import org.apache.cassandra.cdc.stats.ICdcStats;
-import org.apache.cassandra.secrets.SecretsProvider;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.common.server.cluster.locator.TokenRange;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
-import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -80,11 +88,7 @@ public class CdcManagerTest
     @Mock
     private ClusterConfigProvider clusterConfigProvider;
     @Mock
-    private CdcSidecarInstancesProvider sidecarInstancesProvider;
-    @Mock
-    private SecretsProvider secretsProvider;
-    @Mock
-    private SidecarCdcClient.ClientConfig clientConfig;
+    private SidecarCdcClient sidecarCdcClient;
     @Mock
     private ICdcStats cdcStats;
     @Mock
@@ -106,12 +110,11 @@ public class CdcManagerTest
             rangeManager,
             instanceFetcher,
             clusterConfigProvider,
-            sidecarInstancesProvider,
-            secretsProvider,
-            clientConfig,
+            sidecarCdcClient,
             cdcStats,
             taskExecutorPool,
-            cdcDatabaseAccessor
+            cdcDatabaseAccessor,
+            ReplicationFactorSupplier.DEFAULT
         );
     }
 
@@ -136,7 +139,7 @@ public class CdcManagerTest
     }
 
     @Test
-    void testSingleInstanceSingleRangeCreatesOneConsumer() throws IOException
+    void testSingleInstanceSingleRangeCreatesOneConsumer()
     {
         String instanceIp = "127.0.0.1";
         int instanceId = 1;
@@ -148,22 +151,24 @@ public class CdcManagerTest
         InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
         when(cdcConfig.jobId()).thenReturn("test-job");
 
+        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer = mock(SidecarCdc.class);
         doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
+        // Assert
         assertThat(consumers).hasSize(1);
     }
 
     @Test
-    void testSingleInstanceMultipleRangesCreatesMultipleConsumers() throws IOException
+    void testSingleInstanceMultipleRangesCreatesMultipleConsumers()
     {
         String instanceIp = "127.0.0.1";
         int instanceId = 1;
@@ -179,23 +184,25 @@ public class CdcManagerTest
         InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
         when(cdcConfig.jobId()).thenReturn("test-job");
 
+        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer1 = mock(SidecarCdc.class);
         SidecarCdc mockConsumer2 = mock(SidecarCdc.class);
         doReturn(mockConsumer1, mockConsumer2).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
+        // Assert
         assertThat(consumers).hasSize(2);
     }
 
     @Test
-    void testMultipleInstancesMultipleRangesCreatesConsumers() throws IOException
+    void testMultipleInstancesMultipleRangesCreatesConsumers()
     {
         String instance1Ip = "127.0.0.1";
         String instance2Ip = "127.0.0.2";
@@ -212,29 +219,35 @@ public class CdcManagerTest
         InstanceMetadata instance1 = mockInstance(instance1Id, instance1Ip);
         InstanceMetadata instance2 = mockInstance(instance2Id, instance2Ip);
 
+        List<InstanceMetadata> instances = new ArrayList<>();
+        instances.add(instance1);
+        instances.add(instance2);
+
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(instance1Ip)).thenReturn(instance1);
-        when(instanceFetcher.instance(instance2Ip)).thenReturn(instance2);
+        when(instanceFetcher.allLocalInstances()).thenReturn(instances);
         when(cdcConfig.jobId()).thenReturn("test-job");
 
+        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer1 = mock(SidecarCdc.class);
         SidecarCdc mockConsumer2 = mock(SidecarCdc.class);
         doReturn(mockConsumer1, mockConsumer2).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
+        // Assert
         assertThat(consumers).hasSize(2);
     }
 
     @Test
-    void testDuplicateRangesDeduplicates() throws IOException
+    void testDuplicateRangesDeduplicates()
     {
         String instanceIp = "127.0.0.1";
         int instanceId = 1;
 
+        // Create two identical ranges
         TokenRange range1 = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
         TokenRange range2 = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
 
@@ -247,128 +260,210 @@ public class CdcManagerTest
         InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
         when(cdcConfig.jobId()).thenReturn("test-job");
 
+        // Spy to mock loadOrBuildCdcConsumer
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer = mock(SidecarCdc.class);
         doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
+        // Assert - Should deduplicate to 1 consumer
         assertThat(consumers).hasSize(1);
     }
 
     @Test
-    void testUnknownInstanceHandlesGracefully() throws IOException
+    void testUnknownInstanceHandlesGracefully()
     {
         String unknownIp = "192.168.1.100";
 
         TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
         Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(unknownIp, Collections.singleton(range));
 
+        // No matching instances
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(unknownIp)).thenThrow(new NoSuchCassandraInstanceException("Instance not found: " + unknownIp));
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.emptyList());
         when(cdcConfig.jobId()).thenReturn("test-job");
 
+        // Spy to mock loadOrBuildCdcConsumer - will be called with instanceId = -1
         CdcManager spyManager = spy(cdcManager);
         SidecarCdc mockConsumer = mock(SidecarCdc.class);
         doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
 
+        // Assert - Should still create consumer with instanceId = -1
         assertThat(consumers).hasSize(1);
+    }
+
+    @Test
+    void testBuildConsumerPassesReplicationFactorSupplierToBuilder() throws Exception
+    {
+        ReplicationFactorSupplier customSupplier = mock(ReplicationFactorSupplier.class);
+        CdcManager managerWithCustomSupplier = new CdcManager(
+            eventConsumer, schemaSupplier, cdcConfig, rangeManager, instanceFetcher,
+            clusterConfigProvider, sidecarCdcClient,
+            cdcStats, taskExecutorPool, cdcDatabaseAccessor, customSupplier);
+
+        try (MockedStatic<SidecarCdc> mockedSidecarCdc = mockStatic(SidecarCdc.class);
+             MockedConstruction<SidecarStatePersister> ignoredPersister = mockConstruction(SidecarStatePersister.class))
+        {
+            SidecarCdcBuilder mockBuilder = mock(SidecarCdcBuilder.class, Answers.RETURNS_SELF);
+            mockedSidecarCdc.when(() -> SidecarCdc.builder(
+                anyString(), anyInt(), any(), any(), any(), any(), any(), any(), any()
+            )).thenReturn(mockBuilder);
+
+            when(cdcConfig.jobId()).thenReturn("test-job");
+
+            managerWithCustomSupplier.loadOrBuildCdcConsumer(
+                1, clusterConfigProvider, eventConsumer, schemaSupplier,
+                mock(TokenRangeSupplier.class),
+                cdcConfig, cdcStats, taskExecutorPool);
+
+            verify(mockBuilder).withReplicationFactorSupplier(customSupplier);
+        }
     }
 
     @Test
     void testResolveToSameAddressTrue()
     {
-        assertThat(resolveToSameAddress("127.0.0.1", "localhost")).isTrue();
+        String address1 = "127.0.0.1";
+        String address2 = "localhost";
+        assertThat(CdcManager.resolveToSameAddress(address1, address2)).isTrue();
     }
 
     @Test
     void testResolveToSameAddressFalse()
     {
-        assertThat(resolveToSameAddress("127.0.0.1", "127.0.0.2")).isFalse();
+        String address1 = "127.0.0.1";
+        String address2 = "127.0.0.2";
+        assertThat(CdcManager.resolveToSameAddress(address1, address2)).isFalse();
     }
 
-    /**
-     * Verifies that the correct instanceId is propagated into {@code loadOrBuildCdcConsumer}
-     * during the full {@code buildCdcConsumers()} flow when {@code ipAddress()} is null.
-     * Complements {@code testGetInstanceIdReturnsCorrectIdWhenIpAddressIsNull}, which tests
-     * {@code getInstanceId} in isolation; this test confirms the fix is effective end-to-end.
-     */
     @Test
-    void testGetInstanceIdResolvesCorrectlyWhenIpAddressIsNull() throws IOException
+    void testStopConsumersWithEmptyConsumersClosesClient() throws Exception
     {
-        String instanceIp = "172.19.0.5";
-        int instanceId = 1000;
+        // No consumers built yet; stopConsumers must still close the client and not throw.
+        assertThatCode(() -> cdcManager.stopConsumers()).doesNotThrowAnyException();
 
-        TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
-        Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(instanceIp, Collections.singleton(range));
+        verify(sidecarCdcClient, times(1)).close();
+    }
 
-        InstanceMetadata instance = mock(InstanceMetadata.class, RETURNS_DEEP_STUBS);
-        when(instance.id()).thenReturn(instanceId);
-        when(instance.ipAddress()).thenReturn(null);
+    @Test
+    void testStopConsumersInvokesStopOnEachConsumerAndClosesClient() throws Exception
+    {
+        // Arrange: populate consumers via buildCdcConsumers with two distinct ranges.
+        String instanceIp = "127.0.0.1";
+        int instanceId = 1;
+        TokenRange range1 = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
+        TokenRange range2 = mockTokenRange(BigInteger.TEN, new BigInteger("20"));
+        Set<TokenRange> ranges = new HashSet<>();
+        ranges.add(range1);
+        ranges.add(range2);
+        Map<String, Set<TokenRange>> ownedRanges = Collections.singletonMap(instanceIp, ranges);
+
+        InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
         when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
-        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
         when(cdcConfig.jobId()).thenReturn("test-job");
 
         CdcManager spyManager = spy(cdcManager);
-        SidecarCdc mockConsumer = mock(SidecarCdc.class);
-        doReturn(mockConsumer).when(spyManager).loadOrBuildCdcConsumer(
-            anyInt(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
+        SidecarCdc consumer1 = mock(SidecarCdc.class);
+        SidecarCdc consumer2 = mock(SidecarCdc.class);
+        doReturn(consumer1, consumer2).when(spyManager).loadOrBuildCdcConsumer(
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
         );
 
         List<SidecarCdc> consumers = spyManager.buildCdcConsumers();
+        assertThat(consumers).hasSize(2);
 
-        assertThat(consumers).hasSize(1);
-        verify(spyManager).loadOrBuildCdcConsumer(
-            eq(instanceId), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()
-        );
+        // Act
+        spyManager.stopConsumers();
+
+        // Assert: each consumer was stopped exactly once and the client was closed.
+        verify(consumer1, times(1)).stop();
+        verify(consumer2, times(1)).stop();
+        verify(sidecarCdcClient, times(1)).close();
     }
 
-    /**
-     * Unit test for the CASSSIDECAR-417 bug fix: {@code getInstanceId} must return the correct id
-     * even when {@code ipAddress()} is null (not yet refreshed). The old code passed {@code null}
-     * to {@code resolveToSameAddress}, which resolved to {@code 127.0.0.1} and returned {@code -1}.
-     * The fix resolves the instance via {@code instanceFetcher.instance(ip)} instead.
-     */
     @Test
-    void testGetInstanceIdReturnsCorrectIdWhenIpAddressIsNull()
+    void testStopConsumersSwallowsExceptionFromClientClose() throws Exception
     {
-        String instanceIp = "172.19.0.5";
+        // Arrange: build a single consumer, then make sidecarCdcClient.close() throw.
+        String instanceIp = "127.0.0.1";
         int instanceId = 1;
+        TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
+        Map<String, Set<TokenRange>> ownedRanges =
+            Collections.singletonMap(instanceIp, Collections.singleton(range));
+        InstanceMetadata instance = mockInstance(instanceId, instanceIp);
 
-        InstanceMetadata instance = mock(InstanceMetadata.class);
-        when(instance.id()).thenReturn(instanceId);
-        when(instance.ipAddress()).thenReturn(null); // not yet refreshed — the key precondition
-
+        when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
         when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
-        when(instanceFetcher.instance(instanceIp)).thenReturn(instance);
+        when(cdcConfig.jobId()).thenReturn("test-job");
 
-        assertThat(cdcManager.getInstanceId(instanceIp)).isEqualTo(instanceId);
+        CdcManager spyManager = spy(cdcManager);
+        SidecarCdc consumer = mock(SidecarCdc.class);
+        doReturn(consumer).when(spyManager).loadOrBuildCdcConsumer(
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
+        );
+        spyManager.buildCdcConsumers();
+
+        doThrow(new RuntimeException("simulated client close failure"))
+            .when(sidecarCdcClient).close();
+
+        // Act + Assert: exception from close() must not propagate.
+        assertThatCode(() -> spyManager.stopConsumers()).doesNotThrowAnyException();
+
+        // Consumer must still have been stopped before the failing close() call.
+        verify(consumer, times(1)).stop();
+        verify(sidecarCdcClient, times(1)).close();
     }
 
-    /**
-     * Verifies that getInstanceId returns -1 when the IP is not known to any local instance.
-     * Both old and new code produce -1 here, but via different mechanisms.
-     */
     @Test
-    void testGetInstanceIdReturnsMinusOneWhenInstanceNotFound()
+    void testStopConsumersDoesNotInteractWithRangeManager() throws Exception
     {
-        String unknownIp = "192.168.1.100";
+        // stopConsumers() must not consult the RangeManager; it only operates on
+        // the previously built consumer list and the cdc client.
+        cdcManager.stopConsumers();
 
-        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.emptyList());
-        when(instanceFetcher.instance(unknownIp))
-            .thenThrow(new NoSuchCassandraInstanceException("Instance not found: " + unknownIp));
+        verifyNoInteractions(rangeManager);
+        verify(sidecarCdcClient, times(1)).close();
+    }
 
-        assertThat(cdcManager.getInstanceId(unknownIp)).isEqualTo(-1);
+    @Test
+    void testStopConsumersIsIdempotent() throws Exception
+    {
+        // Arrange: build a single consumer.
+        String instanceIp = "127.0.0.1";
+        TokenRange range = mockTokenRange(BigInteger.ZERO, BigInteger.TEN);
+        Map<String, Set<TokenRange>> ownedRanges =
+            Collections.singletonMap(instanceIp, Collections.singleton(range));
+        InstanceMetadata instance = mockInstance(1, instanceIp);
+        when(rangeManager.ownedTokenRanges()).thenReturn(ownedRanges);
+        when(instanceFetcher.allLocalInstances()).thenReturn(Collections.singletonList(instance));
+        when(cdcConfig.jobId()).thenReturn("test-job");
+
+        CdcManager spyManager = spy(cdcManager);
+        SidecarCdc consumer = mock(SidecarCdc.class);
+        doReturn(consumer).when(spyManager).loadOrBuildCdcConsumer(
+            anyInt(), any(), any(), any(), any(), any(), any(), any()
+        );
+        spyManager.buildCdcConsumers();
+
+        // Act: invoke twice.
+        spyManager.stopConsumers();
+        spyManager.stopConsumers();
+
+        // Assert: each call independently stops every consumer and closes the client.
+        verify(consumer, times(2)).stop();
+        verify(sidecarCdcClient, times(2)).close();
     }
 
     // Helper methods
@@ -387,19 +482,5 @@ public class CdcManagerTest
         when(instance.id()).thenReturn(id);
         when(instance.ipAddress()).thenReturn(ipAddress);
         return instance;
-    }
-
-    private static boolean resolveToSameAddress(String address1, String address2)
-    {
-        try
-        {
-            InetAddress addr1 = InetAddress.getByName(address1);
-            InetAddress addr2 = InetAddress.getByName(address2);
-            return addr1.equals(addr2);
-        }
-        catch (UnknownHostException e)
-        {
-            return address1.equals(address2);
-        }
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
@@ -27,12 +27,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.inject.Provider;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.msg.CdcEvent;
 import org.apache.cassandra.cdc.sidecar.CdcSidecarInstancesProvider;
 import org.apache.cassandra.cdc.sidecar.ClusterConfigProvider;
+import org.apache.cassandra.cdc.sidecar.ReplicationFactorSupplier;
 import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.stats.ICdcStats;
 import org.apache.cassandra.secrets.SecretsProvider;
@@ -45,15 +47,20 @@ import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.config.SslConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
+import org.apache.cassandra.sidecar.db.SidecarRegistryCache;
 import org.apache.cassandra.sidecar.db.VirtualTablesDatabaseAccessor;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.kafka.common.serialization.Serializer;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -89,6 +96,8 @@ public class CdcPublisherTests
     private Serializer<CdcEvent> avroSerializer;
     @Mock
     private Provider<RangeManager> rangeManager;
+    @Mock
+    private SidecarRegistryCache sidecarRegistryCache;
 
     private SidecarConfiguration sidecarConfiguration;
     private CdcConfig cdcConfig;
@@ -124,7 +133,8 @@ public class CdcPublisherTests
             virtualTables,
             sidecarCdcStats,
             avroSerializer,
-            rangeManager
+            rangeManager,
+            sidecarRegistryCache
         );
     }
 
@@ -312,6 +322,13 @@ public class CdcPublisherTests
     }
 
     @Test
+    void testCreateReplicationFactorSupplierReturnsSidecarImpl()
+    {
+        ReplicationFactorSupplier supplier = cdcPublisher.createReplicationFactorSupplier();
+        assertThat(supplier).isInstanceOf(SidecarReplicationFactorSupplier.class);
+    }
+
+    @Test
     void testEventConsumerCreatesValidConsumer()
     {
         Map<String, Object> kafkaConfigs = new HashMap<>();
@@ -324,6 +341,7 @@ public class CdcPublisherTests
         when(cdcConfig.maxRecordSizeBytes()).thenReturn(1048576); // 1MB
         when(cdcConfig.failOnRecordTooLargeError()).thenReturn(false);
         when(cdcConfig.failOnKafkaError()).thenReturn(true);
+        when(instanceMetadataFetcher.callOnFirstAvailableInstance(any())).thenReturn("4.1.11");
 
         EventConsumer result = cdcPublisher.eventConsumer(cdcConfig, avroSerializer);
 
@@ -331,6 +349,301 @@ public class CdcPublisherTests
         assertThat(result).isInstanceOf(CdcEventConsumer.class);
     }
 
+    @Test
+    void testResolveSidecarPortReturnsCachedPortWhenPresent()
+    {
+        // Arrange: registry cache has an entry for the requested host.
+        String host = "10.0.0.1";
+        int cachedPort = 28747;
+        int defaultPort = 9043;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(cachedPort);
+
+        // Act
+        Integer resolved = cdcPublisher.resolveSidecarPort(instance, defaultPort);
+
+        // Assert: cached value wins; default port must not be returned.
+        assertThat(resolved).isEqualTo(cachedPort);
+    }
+
+    @Test
+    void testResolveSidecarPortFallsBackToDefaultWhenCacheMisses()
+    {
+        // Arrange: registry cache has no entry for the requested host.
+        String host = "10.0.0.2";
+        int defaultPort = 9043;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
+        when(sidecarRegistryCache.size()).thenReturn(0L);
+
+        // Act
+        Integer resolved = cdcPublisher.resolveSidecarPort(instance, defaultPort);
+
+        // Assert: caller-provided default port is returned on miss.
+        assertThat(resolved).isEqualTo(defaultPort);
+    }
+
+    @Test
+    void testResolveSidecarPortLooksUpUsingNodeName()
+    {
+        // Arrange: ensure the lookup key is the instance's nodeName(), not some other field.
+        String host = "cassandra-host-3.dc1.example.com";
+        int cachedPort = 30001;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(cachedPort);
+
+        // Act
+        Integer resolved = cdcPublisher.resolveSidecarPort(instance, 9999);
+
+        // Assert
+        assertThat(resolved).isEqualTo(cachedPort);
+        verify(instance).nodeName();
+        verify(sidecarRegistryCache).getPort(host);
+    }
+
+    @Test
+    void testResolveSidecarPortReturnsZeroFromCacheWhenExplicitlyCached()
+    {
+        // Edge case: a cached entry of 0 (autoboxed Integer, not null) is still "present" and must win
+        // over the default port. This guards against accidentally treating 0 as "missing".
+        String host = "10.0.0.3";
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(0);
+
+        Integer resolved = cdcPublisher.resolveSidecarPort(instance, 9043);
+
+        assertThat(resolved).isEqualTo(0);
+    }
+
+    @Test
+    void testResolveSidecarPortDoesNotCallSizeOnCacheHit()
+    {
+        // size() is only consulted for the fallback log line; on a cache hit it must not be called.
+        String host = "10.0.0.4";
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(28747);
+
+        cdcPublisher.resolveSidecarPort(instance, 9043);
+
+        verify(sidecarRegistryCache).getPort(host);
+        verify(sidecarRegistryCache, never()).size();
+    }
+
+    @Test
+    void testResolveSidecarPortConsultsCacheSizeOnFallback()
+    {
+        // On a cache miss the publisher logs cacheSize for diagnostics; verify size() is queried.
+        String host = "10.0.0.5";
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
+        when(sidecarRegistryCache.size()).thenReturn(7L);
+
+        Integer resolved = cdcPublisher.resolveSidecarPort(instance, 9043);
+
+        assertThat(resolved).isEqualTo(9043);
+        verify(sidecarRegistryCache).size();
+    }
+
+    // ---- portResolver() — the Function<CassandraInstance,Integer> handed to SidecarCdcClient ----
+
+    @Test
+    void testPortResolverIsNotNull()
+    {
+        // Smoke-check: the builder must always return a usable Function reference;
+        // SidecarCdcClient construction would NPE otherwise.
+        java.util.function.Function<CassandraInstance, Integer> resolver = cdcPublisher.portResolver(9043);
+        assertThat(resolver).isNotNull();
+    }
+
+    @Test
+    void testPortResolverReturnsCachedPortFromRegistry()
+    {
+        // Verifies the Function delegates to resolveSidecarPort(): a cache hit returns the cached port.
+        String host = "10.0.0.10";
+        int cachedPort = 28747;
+        int defaultPort = 9043;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(cachedPort);
+
+        Integer resolved = cdcPublisher.portResolver(defaultPort).apply(instance);
+
+        assertThat(resolved).isEqualTo(cachedPort);
+    }
+
+    @Test
+    void testPortResolverFallsBackToCapturedDefaultPort()
+    {
+        // The lambda must close over the defaultPort passed to portResolver(...), not some other value.
+        String host = "10.0.0.11";
+        int defaultPort = 12345;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
+        when(sidecarRegistryCache.size()).thenReturn(0L);
+
+        Integer resolved = cdcPublisher.portResolver(defaultPort).apply(instance);
+
+        assertThat(resolved).isEqualTo(defaultPort);
+    }
+
+    @Test
+    void testPortResolverEachCallReevaluatesCache()
+    {
+        // The same Function instance must re-query the cache on every call so that
+        // newly-registered peers become visible without rebuilding the SidecarCdcClient.
+        String host = "10.0.0.12";
+        int defaultPort = 9043;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+
+        // First call: cache miss -> returns default port.
+        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
+        when(sidecarRegistryCache.size()).thenReturn(0L);
+        java.util.function.Function<CassandraInstance, Integer> resolver = cdcPublisher.portResolver(defaultPort);
+        assertThat(resolver.apply(instance)).isEqualTo(defaultPort);
+
+        // Cache is updated with a real port, then call again with the same Function.
+        when(sidecarRegistryCache.getPort(host)).thenReturn(28747);
+        assertThat(resolver.apply(instance)).isEqualTo(28747);
+    }
+
+    @Test
+    void testPortResolverInvokesCacheGetPortPerApply()
+    {
+        // The Function is called once per outbound HTTP request to a peer; verify no caching/memoization
+        // hides that fact (otherwise stale ports would be sent).
+        String host = "10.0.0.13";
+        int defaultPort = 9043;
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(28747);
+
+        java.util.function.Function<CassandraInstance, Integer> resolver = cdcPublisher.portResolver(defaultPort);
+        resolver.apply(instance);
+        resolver.apply(instance);
+        resolver.apply(instance);
+
+        verify(sidecarRegistryCache, org.mockito.Mockito.times(3)).getPort(host);
+    }
+
+    @Test
+    void testPortResolverSupportsDifferentDefaultPortsAcrossInvocations()
+    {
+        // Two SidecarCdcClient instances with different default ports must not cross-contaminate state.
+        String host = "10.0.0.14";
+        CassandraInstance instance = mock(CassandraInstance.class);
+        when(instance.nodeName()).thenReturn(host);
+        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
+        when(sidecarRegistryCache.size()).thenReturn(0L);
+
+        java.util.function.Function<CassandraInstance, Integer> resolverA = cdcPublisher.portResolver(1111);
+        java.util.function.Function<CassandraInstance, Integer> resolverB = cdcPublisher.portResolver(2222);
+
+        assertThat(resolverA.apply(instance)).isEqualTo(1111);
+        assertThat(resolverB.apply(instance)).isEqualTo(2222);
+    }
+
+    // ---- createSidecarCdcClient() — covers the variable declaration + construction at run() lines 232+ ----
+
+    @Test
+    void testCreateSidecarCdcClientReturnsClientFromConstructor()
+    {
+        // Stub effectivePort() so portResolver(defaultPort) closes over a known value.
+        when(clientConfig.effectivePort()).thenReturn(9043);
+        // SSL disabled so secretsProvider() returns null (already covered above).
+        SslConfiguration sslConfig = mock(SslConfiguration.class);
+        when(sidecarConfiguration.sidecarClientConfiguration().sslConfiguration()).thenReturn(sslConfig);
+        when(sslConfig.enabled()).thenReturn(false);
+
+        // Mock the SidecarCdcClient constructor itself so we don't open real sockets.
+        try (org.mockito.MockedConstruction<SidecarCdcClient> ignored =
+                 org.mockito.Mockito.mockConstruction(SidecarCdcClient.class))
+        {
+            SidecarCdcClient client = cdcPublisher.createSidecarCdcClient();
+
+            assertThat(client).isNotNull();
+            assertThat(ignored.constructed()).hasSize(1);
+        }
+    }
+
+    @Test
+    void testCreateSidecarCdcClientReadsDefaultPortFromClientConfig()
+    {
+        // Verifies the line `int defaultPort = clientConfig.effectivePort();` is exercised
+        // and the value flows into the constructor (via portResolver).
+        when(clientConfig.effectivePort()).thenReturn(28747);
+        SslConfiguration sslConfig = mock(SslConfiguration.class);
+        when(sidecarConfiguration.sidecarClientConfiguration().sslConfiguration()).thenReturn(sslConfig);
+        when(sslConfig.enabled()).thenReturn(false);
+
+        try (org.mockito.MockedConstruction<SidecarCdcClient> ignored =
+                 org.mockito.Mockito.mockConstruction(SidecarCdcClient.class))
+        {
+            cdcPublisher.createSidecarCdcClient();
+
+            verify(clientConfig).effectivePort();
+        }
+    }
+
+
+    /**
+     * Covers line 243 ({@code SidecarCdcClient sidecarCdcClient = createSidecarCdcClient();} inside
+     * {@code run()}).  The method is {@code private}, so it is reached indirectly via
+     * {@link CdcPublisher#execute(Promise)}.
+     *
+     * <p>The test subclass overrides {@link CdcPublisher#eventConsumer} to prevent real
+     * {@code KafkaProducer} construction.  {@link org.mockito.MockedConstruction} is used for
+     * {@link SidecarCdcClient} and {@link CdcManager} so neither real I/O nor a live Cassandra
+     * cluster is required.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void testExecuteRunsHappyPathAndCoversLine243()
+    {
+        EventConsumer mockConsumer = mock(EventConsumer.class);
+
+        CdcPublisher testPublisher = new CdcPublisher(
+            vertx, sidecarConfiguration, executorPools, clusterConfigProvider,
+            schemaSupplier, sidecarInstancesProvider, clientConfig,
+            instanceMetadataFetcher, cdcConfig, databaseAccessor,
+            cdcStats, virtualTables, sidecarCdcStats, avroSerializer,
+            rangeManager, sidecarRegistryCache)
+        {
+            @Override
+            public EventConsumer eventConsumer(CdcConfig conf, Serializer<CdcEvent> serializer)
+            {
+                return mockConsumer;
+            }
+        };
+
+        when(clientConfig.effectivePort()).thenReturn(9043);
+        SslConfiguration sslConfig = mock(SslConfiguration.class);
+        when(sidecarConfiguration.sidecarClientConfiguration().sslConfiguration()).thenReturn(sslConfig);
+        when(sslConfig.enabled()).thenReturn(false);
+
+        try (org.mockito.MockedConstruction<SidecarCdcClient> mockedClient =
+                 org.mockito.Mockito.mockConstruction(SidecarCdcClient.class);
+             org.mockito.MockedConstruction<CdcManager> mockedManager =
+                 org.mockito.Mockito.mockConstruction(CdcManager.class, (m, ctx) ->
+                     when(m.buildCdcConsumers()).thenReturn(Collections.emptyList())))
+        {
+            Promise<Void> promise = mock(Promise.class);
+            testPublisher.execute(promise);
+
+            // createSidecarCdcClient() (line 243) was reached: exactly one SidecarCdcClient was built
+            assertThat(mockedClient.constructed()).hasSize(1);
+            // new CdcManager(...) (line 244) was also reached
+            assertThat(mockedManager.constructed()).hasSize(1);
+            verify(promise).complete();
+        }
+    }
 
     private SslConfiguration mockSslConfiguration(boolean enabled,
                                                   boolean preferOpenSSL,

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.inject.Provider;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
@@ -47,20 +46,15 @@ import org.apache.cassandra.sidecar.config.SidecarConfiguration;
 import org.apache.cassandra.sidecar.config.SslConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
-import org.apache.cassandra.sidecar.db.SidecarRegistryCache;
 import org.apache.cassandra.sidecar.db.VirtualTablesDatabaseAccessor;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
-import org.apache.cassandra.spark.data.partitioner.CassandraInstance;
 import org.apache.kafka.common.serialization.Serializer;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -96,8 +90,6 @@ public class CdcPublisherTests
     private Serializer<CdcEvent> avroSerializer;
     @Mock
     private Provider<RangeManager> rangeManager;
-    @Mock
-    private SidecarRegistryCache sidecarRegistryCache;
 
     private SidecarConfiguration sidecarConfiguration;
     private CdcConfig cdcConfig;
@@ -133,8 +125,7 @@ public class CdcPublisherTests
             virtualTables,
             sidecarCdcStats,
             avroSerializer,
-            rangeManager,
-            sidecarRegistryCache
+            rangeManager
         );
     }
 
@@ -341,308 +332,11 @@ public class CdcPublisherTests
         when(cdcConfig.maxRecordSizeBytes()).thenReturn(1048576); // 1MB
         when(cdcConfig.failOnRecordTooLargeError()).thenReturn(false);
         when(cdcConfig.failOnKafkaError()).thenReturn(true);
-        when(instanceMetadataFetcher.callOnFirstAvailableInstance(any())).thenReturn("4.1.11");
 
         EventConsumer result = cdcPublisher.eventConsumer(cdcConfig, avroSerializer);
 
         assertThat(result).isNotNull();
         assertThat(result).isInstanceOf(CdcEventConsumer.class);
-    }
-
-    @Test
-    void testResolveSidecarPortReturnsCachedPortWhenPresent()
-    {
-        // Arrange: registry cache has an entry for the requested host.
-        String host = "10.0.0.1";
-        int cachedPort = 28747;
-        int defaultPort = 9043;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(cachedPort);
-
-        // Act
-        Integer resolved = cdcPublisher.resolveSidecarPort(instance, defaultPort);
-
-        // Assert: cached value wins; default port must not be returned.
-        assertThat(resolved).isEqualTo(cachedPort);
-    }
-
-    @Test
-    void testResolveSidecarPortFallsBackToDefaultWhenCacheMisses()
-    {
-        // Arrange: registry cache has no entry for the requested host.
-        String host = "10.0.0.2";
-        int defaultPort = 9043;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
-        when(sidecarRegistryCache.size()).thenReturn(0L);
-
-        // Act
-        Integer resolved = cdcPublisher.resolveSidecarPort(instance, defaultPort);
-
-        // Assert: caller-provided default port is returned on miss.
-        assertThat(resolved).isEqualTo(defaultPort);
-    }
-
-    @Test
-    void testResolveSidecarPortLooksUpUsingNodeName()
-    {
-        // Arrange: ensure the lookup key is the instance's nodeName(), not some other field.
-        String host = "cassandra-host-3.dc1.example.com";
-        int cachedPort = 30001;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(cachedPort);
-
-        // Act
-        Integer resolved = cdcPublisher.resolveSidecarPort(instance, 9999);
-
-        // Assert
-        assertThat(resolved).isEqualTo(cachedPort);
-        verify(instance).nodeName();
-        verify(sidecarRegistryCache).getPort(host);
-    }
-
-    @Test
-    void testResolveSidecarPortReturnsZeroFromCacheWhenExplicitlyCached()
-    {
-        // Edge case: a cached entry of 0 (autoboxed Integer, not null) is still "present" and must win
-        // over the default port. This guards against accidentally treating 0 as "missing".
-        String host = "10.0.0.3";
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(0);
-
-        Integer resolved = cdcPublisher.resolveSidecarPort(instance, 9043);
-
-        assertThat(resolved).isEqualTo(0);
-    }
-
-    @Test
-    void testResolveSidecarPortDoesNotCallSizeOnCacheHit()
-    {
-        // size() is only consulted for the fallback log line; on a cache hit it must not be called.
-        String host = "10.0.0.4";
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(28747);
-
-        cdcPublisher.resolveSidecarPort(instance, 9043);
-
-        verify(sidecarRegistryCache).getPort(host);
-        verify(sidecarRegistryCache, never()).size();
-    }
-
-    @Test
-    void testResolveSidecarPortConsultsCacheSizeOnFallback()
-    {
-        // On a cache miss the publisher logs cacheSize for diagnostics; verify size() is queried.
-        String host = "10.0.0.5";
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
-        when(sidecarRegistryCache.size()).thenReturn(7L);
-
-        Integer resolved = cdcPublisher.resolveSidecarPort(instance, 9043);
-
-        assertThat(resolved).isEqualTo(9043);
-        verify(sidecarRegistryCache).size();
-    }
-
-    // ---- portResolver() — the Function<CassandraInstance,Integer> handed to SidecarCdcClient ----
-
-    @Test
-    void testPortResolverIsNotNull()
-    {
-        // Smoke-check: the builder must always return a usable Function reference;
-        // SidecarCdcClient construction would NPE otherwise.
-        java.util.function.Function<CassandraInstance, Integer> resolver = cdcPublisher.portResolver(9043);
-        assertThat(resolver).isNotNull();
-    }
-
-    @Test
-    void testPortResolverReturnsCachedPortFromRegistry()
-    {
-        // Verifies the Function delegates to resolveSidecarPort(): a cache hit returns the cached port.
-        String host = "10.0.0.10";
-        int cachedPort = 28747;
-        int defaultPort = 9043;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(cachedPort);
-
-        Integer resolved = cdcPublisher.portResolver(defaultPort).apply(instance);
-
-        assertThat(resolved).isEqualTo(cachedPort);
-    }
-
-    @Test
-    void testPortResolverFallsBackToCapturedDefaultPort()
-    {
-        // The lambda must close over the defaultPort passed to portResolver(...), not some other value.
-        String host = "10.0.0.11";
-        int defaultPort = 12345;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
-        when(sidecarRegistryCache.size()).thenReturn(0L);
-
-        Integer resolved = cdcPublisher.portResolver(defaultPort).apply(instance);
-
-        assertThat(resolved).isEqualTo(defaultPort);
-    }
-
-    @Test
-    void testPortResolverEachCallReevaluatesCache()
-    {
-        // The same Function instance must re-query the cache on every call so that
-        // newly-registered peers become visible without rebuilding the SidecarCdcClient.
-        String host = "10.0.0.12";
-        int defaultPort = 9043;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-
-        // First call: cache miss -> returns default port.
-        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
-        when(sidecarRegistryCache.size()).thenReturn(0L);
-        java.util.function.Function<CassandraInstance, Integer> resolver = cdcPublisher.portResolver(defaultPort);
-        assertThat(resolver.apply(instance)).isEqualTo(defaultPort);
-
-        // Cache is updated with a real port, then call again with the same Function.
-        when(sidecarRegistryCache.getPort(host)).thenReturn(28747);
-        assertThat(resolver.apply(instance)).isEqualTo(28747);
-    }
-
-    @Test
-    void testPortResolverInvokesCacheGetPortPerApply()
-    {
-        // The Function is called once per outbound HTTP request to a peer; verify no caching/memoization
-        // hides that fact (otherwise stale ports would be sent).
-        String host = "10.0.0.13";
-        int defaultPort = 9043;
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(28747);
-
-        java.util.function.Function<CassandraInstance, Integer> resolver = cdcPublisher.portResolver(defaultPort);
-        resolver.apply(instance);
-        resolver.apply(instance);
-        resolver.apply(instance);
-
-        verify(sidecarRegistryCache, org.mockito.Mockito.times(3)).getPort(host);
-    }
-
-    @Test
-    void testPortResolverSupportsDifferentDefaultPortsAcrossInvocations()
-    {
-        // Two SidecarCdcClient instances with different default ports must not cross-contaminate state.
-        String host = "10.0.0.14";
-        CassandraInstance instance = mock(CassandraInstance.class);
-        when(instance.nodeName()).thenReturn(host);
-        when(sidecarRegistryCache.getPort(host)).thenReturn(null);
-        when(sidecarRegistryCache.size()).thenReturn(0L);
-
-        java.util.function.Function<CassandraInstance, Integer> resolverA = cdcPublisher.portResolver(1111);
-        java.util.function.Function<CassandraInstance, Integer> resolverB = cdcPublisher.portResolver(2222);
-
-        assertThat(resolverA.apply(instance)).isEqualTo(1111);
-        assertThat(resolverB.apply(instance)).isEqualTo(2222);
-    }
-
-    // ---- createSidecarCdcClient() — covers the variable declaration + construction at run() lines 232+ ----
-
-    @Test
-    void testCreateSidecarCdcClientReturnsClientFromConstructor()
-    {
-        // Stub effectivePort() so portResolver(defaultPort) closes over a known value.
-        when(clientConfig.effectivePort()).thenReturn(9043);
-        // SSL disabled so secretsProvider() returns null (already covered above).
-        SslConfiguration sslConfig = mock(SslConfiguration.class);
-        when(sidecarConfiguration.sidecarClientConfiguration().sslConfiguration()).thenReturn(sslConfig);
-        when(sslConfig.enabled()).thenReturn(false);
-
-        // Mock the SidecarCdcClient constructor itself so we don't open real sockets.
-        try (org.mockito.MockedConstruction<SidecarCdcClient> ignored =
-                 org.mockito.Mockito.mockConstruction(SidecarCdcClient.class))
-        {
-            SidecarCdcClient client = cdcPublisher.createSidecarCdcClient();
-
-            assertThat(client).isNotNull();
-            assertThat(ignored.constructed()).hasSize(1);
-        }
-    }
-
-    @Test
-    void testCreateSidecarCdcClientReadsDefaultPortFromClientConfig()
-    {
-        // Verifies the line `int defaultPort = clientConfig.effectivePort();` is exercised
-        // and the value flows into the constructor (via portResolver).
-        when(clientConfig.effectivePort()).thenReturn(28747);
-        SslConfiguration sslConfig = mock(SslConfiguration.class);
-        when(sidecarConfiguration.sidecarClientConfiguration().sslConfiguration()).thenReturn(sslConfig);
-        when(sslConfig.enabled()).thenReturn(false);
-
-        try (org.mockito.MockedConstruction<SidecarCdcClient> ignored =
-                 org.mockito.Mockito.mockConstruction(SidecarCdcClient.class))
-        {
-            cdcPublisher.createSidecarCdcClient();
-
-            verify(clientConfig).effectivePort();
-        }
-    }
-
-
-    /**
-     * Covers line 243 ({@code SidecarCdcClient sidecarCdcClient = createSidecarCdcClient();} inside
-     * {@code run()}).  The method is {@code private}, so it is reached indirectly via
-     * {@link CdcPublisher#execute(Promise)}.
-     *
-     * <p>The test subclass overrides {@link CdcPublisher#eventConsumer} to prevent real
-     * {@code KafkaProducer} construction.  {@link org.mockito.MockedConstruction} is used for
-     * {@link SidecarCdcClient} and {@link CdcManager} so neither real I/O nor a live Cassandra
-     * cluster is required.
-     */
-    @Test
-    @SuppressWarnings("unchecked")
-    void testExecuteRunsHappyPathAndCoversLine243()
-    {
-        EventConsumer mockConsumer = mock(EventConsumer.class);
-
-        CdcPublisher testPublisher = new CdcPublisher(
-            vertx, sidecarConfiguration, executorPools, clusterConfigProvider,
-            schemaSupplier, sidecarInstancesProvider, clientConfig,
-            instanceMetadataFetcher, cdcConfig, databaseAccessor,
-            cdcStats, virtualTables, sidecarCdcStats, avroSerializer,
-            rangeManager, sidecarRegistryCache)
-        {
-            @Override
-            public EventConsumer eventConsumer(CdcConfig conf, Serializer<CdcEvent> serializer)
-            {
-                return mockConsumer;
-            }
-        };
-
-        when(clientConfig.effectivePort()).thenReturn(9043);
-        SslConfiguration sslConfig = mock(SslConfiguration.class);
-        when(sidecarConfiguration.sidecarClientConfiguration().sslConfiguration()).thenReturn(sslConfig);
-        when(sslConfig.enabled()).thenReturn(false);
-
-        try (org.mockito.MockedConstruction<SidecarCdcClient> mockedClient =
-                 org.mockito.Mockito.mockConstruction(SidecarCdcClient.class);
-             org.mockito.MockedConstruction<CdcManager> mockedManager =
-                 org.mockito.Mockito.mockConstruction(CdcManager.class, (m, ctx) ->
-                     when(m.buildCdcConsumers()).thenReturn(Collections.emptyList())))
-        {
-            Promise<Void> promise = mock(Promise.class);
-            testPublisher.execute(promise);
-
-            // createSidecarCdcClient() (line 243) was reached: exactly one SidecarCdcClient was built
-            assertThat(mockedClient.constructed()).hasSize(1);
-            // new CdcManager(...) (line 244) was also reached
-            assertThat(mockedManager.constructed()).hasSize(1);
-            verify(promise).complete();
-        }
     }
 
     private SslConfiguration mockSslConfiguration(boolean enabled,

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/SidecarReplicationFactorSupplierTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/SidecarReplicationFactorSupplierTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cassandra.sidecar.cdc;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Metadata;
+import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
+import org.apache.cassandra.spark.data.ReplicationFactor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SidecarReplicationFactorSupplierTest
+{
+    @Test
+    void getReplicationFactorReturnsKeyspaceReplicationFromDriver()
+    {
+        Map<String, String> ntsRf = new HashMap<>();
+        ntsRf.put("class", "org.apache.cassandra.locator.NetworkTopologyStrategy");
+        ntsRf.put("dca1", "3");
+        ntsRf.put("phx1", "3");
+
+        InstanceMetadataFetcher fetcher = stubFetcherForKeyspace("test_ks", ntsRf);
+        SidecarReplicationFactorSupplier supplier = new SidecarReplicationFactorSupplier(fetcher);
+
+        ReplicationFactor rf = supplier.getReplicationFactor("test_ks");
+
+        assertThat(rf.getReplicationStrategy())
+            .isEqualTo(ReplicationFactor.ReplicationStrategy.NetworkTopologyStrategy);
+        assertThat(rf.getOptions()).containsEntry("dca1", 3).containsEntry("phx1", 3);
+        assertThat(rf.getTotalReplicationFactor()).isEqualTo(6);
+    }
+
+    @Test
+    void getMaximalReplicationFactorPicksKeyspaceWithHighestTotalRf()
+    {
+        Map<String, String> smallRf = new HashMap<>();
+        smallRf.put("class", "org.apache.cassandra.locator.SimpleStrategy");
+        smallRf.put("replication_factor", "1");
+
+        Map<String, String> bigRf = new HashMap<>();
+        bigRf.put("class", "org.apache.cassandra.locator.NetworkTopologyStrategy");
+        bigRf.put("dca1", "3");
+        bigRf.put("phx1", "3");
+
+        KeyspaceMetadata systemKs = mock(KeyspaceMetadata.class);
+        when(systemKs.getName()).thenReturn("system");
+        when(systemKs.getReplication()).thenReturn(smallRf);
+
+        KeyspaceMetadata testKs = mock(KeyspaceMetadata.class);
+        when(testKs.getName()).thenReturn("test_ks");
+        when(testKs.getReplication()).thenReturn(bigRf);
+
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.getKeyspaces()).thenReturn(Arrays.asList(systemKs, testKs));
+
+        CassandraAdapterDelegate delegate = mock(CassandraAdapterDelegate.class);
+        when(delegate.metadata()).thenReturn(metadata);
+
+        InstanceMetadata instance = mock(InstanceMetadata.class);
+        when(instance.delegate()).thenReturn(delegate);
+
+        InstanceMetadataFetcher fetcher = mock(InstanceMetadataFetcher.class);
+        when(fetcher.callOnFirstAvailableInstance(any())).thenAnswer(inv -> {
+            Function<InstanceMetadata, ?> fn = inv.getArgument(0);
+            return fn.apply(instance);
+        });
+
+        SidecarReplicationFactorSupplier supplier = new SidecarReplicationFactorSupplier(fetcher);
+
+        ReplicationFactor rf = supplier.getMaximalReplicationFactor();
+
+        assertThat(rf.getTotalReplicationFactor()).isEqualTo(6);
+        assertThat(rf.getReplicationStrategy())
+            .isEqualTo(ReplicationFactor.ReplicationStrategy.NetworkTopologyStrategy);
+    }
+
+    private InstanceMetadataFetcher stubFetcherForKeyspace(String keyspace, Map<String, String> replication)
+    {
+        KeyspaceMetadata ksMeta = mock(KeyspaceMetadata.class);
+        when(ksMeta.getReplication()).thenReturn(replication);
+
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.getKeyspace(keyspace)).thenReturn(ksMeta);
+
+        CassandraAdapterDelegate delegate = mock(CassandraAdapterDelegate.class);
+        when(delegate.metadata()).thenReturn(metadata);
+
+        InstanceMetadata instance = mock(InstanceMetadata.class);
+        when(instance.delegate()).thenReturn(delegate);
+
+        InstanceMetadataFetcher fetcher = mock(InstanceMetadataFetcher.class);
+        when(fetcher.callOnFirstAvailableInstance(any())).thenAnswer(inv -> {
+            Function<InstanceMetadata, ?> fn = inv.getArgument(0);
+            return fn.apply(instance);
+        });
+        return fetcher;
+    }
+}


### PR DESCRIPTION
Currently the analytics library uses ReplicationFactorSupplier.DEFAULT (SimpleStrategy/RF=1), which causes peer discovery to find only one replica per token range, it is better to add the support to resolve real keyspace replication factors from the driver.