### PR TITLE
CASSSIDECAR-452: Avoid blocking the event loop in CdcPublisher event-bus handler

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Avoid blocking the event loop in CdcPublisher event-bus handler (CASSSIDECAR-452)
  * Added validations for Live migration configuration (CASSSIDECAR-470)
  * Route CDC events to topics by corresponding topic format configuration (CASSSIDECAR-453)
  * Add Docker Compose setup for local CDC demo (Cassandra → Sidecar → Kafka) (CASSSIDECAR-419)

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -189,7 +189,7 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
             executorPools.executeBlocking(() -> {
                 restart();
                 return null;
-            });
+            }).onFailure(t -> handleAsyncFailure(ON_CDC_CONFIGURATION_CHANGED.address(), t));
         }
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -186,21 +186,14 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         {
             sidecarCdcStats.captureCdcConfigChange();
             // Execute restart on worker thread to avoid blocking event loop
-            executorPools.executeBlocking(() -> {
-                restart();
-                return null;
-            }).onFailure(t -> handleAsyncFailure(ON_CDC_CONFIGURATION_CHANGED.address(), t));
+            executorPools.runBlocking(
+                CdcPublisher.this::restart
+            ).onFailure(t -> handleAsyncFailure(ON_CDC_CONFIGURATION_CHANGED.address(), t));
         }
     }
 
     /**
-     * Backstop for fire-and-forget {@code executeBlocking(...)} dispatches in event-bus handlers.
-     * The handler methods ({@code restart}, {@code stop}) already catch and record their own
-     * failures via {@code sidecarCdcStats}; this fires only when something unexpected escapes
-     * (e.g. an {@link Error}, or a stats-counter increment that throws before reaching the
-     * handler's own try/catch). Logging at ERROR + bumping
-     * {@link SidecarCdcStats#captureUnrecoverableCdcError(Throwable)} so the issue is surfaced
-     * rather than silently dropped by the discarded {@code Future}.
+     * Handle the unexpected error while processing event on worker pool.
      */
     private void handleAsyncFailure(String address, Throwable t)
     {
@@ -270,7 +263,7 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         return isRunning;
     }
 
-    private synchronized void stop()
+    synchronized void stop()
     {
         if (!isRunning)
         {
@@ -355,19 +348,19 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         String address = msg.address();
         if (address.equals(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address()))
         {
-            executorPools.executeBlocking(() -> { handleTokenRangeChange(); return null; })
+            executorPools.runBlocking(CdcPublisher.this::handleTokenRangeChange)
                          .onFailure(t -> handleAsyncFailure(address, t));
         }
         else if (address.equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_GAINED.address()))
         {
             RangeManager.RangeChangeEvent event = (RangeManager.RangeChangeEvent) msg.body();
-            executorPools.executeBlocking(() -> { handleRangeGained(event); return null; })
+            executorPools.runBlocking(() -> handleRangeGained(event))
                          .onFailure(t -> handleAsyncFailure(address, t));
         }
         else if (address.equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_LOST.address()))
         {
             RangeManager.RangeChangeEvent event = (RangeManager.RangeChangeEvent) msg.body();
-            executorPools.executeBlocking(() -> { handleRangeLost(event); return null; })
+            executorPools.runBlocking(() -> handleRangeLost(event))
                          .onFailure(t -> handleAsyncFailure(address, t));
         }
         else if (address.equals(ON_SERVER_STOP.address()))

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -193,6 +193,21 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         }
     }
 
