### PR TITLE
CASSSIDECAR-424: Add ConfigurationProvider interfaces

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Add ConfigurationProvider interfaces for pluggable overlay storage (CASSSIDECAR-424)
  * Refactor OperationalJob to have data separate from execution logic (CASSSIDECAR-460)
  * Sidecar’s CassandraBridgeFactory FQCN colliding with the Cassandra analytics class (CASSSIDECAR-467)
  * Fix ON_CDC_CACHE_WARMED_UP not fired when schema publisher fails (CASSSIDECAR-459)

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -178,6 +178,6 @@ public class CassandraConfigurationOverlay
         ObjectNode node = MAPPER.createObjectNode();
         node.set("cassandraYaml", cassandraYaml);
         node.set("extraJvmOpts", MAPPER.valueToTree(extraJvmOpts));
-        return node.toString();
+        return node.toPrettyString();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -18,9 +18,8 @@
 
 package org.apache.cassandra.sidecar.configmanagement;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -42,7 +41,8 @@ import org.jetbrains.annotations.Nullable;
  * the responsibility of the Configuration Manager.
  *
  * <p>The {@code extraJvmOpts} field contains JVM options that are appended to the Cassandra JVM startup
- * command. These are opaque strings not subject to schema validation.
+ * command. Each entry maps the full option flag (e.g. {@code -Dcassandra.jmx.local.port}) to its value
+ * (e.g. {@code 7199}). These are opaque strings not subject to schema validation.
  */
 public class CassandraConfigurationOverlay
 {
@@ -52,11 +52,11 @@ public class CassandraConfigurationOverlay
     private final JsonNode cassandraYaml;
 
     @NotNull
-    private final List<String> extraJvmOpts;
+    private final Map<String, String> extraJvmOpts;
 
     @JsonCreator
     public CassandraConfigurationOverlay(@JsonProperty("cassandraYaml") @Nullable JsonNode cassandraYaml,
-                                         @JsonProperty("extraJvmOpts") @Nullable List<String> extraJvmOpts)
+                                         @JsonProperty("extraJvmOpts") @Nullable Map<String, String> extraJvmOpts)
     {
         if (cassandraYaml == null)
         {
@@ -71,8 +71,8 @@ public class CassandraConfigurationOverlay
             this.cassandraYaml = cassandraYaml;
         }
         this.extraJvmOpts = extraJvmOpts != null
-                            ? Collections.unmodifiableList(new ArrayList<>(extraJvmOpts))
-                            : Collections.emptyList();
+                            ? Collections.unmodifiableMap(new LinkedHashMap<>(extraJvmOpts))
+                            : Collections.emptyMap();
     }
 
     /**
@@ -86,11 +86,11 @@ public class CassandraConfigurationOverlay
     }
 
     /**
-     * @return an unmodifiable list of extra JVM options
+     * @return an unmodifiable map of extra JVM options (option name to value)
      */
     @JsonProperty("extraJvmOpts")
     @NotNull
-    public List<String> extraJvmOpts()
+    public Map<String, String> extraJvmOpts()
     {
         return extraJvmOpts;
     }
@@ -98,17 +98,19 @@ public class CassandraConfigurationOverlay
     /**
      * Returns a new overlay with the given updates applied. The current instance is not modified.
      *
+     * <p>Both parameters follow the same semantics: a {@code null} value for a key removes that entry,
+     * a non-null value upserts it.
+     *
      * @param cassandraYamlUpdates field-level changes to cassandra.yaml: key = field name, value = new value.
      *                             A null or {@link com.fasterxml.jackson.databind.node.NullNode} value removes
      *                             the field. Pass {@code null} for no yaml changes.
-     * @param addJvmOpts           JVM options to append to the current list. Pass {@code null} for no additions.
-     * @param removeJvmOpts        JVM options to remove by value. Pass {@code null} for no removals.
+     * @param extraJvmOptsUpdates  JVM option changes: key = option name, value = new option value.
+     *                             A {@code null} value removes the option. Pass {@code null} for no changes.
      * @return a new overlay with the updates applied
      */
     @NotNull
     public CassandraConfigurationOverlay updated(@Nullable Map<String, JsonNode> cassandraYamlUpdates,
-                                                 @Nullable List<String> addJvmOpts,
-                                                 @Nullable List<String> removeJvmOpts)
+                                                 @Nullable Map<String, String> extraJvmOptsUpdates)
     {
         ObjectNode mergedYaml = ((ObjectNode) cassandraYaml).deepCopy();
         if (cassandraYamlUpdates != null)
@@ -126,14 +128,20 @@ public class CassandraConfigurationOverlay
             }
         }
 
