### PR TITLE
CASSSIDECAR-470: Added validations for Live migration configuration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.4.0
 -----
+ * Added validations for Live migration configuration (CASSSIDECAR-470)
  * Route CDC events to topics by corresponding topic format configuration (CASSSIDECAR-453)
  * Add Docker Compose setup for local CDC demo (Cassandra → Sidecar → Kafka) (CASSSIDECAR-419)
  * Scope all CDC dependencies exclusively to CdcModule (CASSSIDECAR-447)

--- a/server/src/main/java/org/apache/cassandra/sidecar/config/yaml/LiveMigrationConfigurationImpl.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/config/yaml/LiveMigrationConfigurationImpl.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.config.yaml;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,16 +51,54 @@ public class LiveMigrationConfigurationImpl implements LiveMigrationConfiguratio
                                           @JsonProperty("migration_map") Map<String, String> migrationMap,
                                           @JsonProperty("max_concurrent_file_requests") int maxConcurrentFileRequests)
     {
-        this.filesToExclude = filesToExclude;
-        this.directoriesToExclude = directoriesToExclude;
-        this.migrationMap = migrationMap == null ? Collections.emptyMap() : Collections.unmodifiableMap(migrationMap);
-
+        Map<String, String> migrationMapOrEmpty = migrationMap == null
+                                                  ? Collections.emptyMap()
+                                                  : Collections.unmodifiableMap(migrationMap);
+        validateMigrationMap(migrationMapOrEmpty);
         if (maxConcurrentFileRequests < 1)
         {
             throw new IllegalArgumentException("Invalid max_concurrent_file_requests " + maxConcurrentFileRequests +
                                                ". It must be >= 1");
         }
+
+        this.filesToExclude = filesToExclude;
+        this.directoriesToExclude = directoriesToExclude;
+        this.migrationMap = migrationMapOrEmpty;
         this.maxConcurrentFileRequests = maxConcurrentFileRequests;
+    }
+
+    private static void validateMigrationMap(Map<String, String> migrationMap)
+    {
+        Set<String> sources = migrationMap.keySet();
+        Set<String> destinations = new HashSet<>();
+        Set<String> duplicateDestinations = new HashSet<>();
+        for (String destination : migrationMap.values())
+        {
+            if (!destinations.add(destination))
+            {
+                duplicateDestinations.add(destination);
+            }
+        }
+
+        if (!duplicateDestinations.isEmpty())
+        {
+            throw new IllegalArgumentException("Invalid migration_map: a node cannot be the destination of multiple " +
+                                               "sources. Duplicate destinations: " + duplicateDestinations);
+        }
+
+        Set<String> sourceAndDestination = new HashSet<>();
+        for (String source : sources)
+        {
+            if (destinations.contains(source))
+            {
+                sourceAndDestination.add(source);
+            }
+        }
+        if (!sourceAndDestination.isEmpty())
+        {
+            throw new IllegalArgumentException("Invalid migration_map: a node cannot be both source and destination. " +
+                                               "Conflicting nodes: " + sourceAndDestination);
+        }
     }
 
     @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationMapSidecarConfigImplTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/livemigration/LiveMigrationMapSidecarConfigImplTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.sidecar.config.yaml.SidecarConfigurationImpl;
 import org.apache.cassandra.sidecar.exceptions.LiveMigrationExceptions.LiveMigrationInvalidRequestException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class LiveMigrationMapSidecarConfigImplTest
 {
@@ -111,6 +112,65 @@ class LiveMigrationMapSidecarConfigImplTest
 
         assertThat(migrationMapSidecarConfig.getSource(null).cause())
         .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testMigrationMapRejectsDuplicateDestinations()
+    {
+        Map<String, String> migrationMap = Map.of("localhost1", "localhost3",
+                                                  "localhost2", "localhost3");
+
+        assertThatThrownBy(() -> new LiveMigrationConfigurationImpl(Collections.emptySet(),
+                                                                    Collections.emptySet(),
+                                                                    migrationMap,
+                                                                    20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("a node cannot be the destination of multiple sources")
+        .hasMessageContaining("localhost3");
+    }
+
+    @Test
+    void testMigrationMapRejectsNodeAsBothSourceAndDestination()
+    {
+        Map<String, String> migrationMap = Map.of("localhost1", "localhost2",
+                                                  "localhost2", "localhost3");
+
+        assertThatThrownBy(() -> new LiveMigrationConfigurationImpl(Collections.emptySet(),
+                                                                    Collections.emptySet(),
+                                                                    migrationMap,
+                                                                    20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("a node cannot be both source and destination")
+        .hasMessageContaining("localhost2");
+    }
+
+    @Test
+    void testMigrationMapRejectsSelfMapping()
+    {
+        Map<String, String> migrationMap = Map.of("localhost1", "localhost1");
+
+        assertThatThrownBy(() -> new LiveMigrationConfigurationImpl(Collections.emptySet(),
+                                                                    Collections.emptySet(),
+                                                                    migrationMap,
+                                                                    20))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("a node cannot be both source and destination")
+        .hasMessageContaining("localhost1");
+    }
+
+    @Test
+    void testMigrationMapAcceptsDistinctSourcesAndDestinations()
+    {
+        Map<String, String> migrationMap = Map.of("localhost1", "localhost3",
+                                                  "localhost2", "localhost4");
+
+        LiveMigrationConfiguration liveMigrationConfiguration =
+        new LiveMigrationConfigurationImpl(Collections.emptySet(),
+                                           Collections.emptySet(),
+                                           migrationMap,
+                                           20);
+
+        assertThat(liveMigrationConfiguration.migrationMap()).isEqualTo(migrationMap);
     }
 
     InstanceMetadata instanceMetadata(String host, int id)


### PR DESCRIPTION
Making this change as part of [CEP-40](https://issues.apache.org/jira/browse/CASSSIDECAR-138).

[CASSSIDECAR-470](https://issues.apache.org/jira/browse/CASSSIDECAR-470) Added validations for migration map in Live migration configuration.