+    /**
+     * Backstop for fire-and-forget {@code executeBlocking(...)} dispatches in event-bus handlers.
+     * The handler methods ({@code restart}, {@code stop}) already catch and record their own
+     * failures via {@code sidecarCdcStats}; this fires only when something unexpected escapes
+     * (e.g. an {@link Error}, or a stats-counter increment that throws before reaching the
+     * handler's own try/catch). Logging at ERROR + bumping
+     * {@link SidecarCdcStats#captureUnrecoverableCdcError(Throwable)} so the issue is surfaced
+     * rather than silently dropped by the discarded {@code Future}.
+     */
+    private void handleAsyncFailure(String address, Throwable t)
+    {
+        LOGGER.error("Unexpected error while processing event '{}' on worker pool", address, t);
+        sidecarCdcStats.captureUnrecoverableCdcError(t);
+    }
+
     @SuppressWarnings("resource")
     private synchronized void run() throws IllegalStateException
     {
@@ -340,21 +355,26 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
         String address = msg.address();
         if (address.equals(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address()))
         {
-            executorPools.executeBlocking(() -> { handleTokenRangeChange(); return null; });
+            executorPools.executeBlocking(() -> { handleTokenRangeChange(); return null; })
+                         .onFailure(t -> handleAsyncFailure(address, t));
         }
         else if (address.equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_GAINED.address()))
         {
             RangeManager.RangeChangeEvent event = (RangeManager.RangeChangeEvent) msg.body();
-            executorPools.executeBlocking(() -> { handleRangeGained(event); return null; });
+            executorPools.executeBlocking(() -> { handleRangeGained(event); return null; })
+                         .onFailure(t -> handleAsyncFailure(address, t));
         }
         else if (address.equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_LOST.address()))
         {
             RangeManager.RangeChangeEvent event = (RangeManager.RangeChangeEvent) msg.body();
-            executorPools.executeBlocking(() -> { handleRangeLost(event); return null; });
+            executorPools.executeBlocking(() -> { handleRangeLost(event); return null; })
+                         .onFailure(t -> handleAsyncFailure(address, t));
         }
         else if (address.equals(ON_SERVER_STOP.address()))
         {
-            executorPools.executeBlocking(() -> { stop(); return null; });
+            // Run stop() on the event loop so it completes before the loop closes during shutdown;
+            // stopConsumers() only signals the SidecarCdc iterators (not heavy work).
+            stop();
         }
         else if (address.equals(ON_CDC_CACHE_WARMED_UP.address()))
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -335,26 +335,30 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
 
     // EventBus handlers
     @Override
-    public synchronized void handle(Message<Object> msg)
+    public void handle(Message<Object> msg)
     {
-        if (msg.address().equals(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address()))
+        String address = msg.address();
+        if (address.equals(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address()))
         {
-            handleTokenRangeChange();
+            executorPools.executeBlocking(() -> { handleTokenRangeChange(); return null; });
         }
-        else if (msg.address().equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_GAINED.address()))
+        else if (address.equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_GAINED.address()))
         {
-            handleRangeGained((RangeManager.RangeChangeEvent) msg.body());
+            RangeManager.RangeChangeEvent event = (RangeManager.RangeChangeEvent) msg.body();
+            executorPools.executeBlocking(() -> { handleRangeGained(event); return null; });
         }
-        else if (msg.address().equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_LOST.address()))
+        else if (address.equals(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_LOST.address()))
         {
-            handleRangeLost((RangeManager.RangeChangeEvent) msg.body());
+            RangeManager.RangeChangeEvent event = (RangeManager.RangeChangeEvent) msg.body();
+            executorPools.executeBlocking(() -> { handleRangeLost(event); return null; });
         }
-        else if (msg.address().equals(ON_SERVER_STOP.address()))
+        else if (address.equals(ON_SERVER_STOP.address()))
         {
-            stop();
+            executorPools.executeBlocking(() -> { stop(); return null; });
         }
-        else if (msg.address().equals(ON_CDC_CACHE_WARMED_UP.address()))
+        else if (address.equals(ON_CDC_CACHE_WARMED_UP.address()))
         {
+            // Single volatile write - safe on the event loop
             cdcCacheWarmedUp = true;
         }
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
@@ -21,7 +21,6 @@ package org.apache.cassandra.sidecar.cdc;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -45,11 +44,9 @@ import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.stats.ICdcStats;
 import org.apache.cassandra.sidecar.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
-import org.apache.cassandra.sidecar.common.server.utils.SecondBoundConfiguration;
+import org.apache.cassandra.sidecar.common.server.ThrowingRunnable;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
-import org.apache.cassandra.sidecar.config.KeyStoreConfiguration;
-import org.apache.cassandra.sidecar.config.SslConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
 import org.apache.cassandra.sidecar.db.CdcSystemViewsDatabaseAccessor;
@@ -64,7 +61,6 @@ import org.mockito.MockitoAnnotations;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CACHE_WARMED_UP;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -126,7 +122,7 @@ public class CdcPublisherTests
         // Mock ExecutorPools behavior
         when(executorPools.internal()).thenReturn(taskExecutorPool);
         // Return a real successfully-completed Future so .onFailure(...) chaining in handle() is a safe no-op.
-        when(taskExecutorPool.executeBlocking(any(Callable.class))).thenReturn(Future.succeededFuture(null));
+        when(taskExecutorPool.runBlocking(any(ThrowingRunnable.class))).thenReturn(Future.succeededFuture(null));
 
         // Mock Vertx EventBus for event listeners
         when(vertx.eventBus()).thenReturn(mock(io.vertx.core.eventbus.EventBus.class, RETURNS_DEEP_STUBS));