-        List<String> mergedOpts = new ArrayList<>(extraJvmOpts);
-        if (removeJvmOpts != null)
+        LinkedHashMap<String, String> mergedOpts = new LinkedHashMap<>(extraJvmOpts);
+        if (extraJvmOptsUpdates != null)
         {
-            mergedOpts.removeAll(removeJvmOpts);
-        }
-        if (addJvmOpts != null)
-        {
-            mergedOpts.addAll(addJvmOpts);
+            for (Map.Entry<String, String> entry : extraJvmOptsUpdates.entrySet())
+            {
+                if (entry.getValue() == null)
+                {
+                    mergedOpts.remove(entry.getKey());
+                }
+                else
+                {
+                    mergedOpts.put(entry.getKey(), entry.getValue());
+                }
+            }
         }
 
         return new CassandraConfigurationOverlay(mergedYaml, mergedOpts);

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -24,11 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -46,44 +43,29 @@ import org.jetbrains.annotations.Nullable;
  */
 public class CassandraConfigurationOverlay
 {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     @NotNull
-    private final JsonNode cassandraYaml;
+    private final JsonObject cassandraYaml;
 
     @NotNull
     private final List<String> extraJvmOpts;
 
-    @JsonCreator
-    public CassandraConfigurationOverlay(@JsonProperty("cassandraYaml") @Nullable JsonNode cassandraYaml,
-                                         @JsonProperty("extraJvmOpts") @Nullable List<String> extraJvmOpts)
+    public CassandraConfigurationOverlay(@Nullable JsonObject cassandraYaml,
+                                         @Nullable List<String> extraJvmOpts)
     {
-        if (cassandraYaml == null)
-        {
-            this.cassandraYaml = MAPPER.createObjectNode();
-        }
-        else if (!cassandraYaml.isObject())
-        {
-            throw new IllegalArgumentException("cassandraYaml must be a JSON object, got " + cassandraYaml.getNodeType());
-        }
-        else
-        {
-            this.cassandraYaml = ((ObjectNode) cassandraYaml).deepCopy();
-        }
+        this.cassandraYaml = cassandraYaml != null ? cassandraYaml.copy() : new JsonObject();
         this.extraJvmOpts = extraJvmOpts != null
-                            ? Collections.unmodifiableList(new ArrayList<>(extraJvmOpts))
+                            ? List.copyOf(extraJvmOpts)
                             : Collections.emptyList();
     }
 
     /**
      * Returns the cassandra.yaml overlay as a version-agnostic JSON object. Callers must not mutate the
-     * returned node; use {@link #updated} to produce a new overlay with changes applied.
+     * returned object; use {@link #updated} to produce a new overlay with changes applied.
      *
      * @return the cassandra.yaml overlay as a version-agnostic JSON object
      */
-    @JsonProperty("cassandraYaml")
     @NotNull
-    public JsonNode cassandraYaml()
+    public JsonObject cassandraYaml()
     {
         return cassandraYaml;
     }
@@ -91,7 +73,6 @@ public class CassandraConfigurationOverlay
     /**
      * @return an unmodifiable list of extra JVM options
      */
-    @JsonProperty("extraJvmOpts")
     @NotNull
     public List<String> extraJvmOpts()
     {
@@ -99,32 +80,44 @@ public class CassandraConfigurationOverlay
     }
 
     /**
+     * Returns a JSON representation of this overlay.
+     *
+     * @return a new {@link JsonObject} containing {@code cassandraYaml} and {@code extraJvmOpts}
+     */
+    @NotNull
+    public JsonObject toJson()
+    {
+        return new JsonObject()
+               .put("cassandraYaml", cassandraYaml.copy())
+               .put("extraJvmOpts", new JsonArray(new ArrayList<>(extraJvmOpts)));
+    }
+
+    /**
      * Returns a new overlay with the given updates applied. The current instance is not modified.
      *
      * @param cassandraYamlUpdates field-level changes to cassandra.yaml: key = field name, value = new value.
-     *                             A null or {@link com.fasterxml.jackson.databind.node.NullNode} value removes
-     *                             the field. Pass {@code null} for no yaml changes.
+     *                             A {@code null} value removes the field. Pass {@code null} for no yaml changes.
      * @param addJvmOpts           JVM options to append to the current list. Pass {@code null} for no additions.
      * @param removeJvmOpts        JVM options to remove by value. Pass {@code null} for no removals.
      * @return a new overlay with the updates applied
      */
     @NotNull
-    public CassandraConfigurationOverlay updated(@Nullable Map<String, JsonNode> cassandraYamlUpdates,
+    public CassandraConfigurationOverlay updated(@Nullable Map<String, Object> cassandraYamlUpdates,
                                                  @Nullable List<String> addJvmOpts,
                                                  @Nullable List<String> removeJvmOpts)
     {
-        ObjectNode mergedYaml = ((ObjectNode) cassandraYaml).deepCopy();
+        JsonObject mergedYaml = cassandraYaml.copy();
         if (cassandraYamlUpdates != null)
         {
-            for (Map.Entry<String, JsonNode> entry : cassandraYamlUpdates.entrySet())
+            for (Map.Entry<String, Object> entry : cassandraYamlUpdates.entrySet())
             {
-                if (entry.getValue() == null || entry.getValue().isNull())
+                if (entry.getValue() == null)
                 {
                     mergedYaml.remove(entry.getKey());
                 }
                 else
                 {
-                    mergedYaml.set(entry.getKey(), entry.getValue());
+                    mergedYaml.put(entry.getKey(), entry.getValue());
                 }
             }
         }
@@ -167,9 +160,6 @@ public class CassandraConfigurationOverlay
     @Override
     public String toString()
     {
-        ObjectNode node = MAPPER.createObjectNode();
-        node.set("cassandraYaml", cassandraYaml);
-        node.set("extraJvmOpts", MAPPER.valueToTree(extraJvmOpts));
-        return node.toPrettyString();
+        return toJson().encodePrettily();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -68,7 +68,7 @@ public class CassandraConfigurationOverlay
         }
         else
         {
-            this.cassandraYaml = cassandraYaml;
+            this.cassandraYaml = ((ObjectNode) cassandraYaml).deepCopy();
         }
         this.extraJvmOpts = extraJvmOpts != null
                             ? Collections.unmodifiableMap(new LinkedHashMap<>(extraJvmOpts))
@@ -76,6 +76,9 @@ public class CassandraConfigurationOverlay
     }
 
     /**
+     * Returns the cassandra.yaml overlay as a version-agnostic JSON object. Callers must not mutate the
+     * returned node; use {@link #updated} to produce a new overlay with changes applied.
+     *
      * @return the cassandra.yaml overlay as a version-agnostic JSON object
      */
     @JsonProperty("cassandraYaml")

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a configuration overlay - a sparse set of configuration values that overwrite base template
+ * values or add new configuration attributes.
+ *
+ * <p>The {@code cassandraYaml} field is a version-agnostic JSON representation of {@code cassandra.yaml}
+ * settings. It may contain settings from any Cassandra version supported by Sidecar (4.0, 4.1, 5.0, etc.).
+ * No version-specific validation is performed by this class; validation against a version-aware schema is
+ * the responsibility of the Configuration Manager.
+ *
+ * <p>The {@code extraJvmOpts} field contains JVM options that are appended to the Cassandra JVM startup
+ * command. These are opaque strings not subject to schema validation.
+ */
+public class CassandraConfigurationOverlay
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @NotNull
+    private final JsonNode cassandraYaml;
+
+    @NotNull
+    private final List<String> extraJvmOpts;
+
+    @JsonCreator
+    public CassandraConfigurationOverlay(@JsonProperty("cassandraYaml") @Nullable JsonNode cassandraYaml,
+                                         @JsonProperty("extraJvmOpts") @Nullable List<String> extraJvmOpts)
+    {
+        if (cassandraYaml == null)
+        {
+            this.cassandraYaml = MAPPER.createObjectNode();
+        }
+        else if (!cassandraYaml.isObject())
+        {
+            throw new IllegalArgumentException("cassandraYaml must be a JSON object, got " + cassandraYaml.getNodeType());
+        }
+        else
+        {
+            this.cassandraYaml = cassandraYaml;
+        }
+        this.extraJvmOpts = extraJvmOpts != null
+                            ? Collections.unmodifiableList(new ArrayList<>(extraJvmOpts))
+                            : Collections.emptyList();
+    }
+
+    /**
+     * @return the cassandra.yaml overlay as a version-agnostic JSON object
+     */
+    @JsonProperty("cassandraYaml")
+    @NotNull
+    public JsonNode cassandraYaml()
+    {
+        return cassandraYaml;
+    }
+
+    /**
+     * @return an unmodifiable list of extra JVM options
+     */
+    @JsonProperty("extraJvmOpts")
+    @NotNull
+    public List<String> extraJvmOpts()
+    {
+        return extraJvmOpts;
+    }
+
+    /**
+     * Returns a new overlay with the given updates applied. The current instance is not modified.
+     *
+     * @param cassandraYamlUpdates field-level changes to cassandra.yaml: key = field name, value = new value.
+     *                             A null or {@link com.fasterxml.jackson.databind.node.NullNode} value removes
+     *                             the field. Pass {@code null} for no yaml changes.
+     * @param addJvmOpts           JVM options to append to the current list. Pass {@code null} for no additions.
+     * @param removeJvmOpts        JVM options to remove by value. Pass {@code null} for no removals.
+     * @return a new overlay with the updates applied
+     */
+    @NotNull
+    public CassandraConfigurationOverlay updated(@Nullable Map<String, JsonNode> cassandraYamlUpdates,
+                                                 @Nullable List<String> addJvmOpts,
+                                                 @Nullable List<String> removeJvmOpts)
+    {
+        ObjectNode mergedYaml = ((ObjectNode) cassandraYaml).deepCopy();
+        if (cassandraYamlUpdates != null)
+        {
+            for (Map.Entry<String, JsonNode> entry : cassandraYamlUpdates.entrySet())
+            {
+                if (entry.getValue() == null || entry.getValue().isNull())
+                {
+                    mergedYaml.remove(entry.getKey());
+                }
+                else
+                {
+                    mergedYaml.set(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        List<String> mergedOpts = new ArrayList<>(extraJvmOpts);
+        if (removeJvmOpts != null)
+        {
+            mergedOpts.removeAll(removeJvmOpts);
+        }
+        if (addJvmOpts != null)
+        {
+            mergedOpts.addAll(addJvmOpts);
+        }
+
+        return new CassandraConfigurationOverlay(mergedYaml, mergedOpts);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        CassandraConfigurationOverlay that = (CassandraConfigurationOverlay) o;
+        return Objects.equals(cassandraYaml, that.cassandraYaml)
+               && Objects.equals(extraJvmOpts, that.extraJvmOpts);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(cassandraYaml, extraJvmOpts);
+    }
+
+    @Override
+    public String toString()
+    {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.set("cassandraYaml", cassandraYaml);
+        node.set("extraJvmOpts", MAPPER.valueToTree(extraJvmOpts));
+        return node.toString();
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -18,13 +18,11 @@
 
 package org.apache.cassandra.sidecar.configmanagement;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +37,8 @@ import org.jetbrains.annotations.Nullable;
  * the responsibility of the Configuration Manager.
  *
  * <p>The {@code extraJvmOpts} field contains JVM options that are appended to the Cassandra JVM startup
- * command. These are opaque strings not subject to schema validation.
+ * command. Each entry maps the full option flag (e.g. {@code -Dcassandra.jmx.local.port}) to its value
+ * (e.g. {@code 7199}). These are opaque strings not subject to schema validation.
  */
 public class CassandraConfigurationOverlay
 {
@@ -47,15 +46,15 @@ public class CassandraConfigurationOverlay
     private final JsonObject cassandraYaml;
 
     @NotNull
-    private final List<String> extraJvmOpts;
+    private final Map<String, String> extraJvmOpts;
 
     public CassandraConfigurationOverlay(@Nullable JsonObject cassandraYaml,
-                                         @Nullable List<String> extraJvmOpts)
+                                         @Nullable Map<String, String> extraJvmOpts)
     {
         this.cassandraYaml = cassandraYaml != null ? cassandraYaml.copy() : new JsonObject();
         this.extraJvmOpts = extraJvmOpts != null
-                            ? List.copyOf(extraJvmOpts)
-                            : Collections.emptyList();
+                            ? Collections.unmodifiableMap(new LinkedHashMap<>(extraJvmOpts))
+                            : Collections.emptyMap();
     }
 
     /**
@@ -71,10 +70,10 @@ public class CassandraConfigurationOverlay
     }
 
     /**
-     * @return an unmodifiable list of extra JVM options
+     * @return an unmodifiable map of extra JVM options (option name to value)
      */
     @NotNull
-    public List<String> extraJvmOpts()
+    public Map<String, String> extraJvmOpts()
     {
         return extraJvmOpts;
     }
@@ -89,22 +88,24 @@ public class CassandraConfigurationOverlay
     {
         return new JsonObject()
                .put("cassandraYaml", cassandraYaml.copy())
-               .put("extraJvmOpts", new JsonArray(new ArrayList<>(extraJvmOpts)));
+               .put("extraJvmOpts", new JsonObject(new LinkedHashMap<>(extraJvmOpts)));
     }
 
     /**
      * Returns a new overlay with the given updates applied. The current instance is not modified.
      *
+     * <p>Both parameters follow the same semantics: a {@code null} value for a key removes that entry,
+     * a non-null value upserts it.
+     *
      * @param cassandraYamlUpdates field-level changes to cassandra.yaml: key = field name, value = new value.
      *                             A {@code null} value removes the field. Pass {@code null} for no yaml changes.
-     * @param addJvmOpts           JVM options to append to the current list. Pass {@code null} for no additions.
-     * @param removeJvmOpts        JVM options to remove by value. Pass {@code null} for no removals.
+     * @param extraJvmOptsUpdates  JVM option changes: key = option name, value = new option value.
+     *                             A {@code null} value removes the option. Pass {@code null} for no changes.
      * @return a new overlay with the updates applied
      */
     @NotNull
     public CassandraConfigurationOverlay updated(@Nullable Map<String, Object> cassandraYamlUpdates,
-                                                 @Nullable List<String> addJvmOpts,
-                                                 @Nullable List<String> removeJvmOpts)
+                                                 @Nullable Map<String, String> extraJvmOptsUpdates)
     {
         JsonObject mergedYaml = cassandraYaml.copy();
         if (cassandraYamlUpdates != null)
@@ -122,14 +123,20 @@ public class CassandraConfigurationOverlay
             }
         }
 
-        List<String> mergedOpts = new ArrayList<>(extraJvmOpts);
-        if (removeJvmOpts != null)
+        LinkedHashMap<String, String> mergedOpts = new LinkedHashMap<>(extraJvmOpts);
+        if (extraJvmOptsUpdates != null)
         {
-            mergedOpts.removeAll(removeJvmOpts);
-        }
-        if (addJvmOpts != null)
-        {
-            mergedOpts.addAll(addJvmOpts);
+            for (Map.Entry<String, String> entry : extraJvmOptsUpdates.entrySet())
+            {
+                if (entry.getValue() == null)
+                {
+                    mergedOpts.remove(entry.getKey());
+                }
+                else
+                {
+                    mergedOpts.put(entry.getKey(), entry.getValue());
+                }
+            }
         }
 
         return new CassandraConfigurationOverlay(mergedYaml, mergedOpts);

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -18,8 +18,9 @@
 
 package org.apache.cassandra.sidecar.configmanagement;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -41,8 +42,7 @@ import org.jetbrains.annotations.Nullable;
  * the responsibility of the Configuration Manager.
  *
  * <p>The {@code extraJvmOpts} field contains JVM options that are appended to the Cassandra JVM startup
- * command. Each entry maps the full option flag (e.g. {@code -Dcassandra.jmx.local.port}) to its value
- * (e.g. {@code 7199}). These are opaque strings not subject to schema validation.
+ * command. These are opaque strings not subject to schema validation.
  */
 public class CassandraConfigurationOverlay
 {
@@ -52,11 +52,11 @@ public class CassandraConfigurationOverlay
     private final JsonNode cassandraYaml;
 
     @NotNull
-    private final Map<String, String> extraJvmOpts;
+    private final List<String> extraJvmOpts;
 
     @JsonCreator
     public CassandraConfigurationOverlay(@JsonProperty("cassandraYaml") @Nullable JsonNode cassandraYaml,
-                                         @JsonProperty("extraJvmOpts") @Nullable Map<String, String> extraJvmOpts)
+                                         @JsonProperty("extraJvmOpts") @Nullable List<String> extraJvmOpts)
     {
         if (cassandraYaml == null)
         {
@@ -71,8 +71,8 @@ public class CassandraConfigurationOverlay
             this.cassandraYaml = ((ObjectNode) cassandraYaml).deepCopy();
         }
         this.extraJvmOpts = extraJvmOpts != null
-                            ? Collections.unmodifiableMap(new LinkedHashMap<>(extraJvmOpts))
-                            : Collections.emptyMap();
+                            ? Collections.unmodifiableList(new ArrayList<>(extraJvmOpts))
+                            : Collections.emptyList();
     }
 
     /**
@@ -89,11 +89,11 @@ public class CassandraConfigurationOverlay
     }
 
     /**
-     * @return an unmodifiable map of extra JVM options (option name to value)
+     * @return an unmodifiable list of extra JVM options
      */
     @JsonProperty("extraJvmOpts")
     @NotNull
-    public Map<String, String> extraJvmOpts()
+    public List<String> extraJvmOpts()
     {
         return extraJvmOpts;
     }
@@ -101,19 +101,17 @@ public class CassandraConfigurationOverlay
     /**
      * Returns a new overlay with the given updates applied. The current instance is not modified.
      *
-     * <p>Both parameters follow the same semantics: a {@code null} value for a key removes that entry,
-     * a non-null value upserts it.
-     *
      * @param cassandraYamlUpdates field-level changes to cassandra.yaml: key = field name, value = new value.
      *                             A null or {@link com.fasterxml.jackson.databind.node.NullNode} value removes
      *                             the field. Pass {@code null} for no yaml changes.
-     * @param extraJvmOptsUpdates  JVM option changes: key = option name, value = new option value.
-     *                             A {@code null} value removes the option. Pass {@code null} for no changes.
+     * @param addJvmOpts           JVM options to append to the current list. Pass {@code null} for no additions.
+     * @param removeJvmOpts        JVM options to remove by value. Pass {@code null} for no removals.
      * @return a new overlay with the updates applied
      */
     @NotNull
     public CassandraConfigurationOverlay updated(@Nullable Map<String, JsonNode> cassandraYamlUpdates,
-                                                 @Nullable Map<String, String> extraJvmOptsUpdates)
+                                                 @Nullable List<String> addJvmOpts,
+                                                 @Nullable List<String> removeJvmOpts)
     {
         ObjectNode mergedYaml = ((ObjectNode) cassandraYaml).deepCopy();
         if (cassandraYamlUpdates != null)
@@ -131,20 +129,14 @@ public class CassandraConfigurationOverlay
             }
         }
 
-        LinkedHashMap<String, String> mergedOpts = new LinkedHashMap<>(extraJvmOpts);
-        if (extraJvmOptsUpdates != null)
+        List<String> mergedOpts = new ArrayList<>(extraJvmOpts);
+        if (removeJvmOpts != null)
         {
-            for (Map.Entry<String, String> entry : extraJvmOptsUpdates.entrySet())
-            {
-                if (entry.getValue() == null)
-                {
-                    mergedOpts.remove(entry.getKey());
-                }
-                else
-                {
-                    mergedOpts.put(entry.getKey(), entry.getValue());
-                }
-            }
+            mergedOpts.removeAll(removeJvmOpts);
+        }
+        if (addJvmOpts != null)
+        {
+            mergedOpts.addAll(addJvmOpts);
         }
 
         return new CassandraConfigurationOverlay(mergedYaml, mergedOpts);

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -19,9 +19,11 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
@@ -139,7 +141,33 @@ public class CassandraConfigurationOverlay
             }
         }
 
+        validateNoConflictingBooleanOpts(mergedOpts);
+
         return new CassandraConfigurationOverlay(mergedYaml, mergedOpts);
+    }
+
+    private static void validateNoConflictingBooleanOpts(Map<String, String> opts)
+    {
+        Set<String> enabled = new HashSet<>();
+        Set<String> disabled = new HashSet<>();
+        for (String key : opts.keySet())
+        {
+            if (key.startsWith("-XX:+"))
+            {
+                enabled.add(key.substring(5));
+            }
+            else if (key.startsWith("-XX:-"))
+            {
+                disabled.add(key.substring(5));
+            }
+        }
+        enabled.retainAll(disabled);
+        if (!enabled.isEmpty())
+        {
+            String option = enabled.iterator().next();
+            throw new IllegalArgumentException(
+                "Conflicting boolean JVM options: -XX:+" + option + " and -XX:-" + option);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -133,6 +133,6 @@ public class ConfigurationOverlaySnapshot
         node.put("hash", hash());
         node.put("lastModified", lastModified.toString());
         node.set("configuration", MAPPER.valueToTree(configuration));
-        return node.toString();
+        return node.toPrettyString();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -40,15 +40,15 @@ public class ConfigurationOverlaySnapshot
     private final Instant lastModified;
 
     @NotNull
-    private final CassandraConfigurationOverlay configuration;
+    private final CassandraConfigurationOverlay overlay;
 
     private volatile String hash;
 
     public ConfigurationOverlaySnapshot(@NotNull Instant lastModified,
-                                        @NotNull CassandraConfigurationOverlay configuration)
+                                        @NotNull CassandraConfigurationOverlay overlay)
     {
         this.lastModified = Objects.requireNonNull(lastModified, "lastModified must not be null");
-        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+        this.overlay = Objects.requireNonNull(overlay, "overlay must not be null");
     }
 
     /**
@@ -74,16 +74,16 @@ public class ConfigurationOverlaySnapshot
     }
 
     @NotNull
-    public CassandraConfigurationOverlay configuration()
+    public CassandraConfigurationOverlay overlay()
     {
-        return configuration;
+        return overlay;
     }
 
     private String computeHash()
     {
         try
         {
-            byte[] bytes = MAPPER.writeValueAsBytes(configuration);
+            byte[] bytes = MAPPER.writeValueAsBytes(overlay);
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hashBytes = digest.digest(bytes);
             return "sha256:" + bytesToHex(hashBytes);
@@ -117,13 +117,13 @@ public class ConfigurationOverlaySnapshot
         }
         ConfigurationOverlaySnapshot that = (ConfigurationOverlaySnapshot) o;
         return Objects.equals(lastModified, that.lastModified)
-               && Objects.equals(configuration, that.configuration);
+               && Objects.equals(overlay, that.overlay);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(lastModified, configuration);
+        return Objects.hash(lastModified, overlay);
     }
 
     @Override
@@ -132,7 +132,7 @@ public class ConfigurationOverlaySnapshot
         ObjectNode node = MAPPER.createObjectNode();
         node.put("hash", hash());
         node.put("lastModified", lastModified.toString());
-        node.set("configuration", MAPPER.valueToTree(configuration));
+        node.set("overlay", MAPPER.valueToTree(overlay));
         return node.toPrettyString();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -23,9 +23,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Objects;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -34,8 +32,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ConfigurationOverlaySnapshot
 {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     @NotNull
     private final Instant lastModified;
 
@@ -83,12 +79,12 @@ public class ConfigurationOverlaySnapshot
     {
         try
         {
-            byte[] bytes = MAPPER.writeValueAsBytes(overlay);
+            byte[] bytes = overlay.toJson().toBuffer().getBytes();
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hashBytes = digest.digest(bytes);
             return "sha256:" + bytesToHex(hashBytes);
         }
-        catch (JsonProcessingException | NoSuchAlgorithmException e)
+        catch (NoSuchAlgorithmException e)
         {
             throw new RuntimeException("Failed to compute configuration hash", e);
         }
@@ -129,10 +125,10 @@ public class ConfigurationOverlaySnapshot
     @Override
     public String toString()
     {
-        ObjectNode node = MAPPER.createObjectNode();
-        node.put("hash", hash());
-        node.put("lastModified", lastModified.toString());
-        node.set("overlay", MAPPER.valueToTree(overlay));
-        return node.toPrettyString();
+        return new JsonObject()
+               .put("hash", hash())
+               .put("lastModified", lastModified.toString())
+               .put("overlay", overlay.toJson())
+               .encodePrettily();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a snapshot of a configuration overlay with its metadata.
+ * The SHA-256 hash is dynamically computed from the overlay contents and cached.
+ */
+public class ConfigurationOverlaySnapshot
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @NotNull
+    private final Instant lastModified;
+
+    @NotNull
+    private final CassandraConfigurationOverlay configuration;
+
+    private volatile String hash;
+
+    public ConfigurationOverlaySnapshot(@NotNull Instant lastModified,
+                                        @NotNull CassandraConfigurationOverlay configuration)
+    {
+        this.lastModified = Objects.requireNonNull(lastModified, "lastModified must not be null");
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
+    }
+
+    /**
+     * Returns the SHA-256 hash of the overlay contents, prefixed with "sha256:".
+     * Computed on first access and cached for subsequent calls.
+     *
+     * @return the content hash in the form "sha256:&lt;64 hex chars&gt;"
+     */
+    @NotNull
+    public String hash()
+    {
+        if (hash == null)
+        {
+            hash = computeHash();
+        }
+        return hash;
+    }
+
+    @NotNull
+    public Instant lastModified()
+    {
+        return lastModified;
+    }
+
+    @NotNull
+    public CassandraConfigurationOverlay configuration()
+    {
+        return configuration;
+    }
+
+    private String computeHash()
+    {
+        try
+        {
+            byte[] bytes = MAPPER.writeValueAsBytes(configuration);
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(bytes);
+            return "sha256:" + bytesToHex(hashBytes);
+        }
+        catch (JsonProcessingException | NoSuchAlgorithmException e)
+        {
+            throw new RuntimeException("Failed to compute configuration hash", e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes)
+    {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes)
+        {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+        ConfigurationOverlaySnapshot that = (ConfigurationOverlaySnapshot) o;
+        return Objects.equals(lastModified, that.lastModified)
+               && Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(lastModified, configuration);
+    }
+
+    @Override
+    public String toString()
+    {
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("hash", hash());
+        node.put("lastModified", lastModified.toString());
+        node.set("configuration", MAPPER.valueToTree(configuration));
+        return node.toString();
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides storage and retrieval of configuration overlays for Cassandra instances.
+ *
+ * <p>The provider is a pluggable abstraction that decouples configuration storage from the
+ * Configuration Manager. Implementations may persist overlays locally (files), remotely
+ * (etcd, Consul, HTTP APIs), or in-memory (for testing).
+ *
+ * <p>The provider stores version-agnostic overlays and does not perform version-specific
+ * validation or merge logic. Validation against a version-aware schema and computing updated
+ * overlays (via {@link CassandraConfigurationOverlay#updated}) are the responsibility of the
+ * Configuration Manager.
+ */
+public interface ConfigurationProvider
+{
+    /**
+     * Retrieve the configuration overlay for the given Cassandra instance.
+     *
+     * @param instance the Cassandra instance metadata
+     * @return the configuration overlay snapshot, or {@code null} if no overlay exists for the instance
+     */
+    @Nullable
+    ConfigurationOverlaySnapshot getConfiguration(InstanceMetadata instance);
+
+    /**
+     * Atomically store a new configuration overlay snapshot for the given instance,
+     * subject to hash-based optimistic concurrency control.
+     *
+     * <p>The caller is responsible for computing the new snapshot (via
+     * {@link CassandraConfigurationOverlay#updated}). The provider only validates
+     * the original hash against the currently stored version and persists the result.
+     *
+     * @param instance     the Cassandra instance metadata
+     * @param originalHash the overlay hash from the previously read snapshot,
+     *                     or {@code null} if no overlay existed at the time of the read
+     * @param newSnapshot  the new snapshot to store
+     * @return {@code true} if the snapshot was stored successfully (hash matched),
+     *         {@code false} if a conflict was detected (hash mismatch)
+     */
+    boolean storeConfiguration(InstanceMetadata instance,
+                               @Nullable String originalHash,
+                               @NotNull ConfigurationOverlaySnapshot newSnapshot);
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationProvider.java
@@ -43,7 +43,7 @@ public interface ConfigurationProvider
      * @return the configuration overlay snapshot, or {@code null} if no overlay exists for the instance
      */
     @Nullable
-    ConfigurationOverlaySnapshot getConfiguration(InstanceMetadata instance);
+    ConfigurationOverlaySnapshot getOverlay(InstanceMetadata instance);
 
     /**
      * Atomically store a new configuration overlay snapshot for the given instance,
@@ -60,7 +60,7 @@ public interface ConfigurationProvider
      * @return {@code true} if the snapshot was stored successfully (hash matched),
      *         {@code false} if a conflict was detected (hash mismatch)
      */
-    boolean storeConfiguration(InstanceMetadata instance,
-                               @Nullable String originalHash,
-                               @NotNull ConfigurationOverlaySnapshot newSnapshot);
+    boolean storeOverlay(InstanceMetadata instance,
+                         @Nullable String originalHash,
+                         @NotNull ConfigurationOverlaySnapshot newSnapshot);
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProvider.java
@@ -36,15 +36,15 @@ public class InMemoryConfigurationProvider implements ConfigurationProvider
 
     @Override
     @Nullable
-    public ConfigurationOverlaySnapshot getConfiguration(InstanceMetadata instance)
+    public ConfigurationOverlaySnapshot getOverlay(InstanceMetadata instance)
     {
         return overlays.get(instance.id());
     }
 
     @Override
-    public boolean storeConfiguration(InstanceMetadata instance,
-                                      @Nullable String originalHash,
-                                      @NotNull ConfigurationOverlaySnapshot newSnapshot)
+    public boolean storeOverlay(InstanceMetadata instance,
+                                @Nullable String originalHash,
+                                @NotNull ConfigurationOverlaySnapshot newSnapshot)
     {
         Objects.requireNonNull(newSnapshot, "newSnapshot must not be null");
         Object lock = locks.computeIfAbsent(instance.id(), k -> new Object());

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProvider.java
@@ -32,7 +32,6 @@ import org.jetbrains.annotations.Nullable;
 public class InMemoryConfigurationProvider implements ConfigurationProvider
 {
     private final ConcurrentHashMap<Integer, ConfigurationOverlaySnapshot> overlays = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<Integer, Object> locks = new ConcurrentHashMap<>();
 
     @Override
     @Nullable
@@ -47,23 +46,17 @@ public class InMemoryConfigurationProvider implements ConfigurationProvider
                                 @NotNull ConfigurationOverlaySnapshot newSnapshot)
     {
         Objects.requireNonNull(newSnapshot, "newSnapshot must not be null");
-        Object lock = locks.computeIfAbsent(instance.id(), k -> new Object());
-        synchronized (lock)
-        {
-            ConfigurationOverlaySnapshot current = overlays.get(instance.id());
-
+        return overlays.compute(instance.id(), (k, current) -> {
             if (current == null && originalHash != null)
             {
-                return false;
+                return null;
             }
 
             if (current != null && (originalHash == null || !current.hash().equals(originalHash)))
             {
-                return false;
+                return current;
             }
-
-            overlays.put(instance.id(), newSnapshot);
-            return true;
-        }
+            return newSnapshot;
+        }) == newSnapshot;
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * In-memory implementation of {@link ConfigurationProvider} for testing and as a reference implementation.
+ * Stores configuration overlays in a {@link ConcurrentHashMap} keyed by instance ID.
+ */
+public class InMemoryConfigurationProvider implements ConfigurationProvider
+{
+    private final ConcurrentHashMap<Integer, ConfigurationOverlaySnapshot> overlays = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, Object> locks = new ConcurrentHashMap<>();
+
+    @Override
+    @Nullable
+    public ConfigurationOverlaySnapshot getConfiguration(InstanceMetadata instance)
+    {
+        return overlays.get(instance.id());
+    }
+
+    @Override
+    public boolean storeConfiguration(InstanceMetadata instance,
+                                      @Nullable String originalHash,
+                                      @NotNull ConfigurationOverlaySnapshot newSnapshot)
+    {
+        Objects.requireNonNull(newSnapshot, "newSnapshot must not be null");
+        Object lock = locks.computeIfAbsent(instance.id(), k -> new Object());
+        synchronized (lock)
+        {
+            ConfigurationOverlaySnapshot current = overlays.get(instance.id());
+
+            if (current == null && originalHash != null)
+            {
+                return false;
+            }
+
+            if (current != null && (originalHash == null || !current.hash().equals(originalHash)))
+            {
+                return false;
+            }
+
+            overlays.put(instance.id(), newSnapshot);
+            return true;
+        }
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.sidecar.configmanagement;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -64,7 +63,7 @@ class CassandraConfigurationOverlayTest
         updates.put("concurrent_reads", IntNode.valueOf(64));
         updates.put("storage_compatibility_mode", null);
 
-        CassandraConfigurationOverlay updated = overlay.updated(updates, null, null);
+        CassandraConfigurationOverlay updated = overlay.updated(updates, null);
 
         // concurrent_reads updated
         assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
@@ -75,21 +74,38 @@ class CassandraConfigurationOverlayTest
     }
 
     @Test
-    void testUpdatedAddsAndRemovesJvmOpts()
+    void testUpdatedUpsertsAndRemovesJvmOpts()
     {
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, Arrays.asList(
-            "-Dcassandra.available_processors=8",
-            "-Xmx4G"
-        ));
+        Map<String, String> jvmOpts = new LinkedHashMap<>();
+        jvmOpts.put("-Dcassandra.jmx.local.port", "7199");
+        jvmOpts.put("-Xmx", "4G");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, jvmOpts);
 
-        CassandraConfigurationOverlay updated = overlay.updated(
-            null,
-            Arrays.asList("-Xmx8G"),
-            Arrays.asList("-Xmx4G"));
+        Map<String, String> updates = new LinkedHashMap<>();
+        updates.put("-Xmx", "8G");
 
-        assertThat(updated.extraJvmOpts()).containsExactly(
-            "-Dcassandra.available_processors=8",
-            "-Xmx8G");
+        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
+
+        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of(
+            "-Dcassandra.jmx.local.port", "7199",
+            "-Xmx", "8G"));
+    }
+
+    @Test
+    void testUpdatedRemovesJvmOptWithNullValue()
+    {
+        Map<String, String> jvmOpts = new LinkedHashMap<>();
+        jvmOpts.put("-Dcassandra.jmx.local.port", "7199");
+        jvmOpts.put("-Xmx", "4G");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, jvmOpts);
+
+        Map<String, String> updates = new LinkedHashMap<>();
+        updates.put("-Xmx", null);
+
+        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
+
+        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of(
+            "-Dcassandra.jmx.local.port", "7199"));
     }
 
     @Test
@@ -97,11 +113,11 @@ class CassandraConfigurationOverlayTest
     {
         ObjectNode yaml = MAPPER.createObjectNode();
         yaml.put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
 
         CassandraConfigurationOverlay updated = overlay.updated(
             Collections.singletonMap("concurrent_reads", IntNode.valueOf(64)),
-            null, null);
+            null);
 
         assertThat(updated).isNotSameAs(overlay);
         assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
@@ -115,11 +131,11 @@ class CassandraConfigurationOverlayTest
         ObjectNode yaml = MAPPER.createObjectNode();
         yaml.put("concurrent_reads", 32);
         yaml.put("commitlog_sync", "periodic");
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
 
         assertThat(overlay.toString()).isEqualTo(
             "{\"cassandraYaml\":{\"concurrent_reads\":32,\"commitlog_sync\":\"periodic\"},"
-            + "\"extraJvmOpts\":[\"-Xmx4G\"]}");
+            + "\"extraJvmOpts\":{\"-Xmx\":\"4G\"}}");
     }
 
     @Test
@@ -128,6 +144,6 @@ class CassandraConfigurationOverlayTest
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, null);
 
         assertThat(overlay.toString()).isEqualTo(
-            "{\"cassandraYaml\":{},\"extraJvmOpts\":[]}");
+            "{\"cassandraYaml\":{},\"extraJvmOpts\":{}}");
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -18,74 +18,57 @@
 
 package org.apache.cassandra.sidecar.configmanagement;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.json.JsonObject;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link CassandraConfigurationOverlay}
  */
 class CassandraConfigurationOverlayTest
 {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    @Test
-    void testRejectsNonObjectCassandraYaml()
-    {
-        ArrayNode array = MAPPER.createArrayNode().add("not_an_object");
-
-        assertThatThrownBy(() -> new CassandraConfigurationOverlay(array, null))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("must be a JSON object");
-    }
-
     @Test
     void testUpdatedAppliesCassandraYamlChanges()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("concurrent_reads", 32);
-        yaml.put("memtable_flush_writers", 4);
-        yaml.put("storage_compatibility_mode", "CASSANDRA_4");
+        JsonObject yaml = new JsonObject()
+                          .put("concurrent_reads", 32)
+                          .put("memtable_flush_writers", 4)
+                          .put("storage_compatibility_mode", "CASSANDRA_4");
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
 
-        Map<String, JsonNode> updates = new LinkedHashMap<>();
-        updates.put("concurrent_reads", IntNode.valueOf(64));
+        Map<String, Object> updates = new LinkedHashMap<>();
+        updates.put("concurrent_reads", 64);
         updates.put("storage_compatibility_mode", null);
 
         CassandraConfigurationOverlay updated = overlay.updated(updates, null, null);
 
         // concurrent_reads updated
-        assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
+        assertThat(updated.cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
         // storage_compatibility_mode removed
-        assertThat(updated.cassandraYaml().has("storage_compatibility_mode")).isFalse();
+        assertThat(updated.cassandraYaml().containsKey("storage_compatibility_mode")).isFalse();
         // memtable_flush_writers preserved
-        assertThat(updated.cassandraYaml().get("memtable_flush_writers").asInt()).isEqualTo(4);
+        assertThat(updated.cassandraYaml().getInteger("memtable_flush_writers")).isEqualTo(4);
     }
 
     @Test
     void testUpdatedAddsAndRemovesJvmOpts()
     {
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, Arrays.asList(
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, List.of(
             "-Dcassandra.available_processors=8",
             "-Xmx4G"
         ));
 
         CassandraConfigurationOverlay updated = overlay.updated(
             null,
-            Arrays.asList("-Xmx8G"),
-            Arrays.asList("-Xmx4G"));
+            List.of("-Xmx8G"),
+            List.of("-Xmx4G"));
 
         assertThat(updated.extraJvmOpts()).containsExactly(
             "-Dcassandra.available_processors=8",
@@ -95,39 +78,37 @@ class CassandraConfigurationOverlayTest
     @Test
     void testConstructorDeepCopiesCassandraYaml()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("concurrent_reads", 32);
+        JsonObject yaml = new JsonObject().put("concurrent_reads", 32);
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
 
         yaml.put("concurrent_reads", 64);
 
-        assertThat(overlay.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(32);
+        assertThat(overlay.cassandraYaml().getInteger("concurrent_reads")).isEqualTo(32);
     }
 
     @Test
     void testUpdatedReturnsNewInstance()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        JsonObject yaml = new JsonObject().put("concurrent_reads", 32);
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, List.of("-Xmx4G"));
 
         CassandraConfigurationOverlay updated = overlay.updated(
-            Collections.singletonMap("concurrent_reads", IntNode.valueOf(64)),
+            Collections.singletonMap("concurrent_reads", 64),
             null, null);
 
         assertThat(updated).isNotSameAs(overlay);
-        assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
-        // Original is not modified by updated() — deepCopy used internally
-        assertThat(overlay.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(32);
+        assertThat(updated.cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
+        // Original is not modified by updated() — deep copy used internally
+        assertThat(overlay.cassandraYaml().getInteger("concurrent_reads")).isEqualTo(32);
     }
 
     @Test
     void testToString()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("concurrent_reads", 32);
-        yaml.put("commitlog_sync", "periodic");
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        JsonObject yaml = new JsonObject()
+                          .put("concurrent_reads", 32)
+                          .put("commitlog_sync", "periodic");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, List.of("-Xmx4G"));
 
         assertThat(overlay.toString()).isEqualTo(String.join("\n",
             "{",

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link CassandraConfigurationOverlay}
+ */
+class CassandraConfigurationOverlayTest
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void testRejectsNonObjectCassandraYaml()
+    {
+        ArrayNode array = MAPPER.createArrayNode().add("not_an_object");
+
+        assertThatThrownBy(() -> new CassandraConfigurationOverlay(array, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("must be a JSON object");
+    }
+
+    @Test
+    void testUpdatedAppliesCassandraYamlChanges()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("concurrent_reads", 32);
+        yaml.put("memtable_flush_writers", 4);
+        yaml.put("storage_compatibility_mode", "CASSANDRA_4");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
+
+        Map<String, JsonNode> updates = new LinkedHashMap<>();
+        updates.put("concurrent_reads", IntNode.valueOf(64));
+        updates.put("storage_compatibility_mode", null);
+
+        CassandraConfigurationOverlay updated = overlay.updated(updates, null, null);
+
+        // concurrent_reads updated
+        assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
+        // storage_compatibility_mode removed
+        assertThat(updated.cassandraYaml().has("storage_compatibility_mode")).isFalse();
+        // memtable_flush_writers preserved
+        assertThat(updated.cassandraYaml().get("memtable_flush_writers").asInt()).isEqualTo(4);
+    }
+
+    @Test
+    void testUpdatedAddsAndRemovesJvmOpts()
+    {
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, Arrays.asList(
+            "-Dcassandra.available_processors=8",
+            "-Xmx4G"
+        ));
+
+        CassandraConfigurationOverlay updated = overlay.updated(
+            null,
+            Arrays.asList("-Xmx8G"),
+            Arrays.asList("-Xmx4G"));
+
+        assertThat(updated.extraJvmOpts()).containsExactly(
+            "-Dcassandra.available_processors=8",
+            "-Xmx8G");
+    }
+
+    @Test
+    void testUpdatedReturnsNewInstance()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("concurrent_reads", 32);
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+
+        CassandraConfigurationOverlay updated = overlay.updated(
+            Collections.singletonMap("concurrent_reads", IntNode.valueOf(64)),
+            null, null);
+
+        assertThat(updated).isNotSameAs(overlay);
+        assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
+        // Original is not modified by updated() — deepCopy used internally
+        assertThat(overlay.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(32);
+    }
+
+    @Test
+    void testToString()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("concurrent_reads", 32);
+        yaml.put("commitlog_sync", "periodic");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+
+        assertThat(overlay.toString()).isEqualTo(
+            "{\"cassandraYaml\":{\"concurrent_reads\":32,\"commitlog_sync\":\"periodic\"},"
+            + "\"extraJvmOpts\":[\"-Xmx4G\"]}");
+    }
+
+    @Test
+    void testToStringEmpty()
+    {
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, null);
+
+        assertThat(overlay.toString()).isEqualTo(
+            "{\"cassandraYaml\":{},\"extraJvmOpts\":[]}");
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -86,9 +86,10 @@ class CassandraConfigurationOverlayTest
 
         CassandraConfigurationOverlay updated = overlay.updated(null, updates);
 
-        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of(
-            "-Dcassandra.jmx.local.port", "7199",
-            "-Xmx", "8G"));
+        Map<String, String> expected = new LinkedHashMap<>();
+        expected.put("-Dcassandra.jmx.local.port", "7199");
+        expected.put("-Xmx", "8G");
+        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(expected);
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.sidecar.configmanagement;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ class CassandraConfigurationOverlayTest
         updates.put("concurrent_reads", 64);
         updates.put("storage_compatibility_mode", null);
 
-        CassandraConfigurationOverlay updated = overlay.updated(updates, null, null);
+        CassandraConfigurationOverlay updated = overlay.updated(updates, null);
 
         // concurrent_reads updated
         assertThat(updated.cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
@@ -58,21 +57,39 @@ class CassandraConfigurationOverlayTest
     }
 
     @Test
-    void testUpdatedAddsAndRemovesJvmOpts()
+    void testUpdatedUpsertsAndRemovesJvmOpts()
     {
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, List.of(
-            "-Dcassandra.available_processors=8",
-            "-Xmx4G"
-        ));
+        Map<String, String> jvmOpts = new LinkedHashMap<>();
+        jvmOpts.put("-Dcassandra.jmx.local.port", "7199");
+        jvmOpts.put("-Xmx", "4G");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, jvmOpts);
 
-        CassandraConfigurationOverlay updated = overlay.updated(
-            null,
-            List.of("-Xmx8G"),
-            List.of("-Xmx4G"));
+        Map<String, String> updates = new LinkedHashMap<>();
+        updates.put("-Xmx", "8G");
 
-        assertThat(updated.extraJvmOpts()).containsExactly(
-            "-Dcassandra.available_processors=8",
-            "-Xmx8G");
+        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
+
+        Map<String, String> expected = new LinkedHashMap<>();
+        expected.put("-Dcassandra.jmx.local.port", "7199");
+        expected.put("-Xmx", "8G");
+        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(expected);
+    }
+
+    @Test
+    void testUpdatedRemovesJvmOptWithNullValue()
+    {
+        Map<String, String> jvmOpts = new LinkedHashMap<>();
+        jvmOpts.put("-Dcassandra.jmx.local.port", "7199");
+        jvmOpts.put("-Xmx", "4G");
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, jvmOpts);
+
+        Map<String, String> updates = new LinkedHashMap<>();
+        updates.put("-Xmx", null);
+
+        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
+
+        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of(
+            "-Dcassandra.jmx.local.port", "7199"));
     }
 
     @Test