@@ -220,7 +216,6 @@ public class CdcPublisherTests
 
 
     @Test
-    @SuppressWarnings("unchecked")
     void testHandleTokenRangeChangedDispatchesToWorkerPool() throws Exception
     {
         Message<Object> msg = mock(Message.class);
@@ -229,15 +224,14 @@ public class CdcPublisherTests
         CdcPublisher spyPublisher = spy(cdcPublisher);
         spyPublisher.handle(msg);
 
-        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
-        verify(taskExecutorPool).executeBlocking(captor.capture());
+        ArgumentCaptor<ThrowingRunnable> captor = ArgumentCaptor.forClass(ThrowingRunnable.class);
+        verify(taskExecutorPool).runBlocking(captor.capture());
 
-        captor.getValue().call();
+        captor.getValue().run();
         verify(spyPublisher).handleTokenRangeChange();
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void testHandleTokenRangeGainedPassesEventToHandler() throws Exception
     {
         Message<Object> msg = mock(Message.class);
@@ -248,15 +242,14 @@ public class CdcPublisherTests
         CdcPublisher spyPublisher = spy(cdcPublisher);
         spyPublisher.handle(msg);
 
-        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
-        verify(taskExecutorPool).executeBlocking(captor.capture());
+        ArgumentCaptor<ThrowingRunnable> captor = ArgumentCaptor.forClass(ThrowingRunnable.class);
+        verify(taskExecutorPool).runBlocking(captor.capture());
 
-        captor.getValue().call();
+        captor.getValue().run();
         verify(spyPublisher).handleRangeGained(event);
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void testHandleTokenRangeLostPassesEventToHandler() throws Exception
     {
         Message<Object> msg = mock(Message.class);
@@ -267,10 +260,10 @@ public class CdcPublisherTests
         CdcPublisher spyPublisher = spy(cdcPublisher);
         spyPublisher.handle(msg);
 
-        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
-        verify(taskExecutorPool).executeBlocking(captor.capture());
+        ArgumentCaptor<ThrowingRunnable> captor = ArgumentCaptor.forClass(ThrowingRunnable.class);
+        verify(taskExecutorPool).runBlocking(captor.capture());
 
-        captor.getValue().call();
+        captor.getValue().run();
         verify(spyPublisher).handleRangeLost(event);
     }
 
@@ -280,11 +273,13 @@ public class CdcPublisherTests
         Message<Object> msg = mock(Message.class);
         when(msg.address()).thenReturn(ON_SERVER_STOP.address());
 
-        // ON_SERVER_STOP must run synchronously on the event loop so shutdown
-        // completes before the loop closes; the no-worker-pool assertion below
-        // is the load-bearing part of the contract.
-        assertThatCode(() -> cdcPublisher.handle(msg)).doesNotThrowAnyException();
-        verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
+        cdcPublisher = spy(cdcPublisher);
+        cdcPublisher.handle(msg);
+
+        // stop() must run synchronously on the event loop so shutdown completes
+        // before the loop closes; no worker-pool dispatch should occur.
+        verify(cdcPublisher).stop();
+        verify(taskExecutorPool, never()).runBlocking(any(ThrowingRunnable.class));
     }
 
     @Test
@@ -295,7 +290,7 @@ public class CdcPublisherTests
 
         cdcPublisher.handle(msg);
 
-        verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
+        verify(taskExecutorPool, never()).runBlocking(any(ThrowingRunnable.class));
     }
 
     @Test
@@ -306,15 +301,14 @@ public class CdcPublisherTests
 
         cdcPublisher.handle(msg);
 