@@ -90,11 +107,11 @@ class CassandraConfigurationOverlayTest
     void testUpdatedReturnsNewInstance()
     {
         JsonObject yaml = new JsonObject().put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, List.of("-Xmx4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
 
         CassandraConfigurationOverlay updated = overlay.updated(
             Collections.singletonMap("concurrent_reads", 64),
-            null, null);
+            null);
 
         assertThat(updated).isNotSameAs(overlay);
         assertThat(updated.cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
@@ -108,7 +125,7 @@ class CassandraConfigurationOverlayTest
         JsonObject yaml = new JsonObject()
                           .put("concurrent_reads", 32)
                           .put("commitlog_sync", "periodic");
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, List.of("-Xmx4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
 
         assertThat(overlay.toString()).isEqualTo(String.join("\n",
             "{",
@@ -116,7 +133,9 @@ class CassandraConfigurationOverlayTest
             "    \"concurrent_reads\" : 32,",
             "    \"commitlog_sync\" : \"periodic\"",
             "  },",
-            "  \"extraJvmOpts\" : [ \"-Xmx4G\" ]",
+            "  \"extraJvmOpts\" : {",
+            "    \"-Xmx\" : \"4G\"",
+            "  }",
             "}"));
     }
 
@@ -128,7 +147,7 @@ class CassandraConfigurationOverlayTest
         assertThat(overlay.toString()).isEqualTo(String.join("\n",
             "{",
             "  \"cassandraYaml\" : { },",
-            "  \"extraJvmOpts\" : [ ]",
+            "  \"extraJvmOpts\" : { }",
             "}"));
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -145,9 +145,16 @@ class CassandraConfigurationOverlayTest
         yaml.put("commitlog_sync", "periodic");
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
 
-        assertThat(overlay.toString()).isEqualTo(
-            "{\"cassandraYaml\":{\"concurrent_reads\":32,\"commitlog_sync\":\"periodic\"},"
-            + "\"extraJvmOpts\":{\"-Xmx\":\"4G\"}}");
+        assertThat(overlay.toString()).isEqualTo(String.join("\n",
+            "{",
+            "  \"cassandraYaml\" : {",
+            "    \"concurrent_reads\" : 32,",
+            "    \"commitlog_sync\" : \"periodic\"",
+            "  },",
+            "  \"extraJvmOpts\" : {",
+            "    \"-Xmx\" : \"4G\"",
+            "  }",
+            "}"));
     }
 
     @Test
@@ -155,7 +162,10 @@ class CassandraConfigurationOverlayTest
     {
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, null);
 
-        assertThat(overlay.toString()).isEqualTo(
-            "{\"cassandraYaml\":{},\"extraJvmOpts\":{}}");
+        assertThat(overlay.toString()).isEqualTo(String.join("\n",
+            "{",
+            "  \"cassandraYaml\" : { },",
+            "  \"extraJvmOpts\" : { }",
+            "}"));
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.sidecar.configmanagement;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -63,7 +64,7 @@ class CassandraConfigurationOverlayTest
         updates.put("concurrent_reads", IntNode.valueOf(64));
         updates.put("storage_compatibility_mode", null);
 
-        CassandraConfigurationOverlay updated = overlay.updated(updates, null);
+        CassandraConfigurationOverlay updated = overlay.updated(updates, null, null);
 
         // concurrent_reads updated
         assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
@@ -74,39 +75,21 @@ class CassandraConfigurationOverlayTest
     }
 
     @Test
-    void testUpdatedUpsertsAndRemovesJvmOpts()
+    void testUpdatedAddsAndRemovesJvmOpts()
     {
-        Map<String, String> jvmOpts = new LinkedHashMap<>();
-        jvmOpts.put("-Dcassandra.jmx.local.port", "7199");
-        jvmOpts.put("-Xmx", "4G");
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, jvmOpts);
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, Arrays.asList(
+            "-Dcassandra.available_processors=8",
+            "-Xmx4G"
+        ));
 
-        Map<String, String> updates = new LinkedHashMap<>();
-        updates.put("-Xmx", "8G");
+        CassandraConfigurationOverlay updated = overlay.updated(
+            null,
+            Arrays.asList("-Xmx8G"),
+            Arrays.asList("-Xmx4G"));
 
-        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
-
-        Map<String, String> expected = new LinkedHashMap<>();
-        expected.put("-Dcassandra.jmx.local.port", "7199");
-        expected.put("-Xmx", "8G");
-        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(expected);
-    }
-
-    @Test
-    void testUpdatedRemovesJvmOptWithNullValue()
-    {
-        Map<String, String> jvmOpts = new LinkedHashMap<>();
-        jvmOpts.put("-Dcassandra.jmx.local.port", "7199");
-        jvmOpts.put("-Xmx", "4G");
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, jvmOpts);
-
-        Map<String, String> updates = new LinkedHashMap<>();
-        updates.put("-Xmx", null);
-
-        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
-
-        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of(
-            "-Dcassandra.jmx.local.port", "7199"));
+        assertThat(updated.extraJvmOpts()).containsExactly(
+            "-Dcassandra.available_processors=8",
+            "-Xmx8G");
     }
 
     @Test