-        verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
+        verify(taskExecutorPool, never()).runBlocking(any(ThrowingRunnable.class));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     void testHandleWorkerPoolFailureIsLoggedAndCaptured()
     {
         RuntimeException boom = new RuntimeException("boom");
-        when(taskExecutorPool.executeBlocking(any(Callable.class))).thenReturn(Future.failedFuture(boom));
+        when(taskExecutorPool.runBlocking(any(ThrowingRunnable.class))).thenReturn(Future.failedFuture(boom));
 
         Message<Object> msg = mock(Message.class);
         when(msg.address()).thenReturn(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address());

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import com.google.inject.Provider;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraVersion;
@@ -120,6 +121,8 @@ public class CdcPublisherTests
 
         // Mock ExecutorPools behavior
         when(executorPools.internal()).thenReturn(taskExecutorPool);
+        // Return a real successfully-completed Future so .onFailure(...) chaining in handle() is a safe no-op.
+        when(taskExecutorPool.executeBlocking(any(Callable.class))).thenReturn(Future.succeededFuture(null));
 
         // Mock Vertx EventBus for event listeners
         when(vertx.eventBus()).thenReturn(mock(io.vertx.core.eventbus.EventBus.class, RETURNS_DEEP_STUBS));
@@ -268,8 +271,7 @@ public class CdcPublisherTests
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    void testHandleServerStopDispatchesStopToWorkerPool() throws Exception
+    void testHandleServerStopRunsStopOnEventLoopWithoutWorkerPool()
     {
         Message<Object> msg = mock(Message.class);
         when(msg.address()).thenReturn(ON_SERVER_STOP.address());
@@ -277,11 +279,10 @@ public class CdcPublisherTests
         CdcPublisher spyPublisher = spy(cdcPublisher);
         spyPublisher.handle(msg);
 
-        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
-        verify(taskExecutorPool).executeBlocking(captor.capture());
-
-        captor.getValue().call();
+        // stop() must run synchronously on the event loop so it completes before
+        // the loop closes during shutdown; no worker-pool dispatch should occur.
         verify(spyPublisher).stop();
+        verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
     }
 
     @Test
@@ -304,5 +305,22 @@ public class CdcPublisherTests
         cdcPublisher.handle(msg);
 
         verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testHandleWorkerPoolFailureIsLoggedAndCaptured()
+    {
+        RuntimeException boom = new RuntimeException("boom");
+        when(taskExecutorPool.executeBlocking(any(Callable.class))).thenReturn(Future.failedFuture(boom));
+
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address());
+
+        cdcPublisher.handle(msg);
+
+        // The discarded Future's failure path must reach our backstop:
+        // captureUnrecoverableCdcError so the failure is observable in metrics.
+        verify(sidecarCdcStats).captureUnrecoverableCdcError(boom);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
@@ -22,6 +22,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.concurrent.Callable;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import io.vertx.core.Vertx;
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.cdc.api.CdcOptions;
+import io.vertx.core.eventbus.Message;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.kafka.KafkaProducerFactory;
@@ -49,11 +51,14 @@ import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
 import org.apache.cassandra.sidecar.db.CdcSystemViewsDatabaseAccessor;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CACHE_WARMED_UP;
+import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -61,6 +66,8 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -202,5 +209,100 @@ public class CdcPublisherTests
         when(mockBridge.getVersion()).thenReturn(CassandraVersion.FOURONE);
         when(cassandraBridgeFactory.get(anyString())).thenReturn(mockBridge);
         when(kafkaProducerFactory.create(any())).thenReturn(mock(KafkaProducer.class));
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testHandleTokenRangeChangedDispatchesToWorkerPool() throws Exception
+    {
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn(RangeManager.RangeManagerEvents.ON_TOKEN_RANGE_CHANGED.address());
+
+        CdcPublisher spyPublisher = spy(cdcPublisher);
+        spyPublisher.handle(msg);
+
+        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
+        verify(taskExecutorPool).executeBlocking(captor.capture());
+
+        captor.getValue().call();
+        verify(spyPublisher).handleTokenRangeChange();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testHandleTokenRangeGainedPassesEventToHandler() throws Exception
+    {
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_GAINED.address());
+        RangeManager.RangeChangeEvent event = mock(RangeManager.RangeChangeEvent.class);
+        when(msg.body()).thenReturn(event);
+
+        CdcPublisher spyPublisher = spy(cdcPublisher);
+        spyPublisher.handle(msg);
+
+        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
+        verify(taskExecutorPool).executeBlocking(captor.capture());
+
+        captor.getValue().call();
+        verify(spyPublisher).handleRangeGained(event);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testHandleTokenRangeLostPassesEventToHandler() throws Exception
+    {
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn(RangeManager.LeadershipEvents.ON_TOKEN_RANGE_LOST.address());
+        RangeManager.RangeChangeEvent event = mock(RangeManager.RangeChangeEvent.class);
+        when(msg.body()).thenReturn(event);
+
+        CdcPublisher spyPublisher = spy(cdcPublisher);
+        spyPublisher.handle(msg);
+
+        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
+        verify(taskExecutorPool).executeBlocking(captor.capture());
+
+        captor.getValue().call();
+        verify(spyPublisher).handleRangeLost(event);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testHandleServerStopDispatchesStopToWorkerPool() throws Exception
+    {
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn(ON_SERVER_STOP.address());
+
+        CdcPublisher spyPublisher = spy(cdcPublisher);
+        spyPublisher.handle(msg);
+
+        ArgumentCaptor<Callable<Void>> captor = ArgumentCaptor.forClass(Callable.class);
+        verify(taskExecutorPool).executeBlocking(captor.capture());
+
+        captor.getValue().call();
+        verify(spyPublisher).stop();
+    }
+
+    @Test
+    void testHandleCdcCacheWarmedUpRunsOnEventLoopWithoutWorkerPool()
+    {
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn(ON_CDC_CACHE_WARMED_UP.address());
+
+        cdcPublisher.handle(msg);
+
+        verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
+    }
+
+    @Test
+    void testHandleUnknownAddressIsNoOp()
+    {
+        Message<Object> msg = mock(Message.class);
+        when(msg.address()).thenReturn("unknown.address");
+
+        cdcPublisher.handle(msg);
+
+        verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/CdcPublisherTests.java
@@ -21,8 +21,8 @@ package org.apache.cassandra.sidecar.cdc;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,10 +32,10 @@ import org.junit.jupiter.params.provider.EnumSource;
 import com.google.inject.Provider;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
 import org.apache.cassandra.bridge.CassandraBridge;
 import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.cdc.api.CdcOptions;
-import io.vertx.core.eventbus.Message;
 import org.apache.cassandra.cdc.api.EventConsumer;
 import org.apache.cassandra.cdc.api.SchemaSupplier;
 import org.apache.cassandra.cdc.kafka.KafkaProducerFactory;
@@ -45,8 +45,11 @@ import org.apache.cassandra.cdc.sidecar.SidecarCdcClient;
 import org.apache.cassandra.cdc.stats.ICdcStats;
 import org.apache.cassandra.sidecar.bridge.CassandraBridgeFactory;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.apache.cassandra.sidecar.common.server.utils.SecondBoundConfiguration;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
+import org.apache.cassandra.sidecar.config.KeyStoreConfiguration;
+import org.apache.cassandra.sidecar.config.SslConfiguration;
 import org.apache.cassandra.sidecar.coordination.RangeManager;
 import org.apache.cassandra.sidecar.db.CdcDatabaseAccessor;
 import org.apache.cassandra.sidecar.db.CdcSystemViewsDatabaseAccessor;
@@ -61,6 +64,7 @@ import org.mockito.MockitoAnnotations;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_CDC_CACHE_WARMED_UP;
 import static org.apache.cassandra.sidecar.server.SidecarServerEvents.ON_SERVER_STOP;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -276,12 +280,10 @@ public class CdcPublisherTests
         Message<Object> msg = mock(Message.class);
         when(msg.address()).thenReturn(ON_SERVER_STOP.address());
 
-        CdcPublisher spyPublisher = spy(cdcPublisher);
-        spyPublisher.handle(msg);
-
-        // stop() must run synchronously on the event loop so it completes before
-        // the loop closes during shutdown; no worker-pool dispatch should occur.
-        verify(spyPublisher).stop();
+        // ON_SERVER_STOP must run synchronously on the event loop so shutdown
+        // completes before the loop closes; the no-worker-pool assertion below
+        // is the load-bearing part of the contract.
+        assertThatCode(() -> cdcPublisher.handle(msg)).doesNotThrowAnyException();
         verify(taskExecutorPool, never()).executeBlocking(any(Callable.class));
     }
 


### PR DESCRIPTION
CdcPublisher subscribes to several event-bus addresses (token-range changed, range gained/lost, server stop, CDC cache warmed up) via vertx.eventBus().localConsumer(), so handle(Message) runs on the event loop. The four range/stop branches previously called handleTokenRangeChange / handleRangeGained / handleRangeLost / stop
synchronously, all of which transitively perform blocking work(closing the Kafka producer, stopping SidecarCdc consumers, querying virtual tables). This blocks the event loop and can starve other Vert.x consumers under topology churn.
Dispatch those four branches to the shared worker pool via executorPools.executeBlocking(), matching the existing
ConfigChangedHandler pattern. Keep ON_CDC_CACHE_WARMED_UP on the event loop since it is only a single volatile write. Drop the now-redundant synchronized from handle() (event-loop-dispatched consumers cannot race with themselves; the actual handler methods remain synchronized).