@@ -126,11 +109,11 @@ class CassandraConfigurationOverlayTest
     {
         ObjectNode yaml = MAPPER.createObjectNode();
         yaml.put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
 
         CassandraConfigurationOverlay updated = overlay.updated(
             Collections.singletonMap("concurrent_reads", IntNode.valueOf(64)),
-            null);
+            null, null);
 
         assertThat(updated).isNotSameAs(overlay);
         assertThat(updated.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(64);
@@ -144,7 +127,7 @@ class CassandraConfigurationOverlayTest
         ObjectNode yaml = MAPPER.createObjectNode();
         yaml.put("concurrent_reads", 32);
         yaml.put("commitlog_sync", "periodic");
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
 
         assertThat(overlay.toString()).isEqualTo(String.join("\n",
             "{",
@@ -152,9 +135,7 @@ class CassandraConfigurationOverlayTest
             "    \"concurrent_reads\" : 32,",
             "    \"commitlog_sync\" : \"periodic\"",
             "  },",
-            "  \"extraJvmOpts\" : {",
-            "    \"-Xmx\" : \"4G\"",
-            "  }",
+            "  \"extraJvmOpts\" : [ \"-Xmx4G\" ]",
             "}"));
     }
 
@@ -166,7 +147,7 @@ class CassandraConfigurationOverlayTest
         assertThat(overlay.toString()).isEqualTo(String.join("\n",
             "{",
             "  \"cassandraYaml\" : { },",
-            "  \"extraJvmOpts\" : { }",
+            "  \"extraJvmOpts\" : [ ]",
             "}"));
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import io.vertx.core.json.JsonObject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link CassandraConfigurationOverlay}
@@ -90,6 +91,34 @@ class CassandraConfigurationOverlayTest
 
         assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of(
             "-Dcassandra.jmx.local.port", "7199"));
+    }
+
+    @Test
+    void testUpdatedRejectsConflictingBooleanOpts()
+    {
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, Map.of("-XX:+UseG1GC", ""));
+
+        Map<String, String> updates = new LinkedHashMap<>();
+        updates.put("-XX:-UseG1GC", "");
+
+        assertThatThrownBy(() -> overlay.updated(null, updates))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("-XX:+UseG1GC")
+            .hasMessageContaining("-XX:-UseG1GC");
+    }
+
+    @Test
+    void testUpdatedAllowsReplacingBooleanOpt()
+    {
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(null, Map.of("-XX:+UseG1GC", ""));
+
+        Map<String, String> updates = new LinkedHashMap<>();
+        updates.put("-XX:+UseG1GC", null);
+        updates.put("-XX:-UseG1GC", "");
+
+        CassandraConfigurationOverlay updated = overlay.updated(null, updates);
+
+        assertThat(updated.extraJvmOpts()).containsExactlyEntriesOf(Map.of("-XX:-UseG1GC", ""));
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlayTest.java
@@ -109,6 +109,18 @@ class CassandraConfigurationOverlayTest
     }
 
     @Test
+    void testConstructorDeepCopiesCassandraYaml()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("concurrent_reads", 32);
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
+
+        yaml.put("concurrent_reads", 64);
+
+        assertThat(overlay.cassandraYaml().get("concurrent_reads").asInt()).isEqualTo(32);
+    }
+
+    @Test
     void testUpdatedReturnsNewInstance()
     {
         ObjectNode yaml = MAPPER.createObjectNode();

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -113,10 +113,19 @@ class ConfigurationOverlaySnapshotTest
 
         ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(timestamp, overlay);
 
-        String expected = "{\"hash\":\"" + snapshot.hash() + "\","
-                          + "\"lastModified\":\"2026-02-20T14:32:18Z\","
-                          + "\"configuration\":{\"cassandraYaml\":{\"concurrent_reads\":32},"
-                          + "\"extraJvmOpts\":{\"-Xmx\":\"4G\"}}}";
+        String expected = String.join("\n",
+            "{",
+            "  \"hash\" : \"" + snapshot.hash() + "\",",
+            "  \"lastModified\" : \"2026-02-20T14:32:18Z\",",
+            "  \"configuration\" : {",
+            "    \"cassandraYaml\" : {",
+            "      \"concurrent_reads\" : 32",
+            "    },",
+            "    \"extraJvmOpts\" : {",
+            "      \"-Xmx\" : \"4G\"",
+            "    }",
+            "  }",
+            "}");
         assertThat(snapshot.toString()).isEqualTo(expected);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -118,7 +118,7 @@ class ConfigurationOverlaySnapshotTest
             "{",
             "  \"hash\" : \"" + snapshot.hash() + "\",",
             "  \"lastModified\" : \"2026-02-20T14:32:18Z\",",
-            "  \"configuration\" : {",
+            "  \"overlay\" : {",
             "    \"cassandraYaml\" : {",
             "      \"concurrent_reads\" : 32",
             "    },",

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -19,7 +19,7 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.time.Instant;
-import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,8 +43,8 @@ class ConfigurationOverlaySnapshotTest
                            .put("concurrent_reads", 32)
                            .put("memtable_flush_writers", 4);
 
-        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Arrays.asList("-Xmx4G"));
-        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Map.of("-Xmx", "4G"));
+        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Map.of("-Xmx", "4G"));
 
         ConfigurationOverlaySnapshot snapshot1 = new ConfigurationOverlaySnapshot(Instant.now(), overlay1);
         ConfigurationOverlaySnapshot snapshot2 = new ConfigurationOverlaySnapshot(Instant.now(), overlay2);
@@ -99,7 +99,7 @@ class ConfigurationOverlaySnapshotTest
     void testToString()
     {
         JsonObject yaml = new JsonObject().put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
         Instant timestamp = Instant.parse("2026-02-20T14:32:18Z");
 
         ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(timestamp, overlay);
@@ -112,7 +112,9 @@ class ConfigurationOverlaySnapshotTest
             "    \"cassandraYaml\" : {",
             "      \"concurrent_reads\" : 32",
             "    },",
-            "    \"extraJvmOpts\" : [ \"-Xmx4G\" ]",
+            "    \"extraJvmOpts\" : {",
+            "      \"-Xmx\" : \"4G\"",
+            "    }",
             "  }",
             "}");
         assertThat(snapshot.toString()).isEqualTo(expected);

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -19,8 +19,7 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.time.Instant;
-import java.util.Collections;
-import java.util.Map;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -47,8 +46,8 @@ class ConfigurationOverlaySnapshotTest
         yaml2.put("concurrent_reads", 32);
         yaml2.put("memtable_flush_writers", 4);
 
-        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Collections.singletonMap("-Xmx", "4G"));
-        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Collections.singletonMap("-Xmx", "4G"));
+        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Arrays.asList("-Xmx4G"));
 
         ConfigurationOverlaySnapshot snapshot1 = new ConfigurationOverlaySnapshot(Instant.now(), overlay1);
         ConfigurationOverlaySnapshot snapshot2 = new ConfigurationOverlaySnapshot(Instant.now(), overlay2);
@@ -109,7 +108,7 @@ class ConfigurationOverlaySnapshotTest
     {
         ObjectNode yaml = MAPPER.createObjectNode();
         yaml.put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
         Instant timestamp = Instant.parse("2026-02-20T14:32:18Z");
 
         ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(timestamp, overlay);
@@ -122,9 +121,7 @@ class ConfigurationOverlaySnapshotTest
             "    \"cassandraYaml\" : {",
             "      \"concurrent_reads\" : 32",
             "    },",
-            "    \"extraJvmOpts\" : {",
-            "      \"-Xmx\" : \"4G\"",
-            "    }",
+            "    \"extraJvmOpts\" : [ \"-Xmx4G\" ]",
             "  }",
             "}");
         assertThat(snapshot.toString()).isEqualTo(expected);

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -46,8 +47,8 @@ class ConfigurationOverlaySnapshotTest
         yaml2.put("concurrent_reads", 32);
         yaml2.put("memtable_flush_writers", 4);
 
-        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Arrays.asList("-Xmx4G"));
-        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Collections.singletonMap("-Xmx", "4G"));
+        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Collections.singletonMap("-Xmx", "4G"));
 
         ConfigurationOverlaySnapshot snapshot1 = new ConfigurationOverlaySnapshot(Instant.now(), overlay1);
         ConfigurationOverlaySnapshot snapshot2 = new ConfigurationOverlaySnapshot(Instant.now(), overlay2);

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConfigurationOverlaySnapshot}
+ */
+class ConfigurationOverlaySnapshotTest
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void testHashIsDeterministic()
+    {
+        ObjectNode yaml1 = MAPPER.createObjectNode();
+        yaml1.put("concurrent_reads", 32);
+        yaml1.put("memtable_flush_writers", 4);
+
+        ObjectNode yaml2 = MAPPER.createObjectNode();
+        yaml2.put("concurrent_reads", 32);
+        yaml2.put("memtable_flush_writers", 4);
+
+        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Arrays.asList("-Xmx4G"));
+
+        ConfigurationOverlaySnapshot snapshot1 = new ConfigurationOverlaySnapshot(Instant.now(), overlay1);
+        ConfigurationOverlaySnapshot snapshot2 = new ConfigurationOverlaySnapshot(Instant.now(), overlay2);
+
+        assertThat(snapshot1.hash()).isEqualTo(snapshot2.hash());
+    }
+
+    @Test
+    void testHashChangesWithDifferentContent()
+    {
+        ObjectNode yaml1 = MAPPER.createObjectNode();
+        yaml1.put("concurrent_reads", 32);
+
+        ObjectNode yaml2 = MAPPER.createObjectNode();
+        yaml2.put("concurrent_reads", 64);
+
+        CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, null);
+        CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, null);
+
+        ConfigurationOverlaySnapshot snapshot1 = new ConfigurationOverlaySnapshot(Instant.now(), overlay1);
+        ConfigurationOverlaySnapshot snapshot2 = new ConfigurationOverlaySnapshot(Instant.now(), overlay2);
+
+        assertThat(snapshot1.hash()).isNotEqualTo(snapshot2.hash());
+    }
+
+    @Test
+    void testHashIsCached()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("commitlog_sync", "periodic");
+
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
+        ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(Instant.now(), overlay);
+
+        String firstCall = snapshot.hash();
+        String secondCall = snapshot.hash();
+
+        // Same String instance (referential equality) proves caching
+        assertThat(firstCall).isSameAs(secondCall);
+    }
+
+    @Test
+    void testHashHasSha256Prefix()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("native_transport_port", 9042);
+
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
+        ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(Instant.now(), overlay);
+
+        assertThat(snapshot.hash()).startsWith("sha256:");
+        // SHA-256 produces 64 hex chars, plus "sha256:" prefix = 71 chars
+        assertThat(snapshot.hash()).hasSize(71);
+    }
+
+    @Test
+    void testToString()
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put("concurrent_reads", 32);
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        Instant timestamp = Instant.parse("2026-02-20T14:32:18Z");
+
+        ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(timestamp, overlay);
+
+        String expected = "{\"hash\":\"" + snapshot.hash() + "\","
+                          + "\"lastModified\":\"2026-02-20T14:32:18Z\","
+                          + "\"configuration\":{\"cassandraYaml\":{\"concurrent_reads\":32},"
+                          + "\"extraJvmOpts\":[\"-Xmx4G\"]}}";
+        assertThat(snapshot.toString()).isEqualTo(expected);
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -23,8 +23,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.json.JsonObject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,18 +32,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class ConfigurationOverlaySnapshotTest
 {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     @Test
     void testHashIsDeterministic()
     {
-        ObjectNode yaml1 = MAPPER.createObjectNode();
-        yaml1.put("concurrent_reads", 32);
-        yaml1.put("memtable_flush_writers", 4);
+        JsonObject yaml1 = new JsonObject()
+                           .put("concurrent_reads", 32)
+                           .put("memtable_flush_writers", 4);
 
-        ObjectNode yaml2 = MAPPER.createObjectNode();
-        yaml2.put("concurrent_reads", 32);
-        yaml2.put("memtable_flush_writers", 4);
+        JsonObject yaml2 = new JsonObject()
+                           .put("concurrent_reads", 32)
+                           .put("memtable_flush_writers", 4);
 
         CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, Arrays.asList("-Xmx4G"));
         CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, Arrays.asList("-Xmx4G"));
@@ -58,11 +55,8 @@ class ConfigurationOverlaySnapshotTest
     @Test
     void testHashChangesWithDifferentContent()
     {
-        ObjectNode yaml1 = MAPPER.createObjectNode();
-        yaml1.put("concurrent_reads", 32);
-
-        ObjectNode yaml2 = MAPPER.createObjectNode();
-        yaml2.put("concurrent_reads", 64);
+        JsonObject yaml1 = new JsonObject().put("concurrent_reads", 32);
+        JsonObject yaml2 = new JsonObject().put("concurrent_reads", 64);
 
         CassandraConfigurationOverlay overlay1 = new CassandraConfigurationOverlay(yaml1, null);
         CassandraConfigurationOverlay overlay2 = new CassandraConfigurationOverlay(yaml2, null);
@@ -76,8 +70,7 @@ class ConfigurationOverlaySnapshotTest
     @Test
     void testHashIsCached()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("commitlog_sync", "periodic");
+        JsonObject yaml = new JsonObject().put("commitlog_sync", "periodic");
 
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
         ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(Instant.now(), overlay);
@@ -92,8 +85,7 @@ class ConfigurationOverlaySnapshotTest
     @Test
     void testHashHasSha256Prefix()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("native_transport_port", 9042);
+        JsonObject yaml = new JsonObject().put("native_transport_port", 9042);
 
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
         ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(Instant.now(), overlay);
@@ -106,8 +98,7 @@ class ConfigurationOverlaySnapshotTest
     @Test
     void testToString()
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put("concurrent_reads", 32);
+        JsonObject yaml = new JsonObject().put("concurrent_reads", 32);
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
         Instant timestamp = Instant.parse("2026-02-20T14:32:18Z");
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -19,7 +19,7 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.time.Instant;
-import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -108,7 +108,7 @@ class ConfigurationOverlaySnapshotTest
     {
         ObjectNode yaml = MAPPER.createObjectNode();
         yaml.put("concurrent_reads", 32);
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Arrays.asList("-Xmx4G"));
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Map.of("-Xmx", "4G"));
         Instant timestamp = Instant.parse("2026-02-20T14:32:18Z");
 
         ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(timestamp, overlay);
@@ -116,7 +116,7 @@ class ConfigurationOverlaySnapshotTest
         String expected = "{\"hash\":\"" + snapshot.hash() + "\","
                           + "\"lastModified\":\"2026-02-20T14:32:18Z\","
                           + "\"configuration\":{\"cassandraYaml\":{\"concurrent_reads\":32},"
-                          + "\"extraJvmOpts\":[\"-Xmx4G\"]}}";
+                          + "\"extraJvmOpts\":{\"-Xmx\":\"4G\"}}}";
         assertThat(snapshot.toString()).isEqualTo(expected);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProviderTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProviderTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link InMemoryConfigurationProvider}
+ */
+class InMemoryConfigurationProviderTest
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private InMemoryConfigurationProvider provider;
+    private InstanceMetadata instance1;
+    private InstanceMetadata instance2;
+
+    @BeforeEach
+    void setUp()
+    {
+        provider = new InMemoryConfigurationProvider();
+        instance1 = mockInstance(1);
+        instance2 = mockInstance(2);
+    }
+
+    @Test
+    void testGetReturnsNullForUnknownInstance()
+    {
+        assertThat(provider.getConfiguration(instance1)).isNull();
+    }
+
+    @Test
+    void testStoreAndGet()
+    {
+        ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", 64);
+
+        boolean stored = provider.storeConfiguration(instance1, null, snapshot);
+
+        assertThat(stored).isTrue();
+        ConfigurationOverlaySnapshot fetched = provider.getConfiguration(instance1);
+        assertThat(fetched).isSameAs(snapshot);
+    }
+
+    @Test
+    void testStoreReturnsTrueOnSuccess()
+    {
+        ConfigurationOverlaySnapshot snapshot = createSnapshot("memtable_flush_writers", 8);
+
+        assertThat(provider.storeConfiguration(instance1, null, snapshot)).isTrue();
+    }
+
+    @Test
+    void testStoreReturnsFalseOnHashMismatch()
+    {
+        ConfigurationOverlaySnapshot initial = createSnapshot("concurrent_reads", 32);
+        provider.storeConfiguration(instance1, null, initial);
+
+        ConfigurationOverlaySnapshot update = createSnapshot("concurrent_reads", 64);
+        assertThat(provider.storeConfiguration(instance1, "sha256:stale", update)).isFalse();
+
+        // Original is preserved
+        assertThat(provider.getConfiguration(instance1)).isSameAs(initial);
+    }
+
+    @Test
+    void testStoreReturnsFalseWhenNoOverlayButHashProvided()
+    {
+        ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", 32);
+        assertThat(provider.storeConfiguration(instance1, "sha256:unexpected", snapshot)).isFalse();
+        assertThat(provider.getConfiguration(instance1)).isNull();
+    }
+
+    @Test
+    void testStoreReturnsFalseWhenOverlayExistsButNullHashProvided()
+    {
+        ConfigurationOverlaySnapshot initial = createSnapshot("concurrent_reads", 32);
+        provider.storeConfiguration(instance1, null, initial);
+
+        ConfigurationOverlaySnapshot update = createSnapshot("concurrent_reads", 64);
+        assertThat(provider.storeConfiguration(instance1, null, update)).isFalse();
+
+        // Original is preserved
+        assertThat(provider.getConfiguration(instance1)).isSameAs(initial);
+    }
+
+    @Test
+    void testInstanceIsolation()
+    {
+        ConfigurationOverlaySnapshot snap1 = createSnapshot("concurrent_reads", 32);
+        ConfigurationOverlaySnapshot snap2 = createSnapshot("concurrent_reads", 64);
+
+        provider.storeConfiguration(instance1, null, snap1);
+        provider.storeConfiguration(instance2, null, snap2);
+
+        assertThat(provider.getConfiguration(instance1)).isSameAs(snap1);
+        assertThat(provider.getConfiguration(instance2)).isSameAs(snap2);
+    }
+
+    @Test
+    void testConcurrentStoresDifferentInstances() throws Exception
+    {
+        int instanceCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(instanceCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < instanceCount; i++)
+        {
+            int instanceId = i;
+            futures.add(executor.submit(() ->
+            {
+                startLatch.await();
+                InstanceMetadata instance = mockInstance(instanceId);
+                ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", instanceId * 10);
+                return provider.storeConfiguration(instance, null, snapshot);
+            }));
+        }
+
+        startLatch.countDown();
+        for (Future<Boolean> future : futures)
+        {
+            assertThat(future.get(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        for (int i = 0; i < instanceCount; i++)
+        {
+            assertThat(provider.getConfiguration(mockInstance(i))).isNotNull();
+        }
+
+        executor.shutdown();
+    }
+
+    @Test
+    void testConcurrentStoresSameInstance() throws Exception
+    {
+        ConfigurationOverlaySnapshot initial = createSnapshot("concurrent_reads", 32);
+        provider.storeConfiguration(instance1, null, initial);
+        String hashBeforeRace = initial.hash();
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicInteger successes = new AtomicInteger(0);
+        AtomicInteger conflicts = new AtomicInteger(0);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++)
+        {
+            int value = (i + 1) * 100;
+            futures.add(executor.submit(() ->
+            {
+                try
+                {
+                    startLatch.await();
+                    ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", value);
+                    boolean stored = provider.storeConfiguration(instance1, hashBeforeRace, snapshot);
+                    if (stored)
+                    {
+                        successes.incrementAndGet();
+                    }
+                    else
+                    {
+                        conflicts.incrementAndGet();
+                    }
+                }
+                catch (InterruptedException e)
+                {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        startLatch.countDown();
+        for (Future<?> future : futures)
+        {
+            future.get(5, TimeUnit.SECONDS);
+        }
+
+        assertThat(successes.get()).isEqualTo(1);
+        assertThat(conflicts.get()).isEqualTo(threadCount - 1);
+
+        executor.shutdown();
+    }
+
+    private static ConfigurationOverlaySnapshot createSnapshot(String field, int value)
+    {
+        ObjectNode yaml = MAPPER.createObjectNode();
+        yaml.put(field, value);
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
+        return new ConfigurationOverlaySnapshot(Instant.now(), overlay);
+    }
+
+    private static InstanceMetadata mockInstance(int id)
+    {
+        InstanceMetadata instance = mock(InstanceMetadata.class);
+        when(instance.id()).thenReturn(id);
+        return instance;
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProviderTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProviderTest.java
@@ -61,7 +61,7 @@ class InMemoryConfigurationProviderTest
     @Test
     void testGetReturnsNullForUnknownInstance()
     {
-        assertThat(provider.getConfiguration(instance1)).isNull();
+        assertThat(provider.getOverlay(instance1)).isNull();
     }
 
     @Test
@@ -69,10 +69,10 @@ class InMemoryConfigurationProviderTest
     {
         ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", 64);
 
-        boolean stored = provider.storeConfiguration(instance1, null, snapshot);
+        boolean stored = provider.storeOverlay(instance1, null, snapshot);
 
         assertThat(stored).isTrue();
-        ConfigurationOverlaySnapshot fetched = provider.getConfiguration(instance1);
+        ConfigurationOverlaySnapshot fetched = provider.getOverlay(instance1);
         assertThat(fetched).isSameAs(snapshot);
     }
 
@@ -81,41 +81,41 @@ class InMemoryConfigurationProviderTest
     {
         ConfigurationOverlaySnapshot snapshot = createSnapshot("memtable_flush_writers", 8);
 
-        assertThat(provider.storeConfiguration(instance1, null, snapshot)).isTrue();
+        assertThat(provider.storeOverlay(instance1, null, snapshot)).isTrue();
     }
 
     @Test
     void testStoreReturnsFalseOnHashMismatch()
     {
         ConfigurationOverlaySnapshot initial = createSnapshot("concurrent_reads", 32);
-        provider.storeConfiguration(instance1, null, initial);
+        provider.storeOverlay(instance1, null, initial);
 
         ConfigurationOverlaySnapshot update = createSnapshot("concurrent_reads", 64);
-        assertThat(provider.storeConfiguration(instance1, "sha256:stale", update)).isFalse();
+        assertThat(provider.storeOverlay(instance1, "sha256:stale", update)).isFalse();
 
         // Original is preserved
-        assertThat(provider.getConfiguration(instance1)).isSameAs(initial);
+        assertThat(provider.getOverlay(instance1)).isSameAs(initial);
     }
 
     @Test
     void testStoreReturnsFalseWhenNoOverlayButHashProvided()
     {
         ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", 32);
-        assertThat(provider.storeConfiguration(instance1, "sha256:unexpected", snapshot)).isFalse();
-        assertThat(provider.getConfiguration(instance1)).isNull();
+        assertThat(provider.storeOverlay(instance1, "sha256:unexpected", snapshot)).isFalse();
+        assertThat(provider.getOverlay(instance1)).isNull();
     }
 
     @Test
     void testStoreReturnsFalseWhenOverlayExistsButNullHashProvided()
     {
         ConfigurationOverlaySnapshot initial = createSnapshot("concurrent_reads", 32);
-        provider.storeConfiguration(instance1, null, initial);
+        provider.storeOverlay(instance1, null, initial);
 
         ConfigurationOverlaySnapshot update = createSnapshot("concurrent_reads", 64);
-        assertThat(provider.storeConfiguration(instance1, null, update)).isFalse();
+        assertThat(provider.storeOverlay(instance1, null, update)).isFalse();
 
         // Original is preserved
-        assertThat(provider.getConfiguration(instance1)).isSameAs(initial);
+        assertThat(provider.getOverlay(instance1)).isSameAs(initial);
     }
 
     @Test
@@ -124,11 +124,11 @@ class InMemoryConfigurationProviderTest
         ConfigurationOverlaySnapshot snap1 = createSnapshot("concurrent_reads", 32);
         ConfigurationOverlaySnapshot snap2 = createSnapshot("concurrent_reads", 64);
 
-        provider.storeConfiguration(instance1, null, snap1);
-        provider.storeConfiguration(instance2, null, snap2);
+        provider.storeOverlay(instance1, null, snap1);
+        provider.storeOverlay(instance2, null, snap2);
 
-        assertThat(provider.getConfiguration(instance1)).isSameAs(snap1);
-        assertThat(provider.getConfiguration(instance2)).isSameAs(snap2);
+        assertThat(provider.getOverlay(instance1)).isSameAs(snap1);
+        assertThat(provider.getOverlay(instance2)).isSameAs(snap2);
     }
 
     @Test
@@ -147,7 +147,7 @@ class InMemoryConfigurationProviderTest
                 startLatch.await();
                 InstanceMetadata instance = mockInstance(instanceId);
                 ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", instanceId * 10);
-                return provider.storeConfiguration(instance, null, snapshot);
+                return provider.storeOverlay(instance, null, snapshot);
             }));
         }
 
@@ -159,7 +159,7 @@ class InMemoryConfigurationProviderTest
 
         for (int i = 0; i < instanceCount; i++)
         {
-            assertThat(provider.getConfiguration(mockInstance(i))).isNotNull();
+            assertThat(provider.getOverlay(mockInstance(i))).isNotNull();
         }
 
         executor.shutdown();
@@ -169,7 +169,7 @@ class InMemoryConfigurationProviderTest
     void testConcurrentStoresSameInstance() throws Exception
     {
         ConfigurationOverlaySnapshot initial = createSnapshot("concurrent_reads", 32);
-        provider.storeConfiguration(instance1, null, initial);
+        provider.storeOverlay(instance1, null, initial);
         String hashBeforeRace = initial.hash();
 
         int threadCount = 10;
@@ -188,7 +188,7 @@ class InMemoryConfigurationProviderTest
                 {
                     startLatch.await();
                     ConfigurationOverlaySnapshot snapshot = createSnapshot("concurrent_reads", value);
-                    boolean stored = provider.storeConfiguration(instance1, hashBeforeRace, snapshot);
+                    boolean stored = provider.storeOverlay(instance1, hashBeforeRace, snapshot);
                     if (stored)
                     {
                         successes.incrementAndGet();

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProviderTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/InMemoryConfigurationProviderTest.java
@@ -31,8 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.vertx.core.json.JsonObject;
 import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,8 +43,6 @@ import static org.mockito.Mockito.when;
  */
 class InMemoryConfigurationProviderTest
 {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
     private InMemoryConfigurationProvider provider;
     private InstanceMetadata instance1;
     private InstanceMetadata instance2;
@@ -219,8 +216,7 @@ class InMemoryConfigurationProviderTest
 
     private static ConfigurationOverlaySnapshot createSnapshot(String field, int value)
     {
-        ObjectNode yaml = MAPPER.createObjectNode();
-        yaml.put(field, value);
+        JsonObject yaml = new JsonObject().put(field, value);
         CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, null);
         return new ConfigurationOverlaySnapshot(Instant.now(), overlay);
     }


### PR DESCRIPTION
## Summary

Introduces the pluggable overlay storage abstraction as defined in CEP-62 for managing Cassandra configuration via Sidecar.

- **CassandraConfigurationOverlay**: Immutable model with version-agnostic `cassandraYaml` (JsonNode) and `extraJvmOpts`, with `updated()` centralizing merge logic for both components
- **ConfigurationOverlaySnapshot**: Wrapper with lazily computed cached SHA-256 content hash and last modified timestamp
- **ConfigurationProvider**: Pluggable storage interface with `getConfiguration` and `storeConfiguration` using hash-based optimistic concurrency
- **InMemoryConfigurationProvider**: Sample implementation with per-instance locking

## Test Plan

- CassandraConfigurationOverlayTest: object validation, yaml and jvm opts merge
- ConfigurationOverlaySnapshotTest: hash determinism, caching, format
- InMemoryConfigurationProviderTest: store/get, optimistic concurrency, instance isolation, concurrent access
