### PR TITLE
CASSSIDECAR-427: Implement basic configuration retrieval in ConfigurationManager

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@
  * RPM package is created with wrong version (CASSSIDECAR-472)
  * Define storage provider interface and Cassandra implementation to support durable job tracking (CASSSIDECAR-373)
  * Validate snapshot name during list snapshot (CASSSIDECAR-461)
+ * Add basic configuration retrieval logic to ConfigurationManager (CASSSIDECAR-427)
 
 0.4.0
 -----

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,9 @@
 0.5.0
 -----
+ * Add basic configuration retrieval logic to ConfigurationManager (CASSSIDECAR-427)
  * RPM package is created with wrong version (CASSSIDECAR-472)
  * Define storage provider interface and Cassandra implementation to support durable job tracking (CASSSIDECAR-373)
  * Validate snapshot name during list snapshot (CASSSIDECAR-461)
- * Add basic configuration retrieval logic to ConfigurationManager (CASSSIDECAR-427)
 
 0.4.0
 -----

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -169,15 +169,21 @@ public class CassandraConfigurationOverlay
 
     static boolean hasConflictingBooleanOpt(Map<String, String> existing, String key)
     {
+        String conflicting = conflictingBooleanOpt(key);
+        return conflicting != null && existing.containsKey(conflicting);
+    }
+
+    static String conflictingBooleanOpt(String key)
+    {
         if (key.startsWith("-XX:+"))
         {
-            return existing.containsKey("-XX:-" + key.substring(5));
+            return "-XX:-" + key.substring(5);
         }
         if (key.startsWith("-XX:-"))
         {
-            return existing.containsKey("-XX:+" + key.substring(5));
+            return "-XX:+" + key.substring(5);
         }
-        return false;
+        return null;
     }
 
     private static void validateNoConflictingBooleanOpts(Map<String, String> opts)

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/CassandraConfigurationOverlay.java
@@ -19,11 +19,9 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
@@ -169,27 +167,29 @@ public class CassandraConfigurationOverlay
         return new CassandraConfigurationOverlay(mergedYaml, mergedOpts);
     }
 
+    static boolean hasConflictingBooleanOpt(Map<String, String> existing, String key)
+    {
+        if (key.startsWith("-XX:+"))
+        {
+            return existing.containsKey("-XX:-" + key.substring(5));
+        }
+        if (key.startsWith("-XX:-"))
+        {
+            return existing.containsKey("-XX:+" + key.substring(5));
+        }
+        return false;
+    }
+
     private static void validateNoConflictingBooleanOpts(Map<String, String> opts)
     {
-        Set<String> enabled = new HashSet<>();
-        Set<String> disabled = new HashSet<>();
         for (String key : opts.keySet())
         {
-            if (key.startsWith("-XX:+"))
+            if (hasConflictingBooleanOpt(opts, key))
             {
-                enabled.add(key.substring(5));
+                String option = key.substring(5);
+                throw new IllegalArgumentException(
+                    "Conflicting boolean JVM options: -XX:+" + option + " and -XX:-" + option);
             }
-            else if (key.startsWith("-XX:-"))
-            {
-                disabled.add(key.substring(5));
-            }
-        }
-        enabled.retainAll(disabled);
-        if (!enabled.isEmpty())
-        {
-            String option = enabled.iterator().next();
-            throw new IllegalArgumentException(
-                "Conflicting boolean JVM options: -XX:+" + option + " and -XX:-" + option);
         }
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -127,6 +127,11 @@ public final class ConfigUtils
             Object overlayValue = field.getValue();
             Object baseValue = result.getValue(fieldName);
 
+            if (overlayValue == null)
+            {
+                continue;
+            }
+
             if (isJsonObject(baseValue) && isJsonObject(overlayValue))
             {
                 JsonObject merged = mergeConfigurations(

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -28,12 +28,12 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonParser;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.jackson.DatabindCodec;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Utility methods for configuration operations: YAML loading and deep merge.

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -107,9 +107,8 @@ public final class ConfigUtils
 
     /**
      * Deep-merges the overlay onto the base configuration. For nested objects both base and overlay
-     * contain, fields are merged recursively. For all other node types (scalars, arrays),
-     * the overlay value replaces the base value. Null overlay values are skipped and the
-     * corresponding base value is preserved. The base node is not modified.
+     * contain, fields are merged recursively. For all other node types (scalars, arrays, nulls),
+     * the overlay value replaces the base value. The base node is not modified.
      *
      * <p>Overlays may introduce keys not present in the base configuration. Such keys are
      * added to the result as-is (scalars, arrays) or merged recursively (nested objects).
@@ -122,51 +121,8 @@ public final class ConfigUtils
     {
         Objects.requireNonNull(base, "base must not be null");
         Objects.requireNonNull(overlay, "overlay must not be null");
-        if (overlay.isEmpty())
-        {
-            return base.copy();
-        }
-
         JsonObject result = base.copy();
-        for (Map.Entry<String, Object> field : overlay)
-        {
-            String fieldName = field.getKey();
-            Object overlayValue = field.getValue();
-            Object baseValue = result.getValue(fieldName);
-
-            if (overlayValue == null)
-            {
-                continue;
-            }
-
-            if (isJsonObject(baseValue) && isJsonObject(overlayValue))
-            {
-                JsonObject merged = mergeConfigurations(
-                        asJsonObject(baseValue),
-                        asJsonObject(overlayValue));
-                result.put(fieldName, merged);
-            }
-            else
-            {
-                result.put(fieldName, overlayValue);
-            }
-        }
+        result.mergeIn(overlay, true);
         return result;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static boolean isJsonObject(Object value)
-    {
-        return value instanceof JsonObject || value instanceof Map;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static JsonObject asJsonObject(Object value)
-    {
-        if (value instanceof JsonObject)
-        {
-            return (JsonObject) value;
-        }
-        return new JsonObject((Map<String, Object>) value);
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonParser;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.vertx.core.json.JsonObject;
@@ -58,7 +59,16 @@ public final class ConfigUtils
      * @param yamlPath path to the YAML configuration file, or {@code null} for an empty snapshot
      * @return a snapshot representing the file contents
      */
-    public static ConfigurationOverlaySnapshot loadConfiguration(Path yamlPath)
+    /**
+     * Loads configuration from the given YAML path, returning the cached snapshot if the file
+     * has not been modified since it was last read.
+     *
+     * @param yamlPath the path to the YAML file, or {@code null} for an empty snapshot
+     * @param cached   a previously loaded snapshot to reuse if the file is unchanged, or {@code null}
+     * @return the cached snapshot if still valid, or a freshly loaded snapshot
+     */
+    public static ConfigurationOverlaySnapshot loadConfiguration(@Nullable Path yamlPath,
+                                                                  @Nullable ConfigurationOverlaySnapshot cached)
     {
         if (yamlPath == null)
         {
@@ -67,6 +77,10 @@ public final class ConfigUtils
         try
         {
             Instant lastModifiedBefore = Files.getLastModifiedTime(yamlPath).toInstant();
+            if (cached != null && cached.lastModified().equals(lastModifiedBefore))
+            {
+                return cached;
+            }
             JsonObject yaml = loadYaml(yamlPath);
             Instant lastModifiedAfter = Files.getLastModifiedTime(yamlPath).toInstant();
             if (!lastModifiedBefore.equals(lastModifiedAfter))

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -49,17 +49,6 @@ public final class ConfigUtils
     }
 
     /**
-     * Loads a YAML configuration file and returns it as a {@link ConfigurationOverlaySnapshot}.
-     * The snapshot's {@code lastModified} is set to the file's modification time and
-     * {@code extraJvmOpts} is empty.
-     *
-     * <p>If {@code yamlPath} is {@code null}, returns an {@linkplain ConfigurationOverlaySnapshot#emptySnapshot()
-     * empty snapshot}.
-     *
-     * @param yamlPath path to the YAML configuration file, or {@code null} for an empty snapshot
-     * @return a snapshot representing the file contents
-     */
-    /**
      * Loads configuration from the given YAML path, returning the cached snapshot if the file
      * has not been modified since it was last read.
      *

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -101,6 +101,9 @@ public final class ConfigUtils
      * contain, fields are merged recursively. For all other node types (scalars, arrays, nulls),
      * the overlay value replaces the base value. The base node is not modified.
      *
+     * <p>Overlays may introduce keys not present in the base configuration. Such keys are
+     * added to the result as-is (scalars, arrays) or merged recursively (nested objects).
+     *
      * @param base    the base configuration tree
      * @param overlay the overlay tree whose values take precedence
      * @return a new tree with the merged result

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -25,8 +25,10 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.core.JsonParser;
+import org.jetbrains.annotations.NotNull;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.vertx.core.json.JsonObject;
@@ -108,13 +110,11 @@ public final class ConfigUtils
      * @param overlay the overlay tree whose values take precedence
      * @return a new tree with the merged result
      */
-    public static JsonObject mergeConfigurations(JsonObject base, JsonObject overlay)
+    public static JsonObject mergeConfigurations(@NotNull JsonObject base, @NotNull JsonObject overlay)
     {
-        if (base == null)
-        {
-            return overlay.copy();
-        }
-        if (overlay == null || overlay.isEmpty())
+        Objects.requireNonNull(base, "base must not be null");
+        Objects.requireNonNull(overlay, "overlay must not be null");
+        if (overlay.isEmpty())
         {
             return base.copy();
         }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -124,8 +124,7 @@ public final class ConfigUtils
         }
 
         JsonObject result = base.copy();
-        JsonObject overlayCopy = overlay.copy();
-        for (Map.Entry<String, Object> field : overlayCopy)
+        for (Map.Entry<String, Object> field : overlay)
         {
             String fieldName = field.getKey();
             Object overlayValue = field.getValue();

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -107,8 +107,9 @@ public final class ConfigUtils
 
     /**
      * Deep-merges the overlay onto the base configuration. For nested objects both base and overlay
-     * contain, fields are merged recursively. For all other node types (scalars, arrays, nulls),
-     * the overlay value replaces the base value. The base node is not modified.
+     * contain, fields are merged recursively. For all other node types (scalars, arrays),
+     * the overlay value replaces the base value. Null overlay values are skipped and the
+     * corresponding base value is preserved. The base node is not modified.
      *
      * <p>Overlays may introduce keys not present in the base configuration. Such keys are
      * added to the result as-is (scalars, arrays) or merged recursively (nested objects).

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
+
+/**
+ * Utility methods for configuration operations: YAML loading and deep merge.
+ */
+public final class ConfigUtils
+{
+    static final YAMLFactory YAML_FACTORY = new YAMLFactory()
+            .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
+
+    private ConfigUtils()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Loads a YAML configuration file and returns it as a {@link ConfigurationOverlaySnapshot}.
+     * The snapshot's {@code lastModified} is set to the file's modification time and
+     * {@code extraJvmOpts} is empty.
+     *
+     * <p>If {@code yamlPath} is {@code null}, returns an {@linkplain ConfigurationOverlaySnapshot#emptySnapshot()
+     * empty snapshot}.
+     *
+     * @param yamlPath path to the YAML configuration file, or {@code null} for an empty snapshot
+     * @return a snapshot representing the file contents
+     */
+    public static ConfigurationOverlaySnapshot loadConfiguration(Path yamlPath)
+    {
+        if (yamlPath == null)
+        {
+            return ConfigurationOverlaySnapshot.emptySnapshot();
+        }
+        JsonObject yaml = loadYaml(yamlPath);
+        Instant lastModified;
+        try
+        {
+            lastModified = Files.getLastModifiedTime(yamlPath).toInstant();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException("Failed to read modification time of " + yamlPath, e);
+        }
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Collections.emptyMap());
+        return new ConfigurationOverlaySnapshot(lastModified, overlay);
+    }
+
+    /**
+     * Loads a YAML file into a Vert.x {@link JsonObject}.
+     *
+     * @param yamlPath path to the YAML file
+     * @return the parsed configuration as a JsonObject
+     */
+    @SuppressWarnings("unchecked")
+    public static JsonObject loadYaml(Path yamlPath)
+    {
+        try (JsonParser parser = YAML_FACTORY.createParser(yamlPath.toFile()))
+        {
+            Map<String, Object> map = DatabindCodec.mapper().readValue(parser, Map.class);
+            return map != null ? new JsonObject(map) : new JsonObject();
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException("Failed to load YAML from " + yamlPath, e);
+        }
+    }
+
+    /**
+     * Deep-merges the overlay onto the base configuration. For nested objects both base and overlay
+     * contain, fields are merged recursively. For all other node types (scalars, arrays, nulls),
+     * the overlay value replaces the base value. The base node is not modified.
+     *
+     * @param base    the base configuration tree
+     * @param overlay the overlay tree whose values take precedence
+     * @return a new tree with the merged result
+     */
+    public static JsonObject mergeConfigurations(JsonObject base, JsonObject overlay)
+    {
+        if (base == null)
+        {
+            return overlay.copy();
+        }
+        if (overlay == null || overlay.isEmpty())
+        {
+            return base.copy();
+        }
+
+        JsonObject result = base.copy();
+        JsonObject overlayCopy = overlay.copy();
+        for (Map.Entry<String, Object> field : overlayCopy)
+        {
+            String fieldName = field.getKey();
+            Object overlayValue = field.getValue();
+            Object baseValue = result.getValue(fieldName);
+
+            if (isJsonObject(baseValue) && isJsonObject(overlayValue))
+            {
+                JsonObject merged = mergeConfigurations(
+                        asJsonObject(baseValue),
+                        asJsonObject(overlayValue));
+                result.put(fieldName, merged);
+            }
+            else
+            {
+                result.put(fieldName, overlayValue);
+            }
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean isJsonObject(Object value)
+    {
+        return value instanceof JsonObject || value instanceof Map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JsonObject asJsonObject(Object value)
+    {
+        if (value instanceof JsonObject)
+        {
+            return (JsonObject) value;
+        }
+        return new JsonObject((Map<String, Object>) value);
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtils.java
@@ -64,18 +64,22 @@ public final class ConfigUtils
         {
             return ConfigurationOverlaySnapshot.emptySnapshot();
         }
-        JsonObject yaml = loadYaml(yamlPath);
-        Instant lastModified;
         try
         {
-            lastModified = Files.getLastModifiedTime(yamlPath).toInstant();
+            Instant lastModifiedBefore = Files.getLastModifiedTime(yamlPath).toInstant();
+            JsonObject yaml = loadYaml(yamlPath);
+            Instant lastModifiedAfter = Files.getLastModifiedTime(yamlPath).toInstant();
+            if (!lastModifiedBefore.equals(lastModifiedAfter))
+            {
+                throw new IllegalStateException("File was modified while reading: " + yamlPath);
+            }
+            CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Collections.emptyMap());
+            return new ConfigurationOverlaySnapshot(lastModifiedAfter, overlay);
         }
         catch (IOException e)
         {
             throw new UncheckedIOException("Failed to read modification time of " + yamlPath, e);
         }
-        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yaml, Collections.emptyMap());
-        return new ConfigurationOverlaySnapshot(lastModified, overlay);
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManager.java
@@ -73,7 +73,7 @@ public class ConfigurationManager
 
         if (providerSnapshot != null)
         {
-            return baseSnapshot.overlay(providerSnapshot);
+            return baseSnapshot.overlay(providerSnapshot, instance.id());
         }
         return baseSnapshot;
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManager.java
@@ -34,6 +34,9 @@ public class ConfigurationManager
     @Nullable
     private final Path baseTemplatePath;
 
+    @Nullable
+    private volatile ConfigurationOverlaySnapshot cachedBaseSnapshot;
+
     /**
      * @param provider         the configuration provider for fetching overlays
      * @param baseTemplatePath path to the base cassandra.yaml template, or {@code null} for an empty base
@@ -55,7 +58,7 @@ public class ConfigurationManager
     @NotNull
     public ConfigurationOverlaySnapshot getEffectiveConfiguration(InstanceMetadata instance)
     {
-        ConfigurationOverlaySnapshot baseSnapshot = ConfigUtils.loadConfiguration(baseTemplatePath);
+        ConfigurationOverlaySnapshot baseSnapshot = getBaseSnapshot();
 
         ConfigurationOverlaySnapshot providerSnapshot;
         try
@@ -73,5 +76,12 @@ public class ConfigurationManager
             return baseSnapshot.overlay(providerSnapshot);
         }
         return baseSnapshot;
+    }
+
+    private ConfigurationOverlaySnapshot getBaseSnapshot()
+    {
+        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(baseTemplatePath, cachedBaseSnapshot);
+        cachedBaseSnapshot = snapshot;
+        return snapshot;
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManager.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Manages configuration of Cassandra instances via Sidecar
+ */
+public class ConfigurationManager
+{
+    private final ConfigurationProvider provider;
+    @Nullable
+    private final Path baseTemplatePath;
+
+    /**
+     * @param provider         the configuration provider for fetching overlays
+     * @param baseTemplatePath path to the base cassandra.yaml template, or {@code null} for an empty base
+     */
+    public ConfigurationManager(ConfigurationProvider provider, @Nullable Path baseTemplatePath)
+    {
+        this.provider = Objects.requireNonNull(provider, "provider must not be null");
+        this.baseTemplatePath = baseTemplatePath;
+    }
+
+    /**
+     * Computes the effective configuration for the given instance by merging the base template
+     * with the overlay from the {@link ConfigurationProvider}.
+     *
+     * @param instance the Cassandra instance metadata
+     * @return a snapshot of the effective configuration with its SHA-256 hash and last modified timestamp
+     * @throws ConfigurationManagerException if the provider fails to retrieve the overlay
+     */
+    @NotNull
+    public ConfigurationOverlaySnapshot getEffectiveConfiguration(InstanceMetadata instance)
+    {
+        ConfigurationOverlaySnapshot baseSnapshot = ConfigUtils.loadConfiguration(baseTemplatePath);
+
+        ConfigurationOverlaySnapshot providerSnapshot;
+        try
+        {
+            providerSnapshot = provider.getOverlay(instance);
+        }
+        catch (Exception e)
+        {
+            throw new ConfigurationManagerException(
+                    "Failed to retrieve configuration overlay from provider", e);
+        }
+
+        if (providerSnapshot != null)
+        {
+            return baseSnapshot.overlay(providerSnapshot);
+        }
+        return baseSnapshot;
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManagerException.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManagerException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+/**
+ * Thrown when the {@link ConfigurationManager} encounters a failure during configuration operations.
+ */
+public class ConfigurationManagerException extends RuntimeException
+{
+    public ConfigurationManagerException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -21,14 +21,16 @@ package org.apache.cassandra.sidecar.configmanagement;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a snapshot of a configuration overlay with its metadata.
- * The SHA-256 hash is dynamically computed from the overlay contents and cached.
+ * Represents a snapshot of a configuration with its metadata.
+ * The SHA-256 hash is dynamically computed from the configuration contents and cached.
  */
 public class ConfigurationOverlaySnapshot
 {
@@ -36,19 +38,47 @@ public class ConfigurationOverlaySnapshot
     private final Instant lastModified;
 
     @NotNull
-    private final CassandraConfigurationOverlay overlay;
+    private final CassandraConfigurationOverlay configuration;
 
     private volatile String hash;
 
     public ConfigurationOverlaySnapshot(@NotNull Instant lastModified,
-                                        @NotNull CassandraConfigurationOverlay overlay)
+                                        @NotNull CassandraConfigurationOverlay configuration)
     {
         this.lastModified = Objects.requireNonNull(lastModified, "lastModified must not be null");
-        this.overlay = Objects.requireNonNull(overlay, "overlay must not be null");
+        this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
     }
 
     /**
-     * Returns the SHA-256 hash of the overlay contents, prefixed with "sha256:".
+     * Merges another snapshot on top of this one, producing the effective configuration.
+     * The other snapshot's values take precedence over this snapshot's values.
+     *
+     * <p>Deep-merges {@code cassandraYaml} (nested objects are recursively merged, all other
+     * types are replaced by the other snapshot's values). Merges {@code extraJvmOpts} with the
+     * other snapshot's entries overriding this snapshot's entries on key conflict.
+     *
+     * @param other the overlay snapshot whose values take precedence
+     * @return a new snapshot with the merged configuration and the max of both lastModified timestamps
+     */
+    @NotNull
+    public ConfigurationOverlaySnapshot overlay(@NotNull ConfigurationOverlaySnapshot other)
+    {
+        JsonObject mergedYaml = ConfigUtils.mergeConfigurations(configuration.cassandraYaml(),
+                                                                other.configuration().cassandraYaml());
+
+        Map<String, String> mergedOpts = new LinkedHashMap<>(configuration.extraJvmOpts());
+        mergedOpts.putAll(other.configuration().extraJvmOpts());
+
+        Instant mergedLastModified = lastModified.isAfter(other.lastModified)
+                                     ? lastModified
+                                     : other.lastModified;
+
+        CassandraConfigurationOverlay mergedOverlay = new CassandraConfigurationOverlay(mergedYaml, mergedOpts);
+        return new ConfigurationOverlaySnapshot(mergedLastModified, mergedOverlay);
+    }
+
+    /**
+     * Returns the SHA-256 hash of the configuration contents, prefixed with "sha256:".
      * Computed on first access and cached for subsequent calls.
      *
      * @return the content hash in the form "sha256:&lt;64 hex chars&gt;"
@@ -70,9 +100,9 @@ public class ConfigurationOverlaySnapshot
     }
 
     @NotNull
-    public CassandraConfigurationOverlay overlay()
+    public CassandraConfigurationOverlay configuration()
     {
-        return overlay;
+        return configuration;
     }
 
     /**
@@ -84,29 +114,43 @@ public class ConfigurationOverlaySnapshot
     public JsonObject toJson()
     {
         return new JsonObject()
+               .put("hash", hash())
                .put("lastModified", lastModified.toString())
-               .put("overlay", overlay.toJson());
+               .put("configuration", configuration.toJson());
+    }
+
+    /**
+     * Returns an empty snapshot with {@link Instant#EPOCH} as the last modified time,
+     * an empty {@code cassandraYaml}, and no extra JVM options.
+     *
+     * @return an empty configuration snapshot
+     */
+    @NotNull
+    public static ConfigurationOverlaySnapshot emptySnapshot()
+    {
+        return new ConfigurationOverlaySnapshot(Instant.EPOCH, new CassandraConfigurationOverlay(null, null));
     }
 
     /**
      * Creates a {@link ConfigurationOverlaySnapshot} from its JSON representation.
      *
-     * @param json the JSON object containing {@code lastModified} and {@code overlay}
+     * @param json the JSON object containing {@code lastModified} and {@code configuration}
      * @return a new snapshot instance
      */
     @NotNull
     public static ConfigurationOverlaySnapshot fromJson(@NotNull JsonObject json)
     {
         Instant lastModified = Instant.parse(json.getString("lastModified"));
-        CassandraConfigurationOverlay overlay = CassandraConfigurationOverlay.fromJson(json.getJsonObject("overlay"));
-        return new ConfigurationOverlaySnapshot(lastModified, overlay);
+        CassandraConfigurationOverlay configuration =
+                CassandraConfigurationOverlay.fromJson(json.getJsonObject("configuration"));
+        return new ConfigurationOverlaySnapshot(lastModified, configuration);
     }
 
     private String computeHash()
     {
         try
         {
-            byte[] bytes = overlay.toJson().toBuffer().getBytes();
+            byte[] bytes = configuration.toJson().toBuffer().getBytes();
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hashBytes = digest.digest(bytes);
             return "sha256:" + bytesToHex(hashBytes);
@@ -140,22 +184,19 @@ public class ConfigurationOverlaySnapshot
         }
         ConfigurationOverlaySnapshot that = (ConfigurationOverlaySnapshot) o;
         return Objects.equals(lastModified, that.lastModified)
-               && Objects.equals(overlay, that.overlay);
+               && Objects.equals(configuration, that.configuration);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(lastModified, overlay);
+        return Objects.hash(lastModified, configuration);
     }
 
     @Override
     public String toString()
     {
-        return new JsonObject()
-               .put("hash", hash())
-               .put("lastModified", lastModified.toString())
-               .put("overlay", overlay.toJson())
+        return toJson()
                .encodePrettily();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -57,6 +57,10 @@ public class ConfigurationOverlaySnapshot
      * types are replaced by the other snapshot's values). Merges {@code extraJvmOpts} with the
      * other snapshot's entries overriding this snapshot's entries on key conflict.
      *
+     * <p>Overlays may introduce keys not present in the base snapshot. New keys in
+     * {@code cassandraYaml} are added to the result, and new keys in {@code extraJvmOpts}
+     * are added alongside existing entries.
+     *
      * @param other the overlay snapshot whose values take precedence
      * @return a new snapshot with the merged configuration and the max of both lastModified timestamps
      */

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -25,6 +25,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.vertx.core.json.JsonObject;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,6 +41,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class ConfigurationOverlaySnapshot
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationOverlaySnapshot.class);
+
     @NotNull
     private final Instant lastModified;
 
@@ -65,11 +70,16 @@ public class ConfigurationOverlaySnapshot
      * {@code cassandraYaml} are added to the result, and new keys in {@code extraJvmOpts}
      * are added alongside existing entries.
      *
-     * @param other the overlay snapshot whose values take precedence
+     * <p>When a conflicting boolean JVM option is detected (e.g. {@code -XX:+UseG1GC} in the base
+     * and {@code -XX:-UseG1GC} in the overlay), the base option is preserved and the overlay's
+     * conflicting entry is skipped. A warning is logged to alert the operator.
+     *
+     * @param other      the overlay snapshot whose values take precedence
+     * @param instanceId the Cassandra instance id, used for contextual log messages
      * @return a new snapshot with the merged configuration and the max of both lastModified timestamps
      */
     @NotNull
-    public ConfigurationOverlaySnapshot overlay(@NotNull ConfigurationOverlaySnapshot other)
+    public ConfigurationOverlaySnapshot overlay(@NotNull ConfigurationOverlaySnapshot other, int instanceId)
     {
         JsonObject mergedYaml = ConfigUtils.mergeConfigurations(configuration.cassandraYaml(),
                                                                 other.configuration().cassandraYaml());
@@ -80,6 +90,9 @@ public class ConfigurationOverlaySnapshot
             String key = entry.getKey();
             if (CassandraConfigurationOverlay.hasConflictingBooleanOpt(mergedOpts, key))
             {
+                LOGGER.warn("Instance {}: Conflicting boolean JVM option '{}' in overlay conflicts with base " +
+                            "option '{}'. Preserving base option and skipping overlay entry.",
+                            instanceId, key, CassandraConfigurationOverlay.conflictingBooleanOpt(key));
                 continue;
             }
             mergedOpts.put(key, entry.getValue());

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -31,6 +31,10 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Represents a snapshot of a configuration with its metadata.
  * The SHA-256 hash is dynamically computed from the configuration contents and cached.
+ *
+ * <p>{@code lastModified} tracks when the configuration content was last updated at its source.
+ * Merging two snapshots takes the maximum of both timestamps because merging combines existing
+ * content without producing new configuration.
  */
 public class ConfigurationOverlaySnapshot
 {

--- a/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshot.java
@@ -75,7 +75,15 @@ public class ConfigurationOverlaySnapshot
                                                                 other.configuration().cassandraYaml());
 
         Map<String, String> mergedOpts = new LinkedHashMap<>(configuration.extraJvmOpts());
-        mergedOpts.putAll(other.configuration().extraJvmOpts());
+        for (Map.Entry<String, String> entry : other.configuration().extraJvmOpts().entrySet())
+        {
+            String key = entry.getKey();
+            if (CassandraConfigurationOverlay.hasConflictingBooleanOpt(mergedOpts, key))
+            {
+                continue;
+            }
+            mergedOpts.put(key, entry.getValue());
+        }
 
         Instant mergedLastModified = lastModified.isAfter(other.lastModified)
                                      ? lastModified

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
@@ -97,6 +97,42 @@ class ConfigUtilsTest
     }
 
     @Test
+    void testMergeOverlayOnlyOverridesSpecifiedKeys()
+    {
+        JsonObject base = new JsonObject()
+                          .put("a", "a")
+                          .put("b", "b")
+                          .put("c", "c");
+
+        JsonObject overlay = new JsonObject()
+                             .put("b", "b2");
+
+        JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
+
+        assertThat(result.getString("a")).isEqualTo("a");
+        assertThat(result.getString("b")).isEqualTo("b2");
+        assertThat(result.getString("c")).isEqualTo("c");
+    }
+
+    @Test
+    void testMergeNullOverlayValueKeepsBaseValue()
+    {
+        JsonObject base = new JsonObject()
+                          .put("a", "a")
+                          .put("b", "b")
+                          .put("c", "c");
+
+        JsonObject overlay = new JsonObject()
+                             .put("b", (String) null);
+
+        JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
+
+        assertThat(result.getString("a")).isEqualTo("a");
+        assertThat(result.getString("b")).isEqualTo("b");
+        assertThat(result.getString("c")).isEqualTo("c");
+    }
+
+    @Test
     void testMergeEmptyOverlay()
     {
         JsonObject base = new JsonObject()

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConfigUtils}
+ */
+class ConfigUtilsTest
+{
+    @Test
+    void testMergeOverlayWins()
+    {
+        JsonObject base = new JsonObject()
+                          .put("concurrent_reads", 32)
+                          .put("cluster_name", "original");
+
+        JsonObject overlay = new JsonObject()
+                             .put("concurrent_reads", 64);
+
+        JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
+
+        assertThat(result.getInteger("concurrent_reads")).isEqualTo(64);
+        assertThat(result.getString("cluster_name")).isEqualTo("original");
+    }
+
+    @Test
+    void testMergeAddsNewKeys()
+    {
+        JsonObject base = new JsonObject()
+                          .put("cluster_name", "test");
+
+        JsonObject overlay = new JsonObject()
+                             .put("concurrent_reads", 64)
+                             .put("storage_compatibility_mode", "CASSANDRA_5");
+
+        JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
+
+        assertThat(result.getString("cluster_name")).isEqualTo("test");
+        assertThat(result.getInteger("concurrent_reads")).isEqualTo(64);
+        assertThat(result.getString("storage_compatibility_mode")).isEqualTo("CASSANDRA_5");
+    }
+
+    @Test
+    void testMergeDeepNestedValues()
+    {
+        JsonObject skiplist = new JsonObject().put("class_name", "SkipListMemtable");
+        JsonObject defaultConfig = new JsonObject().put("inherits", "skiplist");
+        JsonObject configurations = new JsonObject()
+                                    .put("skiplist", skiplist.getMap())
+                                    .put("default", defaultConfig.getMap());
+        JsonObject memtable = new JsonObject().put("configurations", configurations.getMap());
+        JsonObject base = new JsonObject()
+                          .put("memtable", memtable.getMap())
+                          .put("cluster_name", "test");
+
+        JsonObject trie = new JsonObject().put("class_name", "TrieMemtable");
+        JsonObject overlayDefault = new JsonObject().put("inherits", "trie");
+        JsonObject overlayConfigurations = new JsonObject()
+                                           .put("trie", trie.getMap())
+                                           .put("default", overlayDefault.getMap());
+        JsonObject overlayMemtable = new JsonObject().put("configurations", overlayConfigurations.getMap());
+        JsonObject overlay = new JsonObject().put("memtable", overlayMemtable.getMap());
+
+        JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
+
+        JsonObject resultConfigs = result.getJsonObject("memtable").getJsonObject("configurations");
+        assertThat(resultConfigs.getJsonObject("skiplist").getString("class_name")).isEqualTo("SkipListMemtable");
+        assertThat(resultConfigs.getJsonObject("trie").getString("class_name")).isEqualTo("TrieMemtable");
+        assertThat(resultConfigs.getJsonObject("default").getString("inherits")).isEqualTo("trie");
+        assertThat(result.getString("cluster_name")).isEqualTo("test");
+    }
+
+    @Test
+    void testMergeEmptyOverlay()
+    {
+        JsonObject base = new JsonObject()
+                          .put("cluster_name", "test")
+                          .put("concurrent_reads", 32);
+
+        JsonObject overlay = new JsonObject();
+
+        JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
+
+        assertThat(result.getString("cluster_name")).isEqualTo("test");
+        assertThat(result.getInteger("concurrent_reads")).isEqualTo(32);
+    }
+
+    @Test
+    void testLoadYamlRealCassandraConfig()
+    {
+        Path yamlPath = Paths.get("src/test/resources/configmanagement/cassandra_latest.yaml");
+        JsonObject config = ConfigUtils.loadYaml(yamlPath);
+
+        assertThat(config).isNotNull();
+        assertThat(config.getString("cluster_name")).isEqualTo("Test Cluster");
+        assertThat(config.getInteger("num_tokens")).isEqualTo(16);
+        assertThat(config.getString("commitlog_sync")).isEqualTo("periodic");
+        assertThat(new JsonObject(config.getJsonObject("memtable").getMap())
+                .getJsonObject("configurations")
+                .getJsonObject("trie")
+                .getString("class_name"))
+                .isEqualTo("TrieMemtable");
+        assertThat(config.containsKey("seed_provider")).isTrue();
+    }
+
+    @Test
+    void testLoadConfiguration()
+    {
+        Path yamlPath = Paths.get("src/test/resources/configmanagement/cassandra_latest.yaml");
+
+        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(yamlPath);
+
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.configuration().cassandraYaml().getString("cluster_name")).isEqualTo("Test Cluster");
+        assertThat(snapshot.configuration().cassandraYaml().getInteger("num_tokens")).isEqualTo(16);
+        assertThat(snapshot.configuration().extraJvmOpts()).isEmpty();
+        assertThat(snapshot.lastModified()).isNotNull();
+        assertThat(snapshot.hash()).startsWith("sha256:");
+    }
+
+    @Test
+    void testLoadConfigurationNullPath()
+    {
+        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(null);
+
+        assertThat(snapshot).isNotNull();
+        assertThat(snapshot.lastModified()).isEqualTo(Instant.EPOCH);
+        assertThat(snapshot.configuration().cassandraYaml()).isEmpty();
+        assertThat(snapshot.configuration().extraJvmOpts()).isEmpty();
+        assertThat(snapshot.hash()).startsWith("sha256:");
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
@@ -115,7 +115,7 @@ class ConfigUtilsTest
     }
 
     @Test
-    void testMergeNullOverlayValueKeepsBaseValue()
+    void testMergeNullOverlayValueOverwritesBaseValue()
     {
         JsonObject base = new JsonObject()
                           .put("a", "a")
@@ -128,7 +128,7 @@ class ConfigUtilsTest
         JsonObject result = ConfigUtils.mergeConfigurations(base, overlay);
 
         assertThat(result.getString("a")).isEqualTo("a");
-        assertThat(result.getString("b")).isEqualTo("b");
+        assertThat(result.getValue("b")).isNull();
         assertThat(result.getString("c")).isEqualTo("c");
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigUtilsTest.java
@@ -170,7 +170,7 @@ class ConfigUtilsTest
     {
         Path yamlPath = Paths.get("src/test/resources/configmanagement/cassandra_latest.yaml");
 
-        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(yamlPath);
+        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(yamlPath, null);
 
         assertThat(snapshot).isNotNull();
         assertThat(snapshot.configuration().cassandraYaml().getString("cluster_name")).isEqualTo("Test Cluster");
@@ -183,12 +183,23 @@ class ConfigUtilsTest
     @Test
     void testLoadConfigurationNullPath()
     {
-        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(null);
+        ConfigurationOverlaySnapshot snapshot = ConfigUtils.loadConfiguration(null, null);
 
         assertThat(snapshot).isNotNull();
         assertThat(snapshot.lastModified()).isEqualTo(Instant.EPOCH);
         assertThat(snapshot.configuration().cassandraYaml()).isEmpty();
         assertThat(snapshot.configuration().extraJvmOpts()).isEmpty();
         assertThat(snapshot.hash()).startsWith("sha256:");
+    }
+
+    @Test
+    void testLoadConfigurationReturnsCachedWhenUnmodified()
+    {
+        Path yamlPath = Paths.get("src/test/resources/configmanagement/cassandra_latest.yaml");
+
+        ConfigurationOverlaySnapshot first = ConfigUtils.loadConfiguration(yamlPath, null);
+        ConfigurationOverlaySnapshot second = ConfigUtils.loadConfiguration(yamlPath, first);
+
+        assertThat(second).isSameAs(first);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManagerTest.java
@@ -161,6 +161,18 @@ class ConfigurationManagerTest
         assertThat(result.lastModified()).isEqualTo(overlayTime);
     }
 
+    @Test
+    void testGetEffectiveConfigurationCachesBaseSnapshot()
+    {
+        ConfigurationManager manager = new ConfigurationManager(provider, BASE_TEMPLATE);
+        InstanceMetadata instance = mockInstance(1);
+
+        ConfigurationOverlaySnapshot first = manager.getEffectiveConfiguration(instance);
+        ConfigurationOverlaySnapshot second = manager.getEffectiveConfiguration(instance);
+
+        assertThat(second).isSameAs(first);
+    }
+
     private static InstanceMetadata mockInstance(int id)
     {
         InstanceMetadata instance = mock(InstanceMetadata.class);

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationManagerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.configmanagement;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonObject;
+import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ConfigurationManager}
+ */
+class ConfigurationManagerTest
+{
+    private static final Path BASE_TEMPLATE = Paths.get("src/test/resources/configmanagement/cassandra_latest.yaml");
+
+    private InMemoryConfigurationProvider provider;
+
+    @BeforeEach
+    void setUp()
+    {
+        provider = new InMemoryConfigurationProvider();
+    }
+
+    @Test
+    void testGetEffectiveConfigurationNoOverlay()
+    {
+        ConfigurationManager manager = new ConfigurationManager(provider, BASE_TEMPLATE);
+        InstanceMetadata instance = mockInstance(1);
+
+        ConfigurationOverlaySnapshot result = manager.getEffectiveConfiguration(instance);
+
+        assertThat(result.configuration().cassandraYaml().getString("cluster_name")).isEqualTo("Test Cluster");
+        assertThat(result.configuration().cassandraYaml().getInteger("num_tokens")).isEqualTo(16);
+        assertThat(result.configuration().extraJvmOpts()).isEmpty();
+        assertThat(result.lastModified()).isNotNull();
+        assertThat(result.hash()).startsWith("sha256:");
+    }
+
+    @Test
+    void testGetEffectiveConfigurationWithOverlay()
+    {
+        InstanceMetadata instance = mockInstance(1);
+
+        JsonObject yamlOverlay = new JsonObject()
+                                 .put("concurrent_reads", 128)
+                                 .put("memtable_flush_writers", 8);
+        Map<String, String> jvmOpts = new LinkedHashMap<>();
+        jvmOpts.put("-Xmx", "4g");
+        jvmOpts.put("-Dcassandra.ring_delay_ms", "60000");
+
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yamlOverlay, jvmOpts);
+        ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(Instant.now(), overlay);
+        provider.storeOverlay(instance, null, snapshot);
+
+        ConfigurationManager manager = new ConfigurationManager(provider, BASE_TEMPLATE);
+        ConfigurationOverlaySnapshot result = manager.getEffectiveConfiguration(instance);
+
+        // Overlay values take precedence
+        assertThat(result.configuration().cassandraYaml().getInteger("concurrent_reads")).isEqualTo(128);
+        assertThat(result.configuration().cassandraYaml().getInteger("memtable_flush_writers")).isEqualTo(8);
+        // Base template values preserved
+        assertThat(result.configuration().cassandraYaml().getString("cluster_name")).isEqualTo("Test Cluster");
+        assertThat(result.configuration().cassandraYaml().getInteger("num_tokens")).isEqualTo(16);
+        // JVM opts carried through
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Xmx", "4g");
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Dcassandra.ring_delay_ms", "60000");
+    }
+
+    @Test
+    void testGetEffectiveConfigurationProviderFailure()
+    {
+        ConfigurationProvider failingProvider = new ConfigurationProvider()
+        {
+            @Override
+            public ConfigurationOverlaySnapshot getOverlay(InstanceMetadata instance)
+            {
+                throw new UncheckedIOException(new IOException("provider unavailable"));
+            }
+
+            @Override
+            public boolean storeOverlay(InstanceMetadata instance, String originalHash,
+                                        ConfigurationOverlaySnapshot newSnapshot)
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        ConfigurationManager manager = new ConfigurationManager(failingProvider, BASE_TEMPLATE);
+        InstanceMetadata instance = mockInstance(1);
+
+        assertThatThrownBy(() -> manager.getEffectiveConfiguration(instance))
+                .isInstanceOf(ConfigurationManagerException.class)
+                .hasMessageContaining("Failed to retrieve configuration overlay from provider")
+                .hasCauseInstanceOf(UncheckedIOException.class);
+    }
+
+    @Test
+    void testGetEffectiveConfigurationNullBaseTemplateNoOverlay()
+    {
+        ConfigurationManager manager = new ConfigurationManager(provider, null);
+        InstanceMetadata instance = mockInstance(1);
+
+        ConfigurationOverlaySnapshot result = manager.getEffectiveConfiguration(instance);
+
+        assertThat(result.lastModified()).isEqualTo(Instant.EPOCH);
+        assertThat(result.configuration().cassandraYaml()).isEmpty();
+        assertThat(result.configuration().extraJvmOpts()).isEmpty();
+        assertThat(result.hash()).startsWith("sha256:");
+    }
+
+    @Test
+    void testGetEffectiveConfigurationNullBaseTemplateWithOverlay()
+    {
+        InstanceMetadata instance = mockInstance(1);
+
+        JsonObject yamlOverlay = new JsonObject().put("concurrent_reads", 128);
+        Map<String, String> jvmOpts = Collections.singletonMap("-Xmx", "4g");
+
+        CassandraConfigurationOverlay overlay = new CassandraConfigurationOverlay(yamlOverlay, jvmOpts);
+        Instant overlayTime = Instant.parse("2026-06-01T00:00:00Z");
+        ConfigurationOverlaySnapshot snapshot = new ConfigurationOverlaySnapshot(overlayTime, overlay);
+        provider.storeOverlay(instance, null, snapshot);
+
+        ConfigurationManager manager = new ConfigurationManager(provider, null);
+        ConfigurationOverlaySnapshot result = manager.getEffectiveConfiguration(instance);
+
+        assertThat(result.configuration().cassandraYaml().getInteger("concurrent_reads")).isEqualTo(128);
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Xmx", "4g");
+        assertThat(result.lastModified()).isEqualTo(overlayTime);
+    }
+
+    private static InstanceMetadata mockInstance(int id)
+    {
+        InstanceMetadata instance = mock(InstanceMetadata.class);
+        when(instance.id()).thenReturn(id);
+        return instance;
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -143,6 +143,28 @@ class ConfigurationOverlaySnapshotTest
     }
 
     @Test
+    void testOverlayPrefersBaseOnConflictingBooleanJvmOpts()
+    {
+        Map<String, String> baseOpts = new LinkedHashMap<>();
+        baseOpts.put("-XX:+UseG1GC", "");
+        baseOpts.put("-Xmx", "4g");
+        CassandraConfigurationOverlay baseOverlay = new CassandraConfigurationOverlay(null, baseOpts);
+        ConfigurationOverlaySnapshot base = new ConfigurationOverlaySnapshot(Instant.now(), baseOverlay);
+
+        Map<String, String> otherOpts = new LinkedHashMap<>();
+        otherOpts.put("-XX:-UseG1GC", "");
+        otherOpts.put("-Xmx", "8g");
+        CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(null, otherOpts);
+        ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.now(), otherOverlay);
+
+        ConfigurationOverlaySnapshot result = base.overlay(other);
+
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-XX:+UseG1GC", "");
+        assertThat(result.configuration().extraJvmOpts()).doesNotContainKey("-XX:-UseG1GC");
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Xmx", "8g");
+    }
+
+    @Test
     void testOverlayUsesMaxLastModified()
     {
         Instant older = Instant.parse("2026-01-01T00:00:00Z");

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -113,7 +113,7 @@ class ConfigurationOverlaySnapshotTest
         ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.parse("2026-02-01T00:00:00Z"),
                                                                               otherOverlay);
 
-        ConfigurationOverlaySnapshot result = base.overlay(other);
+        ConfigurationOverlaySnapshot result = base.overlay(other, 1);
 
         assertThat(result.configuration().cassandraYaml().getString("cluster_name")).isEqualTo("test");
         assertThat(result.configuration().cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
@@ -135,7 +135,7 @@ class ConfigurationOverlaySnapshotTest
         CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(null, otherOpts);
         ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.now(), otherOverlay);
 
-        ConfigurationOverlaySnapshot result = base.overlay(other);
+        ConfigurationOverlaySnapshot result = base.overlay(other, 1);
 
         assertThat(result.configuration().extraJvmOpts()).containsEntry("-Xmx", "8g");
         assertThat(result.configuration().extraJvmOpts()).containsEntry("-Dcassandra.jmx.local.port", "7199");
@@ -157,7 +157,7 @@ class ConfigurationOverlaySnapshotTest
         CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(null, otherOpts);
         ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.now(), otherOverlay);
 
-        ConfigurationOverlaySnapshot result = base.overlay(other);
+        ConfigurationOverlaySnapshot result = base.overlay(other, 1);
 
         assertThat(result.configuration().extraJvmOpts()).containsEntry("-XX:+UseG1GC", "");
         assertThat(result.configuration().extraJvmOpts()).doesNotContainKey("-XX:-UseG1GC");
@@ -174,11 +174,11 @@ class ConfigurationOverlaySnapshotTest
 
         ConfigurationOverlaySnapshot baseOlder = new ConfigurationOverlaySnapshot(older, emptyOverlay);
         ConfigurationOverlaySnapshot otherNewer = new ConfigurationOverlaySnapshot(newer, emptyOverlay);
-        assertThat(baseOlder.overlay(otherNewer).lastModified()).isEqualTo(newer);
+        assertThat(baseOlder.overlay(otherNewer, 1).lastModified()).isEqualTo(newer);
 
         ConfigurationOverlaySnapshot baseNewer = new ConfigurationOverlaySnapshot(newer, emptyOverlay);
         ConfigurationOverlaySnapshot otherOlder = new ConfigurationOverlaySnapshot(older, emptyOverlay);
-        assertThat(baseNewer.overlay(otherOlder).lastModified()).isEqualTo(newer);
+        assertThat(baseNewer.overlay(otherOlder, 1).lastModified()).isEqualTo(newer);
     }
 
     @Test
@@ -200,7 +200,7 @@ class ConfigurationOverlaySnapshotTest
         CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(otherYaml, null);
         ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.now(), otherOverlay);
 
-        ConfigurationOverlaySnapshot result = base.overlay(other);
+        ConfigurationOverlaySnapshot result = base.overlay(other, 1);
 
         JsonObject resultConfigs = result.configuration().cassandraYaml()
                                          .getJsonObject("memtable")

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/ConfigurationOverlaySnapshotTest.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.configmanagement;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,110 @@ class ConfigurationOverlaySnapshotTest
     }
 
     @Test
+    void testOverlayMergesYamlKeys()
+    {
+        JsonObject baseYaml = new JsonObject()
+                              .put("cluster_name", "test")
+                              .put("concurrent_reads", 32);
+        CassandraConfigurationOverlay baseOverlay = new CassandraConfigurationOverlay(baseYaml, null);
+        ConfigurationOverlaySnapshot base = new ConfigurationOverlaySnapshot(Instant.parse("2026-01-01T00:00:00Z"),
+                                                                             baseOverlay);
+
+        JsonObject otherYaml = new JsonObject()
+                               .put("concurrent_reads", 64)
+                               .put("storage_compatibility_mode", "CASSANDRA_5");
+        CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(otherYaml, null);
+        ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.parse("2026-02-01T00:00:00Z"),
+                                                                              otherOverlay);
+
+        ConfigurationOverlaySnapshot result = base.overlay(other);
+
+        assertThat(result.configuration().cassandraYaml().getString("cluster_name")).isEqualTo("test");
+        assertThat(result.configuration().cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
+        assertThat(result.configuration().cassandraYaml().getString("storage_compatibility_mode")).isEqualTo("CASSANDRA_5");
+    }
+
+    @Test
+    void testOverlayMergesJvmOpts()
+    {
+        Map<String, String> baseOpts = new LinkedHashMap<>();
+        baseOpts.put("-Xmx", "4g");
+        baseOpts.put("-Dcassandra.jmx.local.port", "7199");
+        CassandraConfigurationOverlay baseOverlay = new CassandraConfigurationOverlay(null, baseOpts);
+        ConfigurationOverlaySnapshot base = new ConfigurationOverlaySnapshot(Instant.now(), baseOverlay);
+
+        Map<String, String> otherOpts = new LinkedHashMap<>();
+        otherOpts.put("-Xmx", "8g");
+        otherOpts.put("-Dcassandra.ring_delay_ms", "60000");
+        CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(null, otherOpts);
+        ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.now(), otherOverlay);
+
+        ConfigurationOverlaySnapshot result = base.overlay(other);
+
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Xmx", "8g");
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Dcassandra.jmx.local.port", "7199");
+        assertThat(result.configuration().extraJvmOpts()).containsEntry("-Dcassandra.ring_delay_ms", "60000");
+    }
+
+    @Test
+    void testOverlayUsesMaxLastModified()
+    {
+        Instant older = Instant.parse("2026-01-01T00:00:00Z");
+        Instant newer = Instant.parse("2026-06-01T00:00:00Z");
+
+        CassandraConfigurationOverlay emptyOverlay = new CassandraConfigurationOverlay(null, null);
+
+        ConfigurationOverlaySnapshot baseOlder = new ConfigurationOverlaySnapshot(older, emptyOverlay);
+        ConfigurationOverlaySnapshot otherNewer = new ConfigurationOverlaySnapshot(newer, emptyOverlay);
+        assertThat(baseOlder.overlay(otherNewer).lastModified()).isEqualTo(newer);
+
+        ConfigurationOverlaySnapshot baseNewer = new ConfigurationOverlaySnapshot(newer, emptyOverlay);
+        ConfigurationOverlaySnapshot otherOlder = new ConfigurationOverlaySnapshot(older, emptyOverlay);
+        assertThat(baseNewer.overlay(otherOlder).lastModified()).isEqualTo(newer);
+    }
+
+    @Test
+    void testOverlayDeepMergesNestedObjects()
+    {
+        JsonObject baseConfigs = new JsonObject()
+                                 .put("skiplist", new JsonObject().put("class_name", "SkipListMemtable"))
+                                 .put("default", new JsonObject().put("inherits", "skiplist"));
+        JsonObject baseYaml = new JsonObject()
+                              .put("memtable", new JsonObject().put("configurations", baseConfigs));
+        CassandraConfigurationOverlay baseOverlay = new CassandraConfigurationOverlay(baseYaml, null);
+        ConfigurationOverlaySnapshot base = new ConfigurationOverlaySnapshot(Instant.now(), baseOverlay);
+
+        JsonObject otherConfigs = new JsonObject()
+                                  .put("trie", new JsonObject().put("class_name", "TrieMemtable"))
+                                  .put("default", new JsonObject().put("inherits", "trie"));
+        JsonObject otherYaml = new JsonObject()
+                               .put("memtable", new JsonObject().put("configurations", otherConfigs));
+        CassandraConfigurationOverlay otherOverlay = new CassandraConfigurationOverlay(otherYaml, null);
+        ConfigurationOverlaySnapshot other = new ConfigurationOverlaySnapshot(Instant.now(), otherOverlay);
+
+        ConfigurationOverlaySnapshot result = base.overlay(other);
+
+        JsonObject resultConfigs = result.configuration().cassandraYaml()
+                                         .getJsonObject("memtable")
+                                         .getJsonObject("configurations");
+        assertThat(resultConfigs.getJsonObject("skiplist").getString("class_name")).isEqualTo("SkipListMemtable");
+        assertThat(resultConfigs.getJsonObject("trie").getString("class_name")).isEqualTo("TrieMemtable");
+        assertThat(resultConfigs.getJsonObject("default").getString("inherits")).isEqualTo("trie");
+    }
+
+    @Test
+    void testEmptySnapshot()
+    {
+        ConfigurationOverlaySnapshot snapshot = ConfigurationOverlaySnapshot.emptySnapshot();
+
+        assertThat(snapshot.lastModified()).isEqualTo(Instant.EPOCH);
+        assertThat(snapshot.configuration().cassandraYaml()).isEmpty();
+        assertThat(snapshot.configuration().extraJvmOpts()).isEmpty();
+        assertThat(snapshot.hash()).startsWith("sha256:");
+        assertThat(snapshot.hash()).hasSize(71);
+    }
+
+    @Test
     void testToString()
     {
         JsonObject yaml = new JsonObject().put("concurrent_reads", 32);
@@ -108,7 +213,7 @@ class ConfigurationOverlaySnapshotTest
             "{",
             "  \"hash\" : \"" + snapshot.hash() + "\",",
             "  \"lastModified\" : \"2026-02-20T14:32:18Z\",",
-            "  \"overlay\" : {",
+            "  \"configuration\" : {",
             "    \"cassandraYaml\" : {",
             "      \"concurrent_reads\" : 32",
             "    },",

--- a/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/FileBasedConfigurationProviderTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/configmanagement/FileBasedConfigurationProviderTest.java
@@ -81,7 +81,7 @@ class FileBasedConfigurationProviderTest
         assertThat(stored).isTrue();
         ConfigurationOverlaySnapshot fetched = provider.getOverlay(instance1);
         assertThat(fetched).isNotNull();
-        assertThat(fetched.overlay()).isEqualTo(snapshot.overlay());
+        assertThat(fetched.configuration()).isEqualTo(snapshot.configuration());
         assertThat(fetched.lastModified()).isEqualTo(snapshot.lastModified());
         assertThat(fetched.hash()).isEqualTo(snapshot.hash());
     }
@@ -105,7 +105,7 @@ class FileBasedConfigurationProviderTest
 
         // Original is preserved
         ConfigurationOverlaySnapshot fetched = provider.getOverlay(instance1);
-        assertThat(fetched.overlay()).isEqualTo(initial.overlay());
+        assertThat(fetched.configuration()).isEqualTo(initial.configuration());
     }
 
     @Test
@@ -127,7 +127,7 @@ class FileBasedConfigurationProviderTest
 
         // Original is preserved
         ConfigurationOverlaySnapshot fetched = provider.getOverlay(instance1);
-        assertThat(fetched.overlay()).isEqualTo(initial.overlay());
+        assertThat(fetched.configuration()).isEqualTo(initial.configuration());
     }
 
     @Test
@@ -141,8 +141,8 @@ class FileBasedConfigurationProviderTest
 
         ConfigurationOverlaySnapshot fetched1 = provider.getOverlay(instance1);
         ConfigurationOverlaySnapshot fetched2 = provider.getOverlay(instance2);
-        assertThat(fetched1.overlay()).isEqualTo(snap1.overlay());
-        assertThat(fetched2.overlay()).isEqualTo(snap2.overlay());
+        assertThat(fetched1.configuration()).isEqualTo(snap1.configuration());
+        assertThat(fetched2.configuration()).isEqualTo(snap2.configuration());
     }
 
     @Test
@@ -241,7 +241,7 @@ class FileBasedConfigurationProviderTest
         ConfigurationOverlaySnapshot fetched = newProvider.getOverlay(instance1);
 
         assertThat(fetched).isNotNull();
-        assertThat(fetched.overlay()).isEqualTo(snapshot.overlay());
+        assertThat(fetched.configuration()).isEqualTo(snapshot.configuration());
         assertThat(fetched.lastModified()).isEqualTo(snapshot.lastModified());
         assertThat(fetched.hash()).isEqualTo(snapshot.hash());
     }
@@ -282,7 +282,7 @@ class FileBasedConfigurationProviderTest
         assertThat(provider.storeOverlay(instance1, hash, updated)).isTrue();
 
         ConfigurationOverlaySnapshot fetched = provider.getOverlay(instance1);
-        assertThat(fetched.overlay()).isEqualTo(updated.overlay());
+        assertThat(fetched.configuration()).isEqualTo(updated.configuration());
         assertThat(fetched.hash()).isEqualTo(updated.hash());
     }
 
@@ -298,8 +298,8 @@ class FileBasedConfigurationProviderTest
 
         ConfigurationOverlaySnapshot fetched = provider.getOverlay(instance1);
         assertThat(fetched).isNotNull();
-        assertThat(fetched.overlay().extraJvmOpts()).containsEntry("-Xmx", "4G");
-        assertThat(fetched.overlay().cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
+        assertThat(fetched.configuration().extraJvmOpts()).containsEntry("-Xmx", "4G");
+        assertThat(fetched.configuration().cassandraYaml().getInteger("concurrent_reads")).isEqualTo(64);
     }
 
     private static ConfigurationOverlaySnapshot createSnapshot(String field, int value)

--- a/server/src/test/resources/configmanagement/cassandra_latest.yaml
+++ b/server/src/test/resources/configmanagement/cassandra_latest.yaml
@@ -1,0 +1,2685 @@
+
+# Cassandra storage config YAML
+
+# NOTE:
+#   See https://cassandra.apache.org/doc/latest/configuration/ for
+#   full explanations of configuration directives
+# /NOTE
+
+# NOTE:
+#   This file is provided in two versions:
+#     - cassandra.yaml: Contains configuration defaults for a "compatible"
+#       configuration that operates using settings that are backwards-compatible
+#       and interoperable with machines running older versions of Cassandra.
+#       This version is provided to facilitate pain-free upgrades for existing
+#       users of Cassandra running in production who want to gradually and
+#       carefully introduce new features.
+#     - cassandra_latest.yaml: Contains configuration defaults that enable
+#       the latest features of Cassandra, including improved functionality as
+#       well as higher performance. This version is provided for new users of
+#       Cassandra who want to get the most out of their cluster, and for users
+#       evaluating the technology.
+#       To use this version, simply copy this file over cassandra.yaml, or specify
+#       it using the -Dcassandra.config system property, e.g. by running
+#         cassandra -Dcassandra.config=file://$CASSANDRA_HOME/conf/cassandra_latest.yaml
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# See https://cassandra.apache.org/doc/latest/getting-started/production.html#tokens for
+# best practice information about num_tokens.
+#
+num_tokens: 16
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replica factor.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+
+# Replica factor is determined via the replication strategy used by the specified
+# keyspace.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# Replica factor is explicitly set, regardless of keyspace or datacenter.
+# This is the replica factor within the datacenter, like NTS.
+allocate_tokens_for_local_replication_factor: 3
+
+# initial_token allows you to specify tokens manually.  While you can use it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters
+# that do not have vnodes enabled.
+# initial_token:
+
+# May either be "true" or "false" to enable globally
+hinted_handoff_enabled: true
+
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+# hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# Min unit: ms
+max_hint_window: 3h
+
+# Maximum throttle in KiBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+# Min unit: KiB
+hinted_handoff_throttle: 1024KiB
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+# hints_directory: /var/lib/cassandra/hints
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+# Min unit: ms
+hints_flush_period: 10000ms
+
+# Maximum size for a single hints file, in mebibytes.
+# Min unit: MiB
+max_hints_file_size: 128MiB
+
+# The file size limit to store hints for an unreachable host, in mebibytes.
+# Once the local hints files have reached the limit, no more new hints will be created.
+# Set a non-positive value will disable the size limit.
+# max_hints_size_per_host: 0MiB
+
+# Enable / disable automatic cleanup for the expired and orphaned hints file.
+# Disable the option in order to preserve those hints on the disk.
+auto_hints_cleanup_enabled: false
+
+# Enable/disable transfering hints to a peer during decommission. Even when enabled, this does not guarantee
+# consistency for logged batches, and it may delay decommission when coupled with a strict hinted_handoff_throttle. 
+# Default: true
+# transfer_hints_on_decommission: true
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Directory where Cassandra should store results of a One-Shot troubleshooting heapdump for uncaught exceptions.
+# Note: this value can be overridden by the -XX:HeapDumpPath JVM env param with a relative local path for testing if
+# so desired.
+# If not set, the default directory is $CASSANDRA_HOME/heapdump
+# heap_dump_path: /var/lib/cassandra/heapdump
+
+# Enable / disable automatic dump of heap on first uncaught exception
+# If not set, the default value is false
+# dump_heap_on_uncaught_exception: true
+
+# Enable / disable persistent hint windows.
+#
+# If set to false, a hint will be stored only in case a respective node
+# that hint is for is down less than or equal to max_hint_window.
+#
+# If set to true, a hint will be stored in case there is not any
+# hint which was stored earlier than max_hint_window. This is for cases
+# when a node keeps to restart and hints are not delivered yet, we would be saving
+# hints for that node indefinitely.
+#
+# Defaults to true.
+#
+# hint_window_persistent_enabled: true
+
+# Maximum throttle in KiBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+# Min unit: KiB
+batchlog_replay_throttle: 1024KiB
+
+# Strategy to choose the batchlog storage endpoints.
+#
+# Available options:
+#
+# - random_remote
+#   Default, purely random, prevents the local rack, if possible.
+#
+# - prefer_local
+#   Similar to random_remote. Random, except that one of the replications will go to the local rack,
+#   which mean it offers lower availability guarantee than random_remote or dynamic_remote.
+#
+# - dynamic_remote
+#   Using DynamicEndpointSnitch to select batchlog storage endpoints, prevents the
+#   local rack, if possible. This strategy offers the same availability guarantees
+#   as random_remote but selects the fastest endpoints according to the DynamicEndpointSnitch.
+#   (DynamicEndpointSnitch currently only tracks reads and not writes - i.e. write-only
+#   (or mostly-write) workloads might not benefit from this strategy.)
+#   Note: this strategy will fall back to random_remote, if dynamic_snitch is not enabled.
+#
+# - dynamic
+#   Mostly the same as dynamic_remote, except that local rack is not excluded, which mean it offers lower
+#   availability guarantee than random_remote or dynamic_remote.
+#   Note: this strategy will fall back to random_remote, if dynamic_snitch is not enabled.
+#
+batchlog_endpoint_strategy: dynamic_remote
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+# Optional parameters can be specified in the form of:
+#   parameters:
+#    param_key1: param_value1
+#    ...
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.roles table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
+authenticator:
+  class_name: AllowAllAuthenticator
+# MutualTlsAuthenticator can be configured using the following configuration. One can add their own validator
+# which implements MutualTlsCertificateValidator class and provide logic for extracting identity out of certificates
+# and validating certificates.
+#  class_name: org.apache.cassandra.auth.MutualTlsAuthenticator
+#  parameters:
+#    validator_class_name: org.apache.cassandra.auth.SpiffeCertificateValidator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+# Optional parameters can be specified in the form of:
+#   parameters:
+#    param_key1: param_value1
+#    ...
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer:
+  class_name: AllowAllAuthorizer
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+# Optional parameters can be specified in the form of:
+#   parameters:
+#    param_key1: param_value1
+#    ...
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+role_manager:
+  class_name: CassandraRoleManager
+  parameters:
+    # Controls how often invalid roles are disconnected, such as when a role is altered with LOGIN=false
+    # Task is scheduled with period + random(0, max_jitter) delay between executions
+    # It's recommended to set these longer than the roles cache refresh period, since the invalidation check depends on
+    # cache contents. Disable by setting period=0h.
+    invalid_role_disconnect_task_period: 4h
+    invalid_role_disconnect_task_max_jitter: 1h
+
+# Network authorization backend, implementing INetworkAuthorizer; used to restrict user
+# access to certain DCs
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllNetworkAuthorizer,
+# CassandraNetworkAuthorizer}.
+# Optional parameters can be specified in the form of:
+#   parameters:
+#    param_key1: param_value1
+#    ...
+#
+# - AllowAllNetworkAuthorizer allows access to any DC to any user - set it to disable authorization.
+# - CassandraNetworkAuthorizer stores permissions in system_auth.network_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+network_authorizer:
+  class_name: AllowAllNetworkAuthorizer
+
+# CIDR authorization backend, implementing ICIDRAuthorizer; used to restrict user
+# access from certain CIDRs
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllCIDRAuthorizer,
+# CassandraCIDRAuthorizer}.
+# Optional parameters can be specified in the form of:
+#   parameters:
+#    param_key1: param_value1
+#    ...
+#
+# - AllowAllCIDRAuthorizer allows access from any CIDR to any user - set it to disable CIDR authorization.
+# - CassandraCIDRAuthorizer stores user's CIDR permissions in system_auth.cidr_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer, otherwise any changes to
+#   system_auth tables being used by this feature may be lost when a host goes down.
+cidr_authorizer:
+  class_name: AllowAllCIDRAuthorizer
+  # Below parameters are used only when CIDR authorizer is enabled
+  # parameters:
+    # CIDR authorizer when enabled, i.e, CassandraCIDRAuthorizer, is applicable for non-superusers only by default.
+    # Set this setting to true, to enable CIDR authorization for superusers as well.
+    # Note: CIDR checks cannot be performed for JMX calls
+    # cidr_checks_for_superusers: true
+
+    # CIDR authorizer when enabled, supports MONITOR and ENFORCE modes. Default mode is MONITOR
+    # In MONITOR mode, CIDR checks are NOT enforced. Instead, CIDR groups of users accesses are logged using
+    # nospamlogger. A warning message would be logged if a user accesses from unauthorized CIDR group (but access won't
+    # be rejected). An info message would be logged otherwise.
+    # In ENFORCE mode, CIDR checks are enforced, i.e, users accesses would be rejected if attempted from unauthorized
+    # CIDR groups.
+    # cidr_authorizer_mode: MONITOR
+
+    # Refresh interval for CIDR groups cache, this value is considered in minutes
+    # cidr_groups_cache_refresh_interval: 5
+
+    # Maximum number of entries an IP to CIDR groups cache can accommodate
+    # ip_cache_max_size: 100
+
+# Depending on the auth strategy of the cluster, it can be beneficial to iterate
+# from root to table (root -> ks -> table) instead of table to root (table -> ks -> root).
+# As the auth entries are whitelisting, once a permission is found you know it to be
+# valid. We default to false as the legacy behavior is to query at the table level then
+# move back up to the root. See CASSANDRA-17016 for details.
+# traverse_auth_from_root: false
+
+# Validity period for roles cache (fetching granted roles can be an expensive
+# operation depending on the role manager, CassandraRoleManager is one example)
+# Granted roles are cached for authenticated sessions in AuthenticatedUser and
+# after the period specified here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable caching entirely.
+# Will be disabled automatically for AllowAllAuthenticator.
+# For a long-running cache using roles_cache_active_update, consider
+# setting to something longer such as a daily validation: 86400000
+# Min unit: ms
+roles_validity: 2000ms
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity is non-zero, then this must be
+# also.
+# This setting is also used to inform the interval of auto-updating if
+# using roles_cache_active_update.
+# Defaults to the same value as roles_validity.
+# For a long-running cache, consider setting this to 60000 (1 hour) etc.
+# Min unit: ms
+# roles_update_interval: 2000ms
+
+# If true, cache contents are actively updated by a background task at the
+# interval set by roles_update_interval. If false, cache entries
+# become eligible for refresh after their update interval. Upon next access,
+# an async reload is scheduled and the old value returned until it completes.
+# roles_cache_active_update: false
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# For a long-running cache using permissions_cache_active_update, consider
+# setting to something longer such as a daily validation: 86400000ms
+# Min unit: ms
+permissions_validity: 2000ms
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity is non-zero, then this must be
+# also.
+# This setting is also used to inform the interval of auto-updating if
+# using permissions_cache_active_update.
+# Defaults to the same value as permissions_validity.
+# For a longer-running permissions cache, consider setting to update hourly (60000)
+# Min unit: ms
+# permissions_update_interval: 2000ms
+
+# If true, cache contents are actively updated by a background task at the
+# interval set by permissions_update_interval. If false, cache entries
+# become eligible for refresh after their update interval. Upon next access,
+# an async reload is scheduled and the old value returned until it completes.
+# permissions_cache_active_update: false
+
+# Validity period for credentials cache. This cache is tightly coupled to
+# the provided PasswordAuthenticator implementation of IAuthenticator. If
+# another IAuthenticator implementation is configured, this cache will not
+# be automatically used and so the following settings will have no effect.
+# Please note, credentials are cached in their encrypted form, so while
+# activating this cache may reduce the number of queries made to the
+# underlying table, it may not  bring a significant reduction in the
+# latency of individual authentication attempts.
+# Defaults to 2000, set to 0 to disable credentials caching.
+# For a long-running cache using credentials_cache_active_update, consider
+# setting to something longer such as a daily validation: 86400000
+# Min unit: ms
+credentials_validity: 2000ms
+
+# Refresh interval for credentials cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If credentials_validity is non-zero, then this must be
+# also.
+# This setting is also used to inform the interval of auto-updating if
+# using credentials_cache_active_update.
+# Defaults to the same value as credentials_validity.
+# For a longer-running permissions cache, consider setting to update hourly (60000)
+# Min unit: ms
+# credentials_update_interval: 2000ms
+
+# If true, cache contents are actively updated by a background task at the
+# interval set by credentials_update_interval. If false (default), cache entries
+# become eligible for refresh after their update interval. Upon next access,
+# an async reload is scheduled and the old value returned until it completes.
+# credentials_cache_active_update: false
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster. The partitioner can NOT be
+# changed without reloading all data.  If you are adding nodes or upgrading,
+# you should set this to the same partitioner that you are currently using.
+#
+# The default partitioner is the Murmur3Partitioner. Older partitioners
+# such as the RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner have been included for backward compatibility only.
+# For new clusters, you should NOT change this value.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk. If multiple
+# directories are specified, Cassandra will spread data evenly across
+# them by partitioning the token ranges.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+
+# Directory were Cassandra should store the data of the local system keyspaces.
+# By default Cassandra will store the data of the local system keyspaces in the first of the data directories specified
+# by data_file_directories.
+# This approach ensures that if one of the other disks is lost Cassandra can continue to operate. For extra security
+# this setting allows to store those data on a different directory that provides redundancy.
+# local_system_data_file_directory:
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+
+# Enable / disable CDC functionality on a per-node basis. This modifies the logic used
+# for write path allocation rejection (standard: never reject. cdc: reject Mutation
+# containing a CDC-enabled table if at space limit in cdc_raw_directory).
+cdc_enabled: false
+
+# Specify whether writes to the CDC-enabled tables should be blocked when CDC data on disk has reached to the limit.
+# When setting to false, the writes will not be blocked and the oldest CDC data on disk will be deleted to
+# ensure the size constraint. The default is true.
+# cdc_block_writes: true
+
+# Specify whether CDC mutations are replayed through the write path on streaming, e.g. repair.
+# When enabled, CDC data streamed to the destination node will be written into commit log first. When setting to false,
+# the streamed CDC data is written into SSTables just the same as normal streaming. The default is true.
+# If this is set to false, streaming will be considerably faster however it's possible that, in extreme situations
+# (losing > quorum # nodes in a replica set), you may have data in your SSTables that never makes it to the CDC log.
+# cdc_on_repair_enabled: true
+
+# CommitLogSegments are moved to this directory on flush if cdc_enabled: true and the
+# segment contains mutations for a CDC-enabled table. This should be placed on a
+# separate spindle than the data directories. If not set, the default directory is
+# $CASSANDRA_HOME/data/cdc_raw.
+# cdc_raw_directory: /var/lib/cassandra/cdc_raw
+
+# Policy for accessing disk:
+#
+# auto
+#   Enable mmap on both data and index files on a 64-bit JVM.
+#
+# standard
+#   Disable mmap entirely.
+#
+# mmap
+#   Map index and data files. mmap can cause excessive paging if all actively read SSTables do not fit into RAM.
+#
+# mmap_index_only
+#   Similar to mmap but maps only index files. Using this setting might also help if you observe high number of page
+#   faults or steals along with increased latencies. This setting is default.
+#
+# disk_access_mode: mmap_index_only
+
+# Policy for data disk failures:
+#
+# die
+#   shut down gossip and client transports and kill the JVM for any fs errors or
+#   single-sstable errors, so the node can be replaced.
+#
+# stop_paranoid
+#   shut down gossip and client transports even for single-sstable errors,
+#   kill the JVM for errors during startup.
+#
+# stop
+#   shut down gossip and client transports, leaving the node effectively dead, but
+#   can still be inspected via JMX, kill the JVM for errors during startup.
+#
+# best_effort
+#    stop using the failed disk and respond to requests based on
+#    remaining available sstables.  This means you WILL see obsolete
+#    data at CL.ONE!
+#
+# ignore
+#    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# Policy for commit disk failures:
+#
+# die
+#   shut down the node and kill the JVM, so the node can be replaced.
+#
+# stop
+#   shut down the node, leaving the node effectively dead, but
+#   can still be inspected via JMX.
+#
+# stop_commit
+#   shutdown the commit log, letting writes collect but
+#   continuing to service reads, as in pre-2.0.5 Cassandra
+#
+# ignore
+#   ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the native protocol prepared statement cache
+#
+# Valid values are either "auto" (omitting the value) or a value greater 0.
+#
+# Note that specifying a too large value will result in long running GCs and possbily
+# out-of-memory errors. Keep the value at a small fraction of the heap.
+#
+# If you constantly see "prepared statements discarded in the last minute because
+# cache limit reached" messages, the first step is to investigate the root cause
+# of these messages and check whether prepared statements are used correctly -
+# i.e. use bind markers for variable parts.
+#
+# Do only change the default value, if you really have more prepared statements than
+# fit in the cache. In most cases it is not neccessary to change this value.
+# Constantly re-preparing statements is a performance penalty.
+#
+# Default value ("auto") is 1/256th of the heap or 10MiB, whichever is greater
+# Min unit: MiB
+prepared_statements_cache_size:
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MiB), 100MiB)). Set to 0 to disable key cache.
+#
+# This is only relevant to SSTable formats that use key cache, e.g. BIG.
+#
+# This version of the configuration is intended for new installs and disables
+# the key cache. Do not do this if you are upgrading from an older Cassandra
+# version and still have sstables in BIG format as it can degrade performance.
+# Min unit: MiB
+key_cache_size: 0MiB
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# This is only relevant to SSTable formats that use key cache, e.g. BIG.
+# Default is 14400 or 4 hours.
+# Min unit: s
+# key_cache_save_period: 4h
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# This is only relevant to SSTable formats that use key cache, e.g. BIG.
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name. Available implementations:
+#
+# org.apache.cassandra.cache.OHCProvider
+#   Fully off-heap row cache implementation (default).
+#
+# org.apache.cassandra.cache.SerializingCacheProvider
+#   This is the row cache implementation available
+#   in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
+# Min unit: MiB
+row_cache_size: 0MiB
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+# Min unit: s
+row_cache_save_period: 0s
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MiB), 50MiB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+# Min unit: MiB
+counter_cache_size:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+# Min unit: s
+counter_cache_save_period: 7200s
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+
+# Number of seconds the server will wait for each cache (row, key, etc ...) to load while starting
+# the Cassandra process. Setting this to zero is equivalent to disabling all cache loading on startup
+# while still having the cache during runtime.
+# Min unit: s
+# cache_load_timeout: 30s
+
+# commitlog_sync may be either "periodic", "group", or "batch."
+#
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been flushed to disk.  Each incoming write will trigger the flush task.
+#
+# group mode is similar to batch mode, where Cassandra will not ack writes
+# until the commit log has been flushed to disk. The difference is group
+# mode will wait up to commitlog_sync_group_window between flushes.
+#
+# Min unit: ms
+# commitlog_sync_group_window: 1000ms
+#
+# the default option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period
+# milliseconds.
+commitlog_sync: periodic
+# Min unit: ms
+commitlog_sync_period: 10000ms
+
+# When in periodic commitlog mode, the number of milliseconds to block writes
+# while waiting for a slow disk flush to complete.
+# Min unit: ms
+# periodic_commitlog_sync_lag_block:
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size in bytes.
+# This should be positive and less than 2048.
+#
+# NOTE: If max_mutation_size is set explicitly then commitlog_segment_size must
+# be set to at least twice the size of max_mutation_size
+#
+# Min unit: MiB
+commitlog_segment_size: 32MiB
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+# commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Set the disk access mode for writing commitlog segments. The allowed values are:
+# - auto: version dependent optimal setting
+# - legacy: the default mode as used in Cassandra 4.x and earlier (standard I/O when the commitlog is either
+#   compressed or encrypted or mmap otherwise)
+# - mmap: use memory mapped I/O - available only when the commitlog is neither compressed nor encrypted
+# - direct: use direct I/O - available only when the commitlog is neither compressed nor encrypted
+# - standard: use standard I/O - available only when the commitlog is compressed or encrypted
+# The default setting is legacy when the storage compatibility is set to 4 or auto otherwise.
+commitlog_disk_access_mode: auto
+
+# Compression to apply to SSTables as they flush for compressed tables.
+# Note that tables without compression enabled do not respect this flag.
+#
+# As high ratio compressors like LZ4HC, Zstd, and Deflate can potentially
+# block flushes for too long, the default is to flush with a known fast
+# compressor in those cases. Options are:
+#
+# none : Flush without compressing blocks but while still doing checksums.
+# fast : Flush with a fast compressor. If the table is already using a
+#        fast compressor that compressor is used.
+# table: Always flush with the same compressor that the table uses. This
+#        was the pre 4.0 behavior.
+#
+# flush_compression: fast
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+  # Addresses of hosts that are deemed contact points.
+  # Cassandra nodes use this list of hosts to find each other and learn
+  # the topology of the ring.  You must change this if you are running
+  # multiple nodes!
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # seeds is actually a comma-delimited list of addresses.
+      # Ex: "<ip1>,<ip2>,<ip3>"
+      - seeds: "127.0.0.1:7000"
+      # If set to "true", SimpleSeedProvider will return all IP addresses for a DNS name,
+      # based on the configured name service on the system. Defaults to "false".
+      #  resolve_multiple_ip_addresses_per_dns_record: "false"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: 32
+
+# Maximum memory to use for inter-node and client-server networking buffers.
+#
+# Defaults to the smaller of 1/16 of heap or 128MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# Min unit: MiB
+# networking_cache_size: 128MiB
+
+# Enable the sstable chunk cache.  The chunk cache will store recently accessed
+# sections of the sstable in-memory as uncompressed buffers.
+# file_cache_enabled: false
+
+# Maximum memory to use for sstable chunk cache and buffer pooling.
+# 32MB of this are reserved for pooling buffers, the rest is used for chunk cache
+# that holds uncompressed sstable chunks.
+# Defaults to the smaller of 1/4 of heap or 512MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
+# Min unit: MiB
+# file_cache_size: 512MiB
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+
+# Supported memtable implementations and selected default.
+# Currently Cassandra offers two memtable implementations:
+# - SkipListMemtable is the legacy memtable implementation provided by earlier
+#   versions of Cassandra.
+# - TrieMemtable is a new memtable that utilizes a trie data structure. This
+#   implementation significantly reduces garbage collection load by moving
+#   more of the sstable metadata off-heap, fits more data in the same allocation
+#   and can reliably handle higher write throughput.
+#   Because the trie memtable is a sharded single-writer solution, it can perform
+#   worse when the load is very unevenly distributed, e.g. when most of the writes
+#   access a very small number of partitions or with legacy secondary indexes.
+# The memtable implementation can be selected per table by setting memtable
+# property in the table definition to one of the configurations specified below.
+# If the memtable property is not set, the "default" configuration will be used.
+# See src/java/org/apache/cassandra/db/memtable/Memtable_API.md for further
+# information.
+memtable:
+  configurations:
+    skiplist:
+      class_name: SkipListMemtable
+    trie:
+      class_name: TrieMemtable
+    default:
+      inherits: trie
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# Min unit: MiB
+# memtable_heap_space: 2048MiB
+# Min unit: MiB
+# memtable_offheap_space: 2048MiB
+
+# memtable_cleanup_threshold is deprecated. The default calculation
+# is the only reasonable choice. See the comments on  memtable_flush_writers
+# for more information.
+#
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#
+# heap_buffers
+#   on heap nio buffers
+#
+# offheap_buffers
+#   off heap (direct) nio buffers
+#
+# offheap_objects
+#    off heap objects
+memtable_allocation_type: offheap_objects
+
+# Limit memory usage for Merkle tree calculations during repairs of a certain
+# table and common token range. Repair commands targetting multiple tables or
+# virtual nodes can exceed this limit depending on concurrent_merkle_tree_requests.
+#
+# The default is 1/16th of the available heap. The main tradeoff is that
+# smaller trees have less resolution, which can lead to over-streaming data.
+# If you see heap pressure during repairs, consider lowering this, but you
+# cannot go below one mebibyte. If you see lots of over-streaming, consider
+# raising this or using subrange repair.
+#
+# For more details see https://issues.apache.org/jira/browse/CASSANDRA-14096.
+#
+# Min unit: MiB
+# repair_session_space:
+
+# The number of simultaneous Merkle tree requests during repairs that can
+# be performed by a repair command. The size of each validation request is
+# limited by the repair_session_space property, so setting this to 1 will make
+# sure that a repair command doesn't exceed that limit, even if the repair
+# command is repairing multiple tables or multiple virtual nodes.
+#
+# There isn't a limit by default for backwards compatibility, but this can
+# produce OOM for  commands repairing multiple tables or multiple virtual nodes.
+# A limit of just 1 simultaneous Merkle tree request is generally recommended
+# with no virtual nodes so repair_session_space, and thereof the Merkle tree
+# resolution, can be high. For virtual nodes a value of 1 with the default
+# repair_session_space value will produce higher resolution Merkle trees
+# at the expense of speed. Alternatively, when working with virtual nodes it
+# can make sense to reduce the repair_session_space and increase the value of
+# concurrent_merkle_tree_requests because each range will contain fewer data.
+#
+# For more details see https://issues.apache.org/jira/browse/CASSANDRA-19336.
+#
+# A zero value means no limit.
+# concurrent_merkle_tree_requests: 0
+
+# repair:
+#   # Configure the retries for each of the repair messages that support it.  As of this moment retries use an exponential algorithm where each attempt sleeps longer based off the base_sleep_time and attempt.
+#   retries:
+#     max_attempts: 10
+#     base_sleep_time: 200ms
+#     max_sleep_time: 1s
+#     # Increase the timeout of validation responses due to them containing the merkle tree
+#     merkle_tree_response:
+#       base_sleep_time: 30s
+#       max_sleep_time: 1m
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space: 8192MiB
+
+# This sets the number of memtable flush writer threads per disk
+# as well as the total number of memtables that can be flushed concurrently.
+# These are generally a combination of compute and IO bound.
+#
+# Memtable flushing is more CPU efficient than memtable ingest and a single thread
+# can keep up with the ingest rate of a whole server on a single fast disk
+# until it temporarily becomes IO bound under contention typically with compaction.
+# At that point you need multiple flush threads. At some point in the future
+# it may become CPU bound all the time.
+#
+# You can tell if flushing is falling behind using the MemtablePool.BlockedOnAllocation
+# metric which should be 0, but will be non-zero if threads are blocked waiting on flushing
+# to free memory.
+#
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory.
+# If you have multiple data directories the default is one memtable flushing at a time
+# but the flush will use a thread per data directory so you will get two or more writers.
+#
+# Two is generally enough to flush on a fast disk [array] mounted as a single data directory.
+# Adding more flush writers will result in smaller more frequent flushes that introduce more
+# compaction overhead.
+#
+# There is a direct tradeoff between number of memtables that can be flushed concurrently
+# and flush size and frequency. More is not better you just need enough flush writers
+# to never stall waiting for flushing to free memory.
+#
+# memtable_flush_writers: 2
+
+# Total space to use for change-data-capture logs on disk.
+#
+# If space gets above this value, Cassandra will throw WriteTimeoutException
+# on Mutations including tables with CDC enabled. A CDCCompactor is responsible
+# for parsing the raw CDC logs and deleting them when parsing is completed.
+#
+# The default value is the min of 4096 MiB and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+# Min unit: MiB
+# cdc_total_space: 4096MiB
+
+# When we hit our cdc_raw limit and the CDCCompactor is either running behind
+# or experiencing backpressure, we check at the following interval to see if any
+# new space for cdc-tracked tables has been made available. Default to 250ms
+# Min unit: ms
+# cdc_free_space_check_interval: 250ms
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: true
+# Min unit: KiB
+trickle_fsync_interval: 10240KiB
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: 7000
+
+# SSL port, for legacy encrypted communication. This property is unused unless enabled in
+# server_encryption_options (see below). As of cassandra 4.0, this property is deprecated
+# as a single port can be used for either/both secure and insecure connections.
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be). If unresolvable
+# it will fall back to InetAddress.getLoopbackAddress(), which is wrong for production systems.
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+listen_address: localhost
+
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# listen_interface: eth0
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+#internode_authenticator:
+#  class_name: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+#  parameters:
+# MutualTlsInternodeAuthenticator can be configured using the following configuration.One can add their own validator
+# which implements MutualTlsCertificateValidator class and provide logic for extracting identity out of certificates
+# and validating certificates.
+#  class_name: org.apache.cassandra.auth.MutualTlsInternodeAuthenticator
+#  parameters:
+#    validator_class_name: org.apache.cassandra.auth.SpiffeCertificateValidator
+#    trusted_peer_identities: "spiffe1,spiffe2"
+#    node_identity: "spiffe1"
+# Whether to start the native transport server.
+# The address on which the native transport is bound is defined by rpc_address.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# The maximum threads for handling requests (note that idle threads are stopped
+# after 30 seconds so there is not corresponding minimum setting).
+# native_transport_max_threads: 128
+# The maximum threads for handling auth requests in a separate executor from main request executor.
+# When set to 0, main executor for requests is used.
+# native_transport_max_auth_threads: 4
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 16MiB. If you're changing this parameter,
+# you may want to adjust max_value_size accordingly. This should be positive and less than 2048.
+# Min unit: MiB
+# native_transport_max_frame_size: 16MiB
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# Controls whether Cassandra honors older, yet currently supported, protocol versions.
+# The default is true, which means all supported protocols will be honored.
+native_transport_allow_older_protocols: true
+
+# Controls when idle client connections are closed. Idle connections are ones that had neither reads
+# nor writes for a time period.
+#
+# Clients may implement heartbeats by sending OPTIONS native protocol message after a timeout, which
+# will reset idle timeout timer on the server side. To close idle client connections, corresponding
+# values for heartbeat intervals have to be set on the client side.
+#
+# Idle connection timeouts are disabled by default.
+# Min unit: ms
+# native_transport_idle_timeout: 60000ms
+
+# When enabled, limits the number of native transport requests dispatched for processing per second.
+# Behavior once the limit has been breached depends on the value of THROW_ON_OVERLOAD specified in
+# the STARTUP message sent by the client during connection establishment. (See section "4.1.1. STARTUP"
+# in "CQL BINARY PROTOCOL v5".) With the THROW_ON_OVERLOAD flag enabled, messages that breach the limit
+# are dropped, and an OverloadedException is thrown for the client to handle. When the flag is not
+# enabled, the server will stop consuming messages from the channel/socket, putting backpressure on
+# the client while already dispatched messages are processed.
+# native_transport_rate_limiting_enabled: false
+# native_transport_max_requests_per_second: 1000000
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+rpc_address: localhost
+
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# rpc_interface: eth1
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# rpc_interface_prefer_ipv6: false
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See also:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and 'man tcp'
+# Min unit: B
+# internode_socket_send_buffer_size:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# Min unit: B
+# internode_socket_receive_buffer_size:
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of all the
+# keyspace data in this node.  Removing these links is the operator's
+# responsibility. The operator can also turn off incremental backups 
+# for specified table by setting table parameter incremental_backups to 
+# false, which is set to true by default. See CASSANDRA-15402
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# Adds a time-to-live (TTL) to auto snapshots generated by table
+# truncation or drop (when enabled).
+# After the TTL is elapsed, the snapshot is automatically cleared.
+# By default, auto snapshots *do not* have TTL, uncomment the property below
+# to enable TTL on auto snapshots.
+# Accepted units: d (days), h (hours) or m (minutes)
+# auto_snapshot_ttl: 30d
+
+# The act of creating or clearing a snapshot involves creating or removing
+# potentially tens of thousands of links, which can cause significant performance
+# impact, especially on consumer grade SSDs. A non-zero value here can
+# be used to throttle these links to avoid negative performance impact of
+# taking and clearing snapshots
+snapshot_links_per_second: 0
+
+# The sstable formats configuration. SSTable formats implementations are
+# loaded using the service loader mechanism. In this section, one can select
+# the format for created sstables and pass additional parameters for the formats
+# available on the classpath.
+# The default format is "big", the legacy SSTable format in use since Cassandra 3.0.
+# Cassandra versions 5.0 and later also support the trie-indexed "bti" format,
+# which offers better performance.
+sstable:
+  selected_format: bti
+
+# Granularity of the collation index of rows within a partition.
+# Applies to both BIG and BTI SSTable formats. In both formats,
+# a smaller granularity results in faster lookup of rows within
+# a partition, but a bigger index file size.
+# Using smaller granularities with the BIG format is not recommended
+# because bigger collation indexes cannot be cached efficiently
+# or at all if they become sufficiently large. Further, if
+# large rows, or a very large number of rows per partition are
+# present, it is recommended to increase the index granularity
+# or switch to the BTI SSTable format.
+#
+# Leave undefined to use a default suitable for the SSTable format
+# in use (64 KiB for BIG, 16KiB for BTI).
+# Min unit: KiB
+column_index_size: 4KiB
+
+# Default compaction strategy, applied when a table's parameters do not
+# specify compaction.
+# The selected compaction strategy will also apply to system tables.
+#
+# If no value is specified, the default is to use SizeTieredCompactionStrategy,
+# with its default compaction parameters.
+#
+default_compaction:
+  class_name: UnifiedCompactionStrategy
+  parameters:
+    scaling_parameters: T4
+    max_sstables_to_compact: 64
+    target_sstable_size: 1GiB
+    sstable_growth: 0.3333333333333333
+    min_sstable_size: 100MiB
+
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+#
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+concurrent_compactors: 8
+
+# Number of simultaneous repair validations to allow. If not set or set to
+# a value less than 1, it defaults to the value of concurrent_compactors.
+# To set a value greeater than concurrent_compactors at startup, the system
+# property cassandra.allow_unlimited_concurrent_validations must be set to
+# true. To dynamically resize to a value > concurrent_compactors on a running
+# node, first call the bypassConcurrentValidatorsLimit method on the
+# org.apache.cassandra.db:type=StorageService mbean
+# concurrent_validations: 0
+
+# Number of simultaneous materialized view builder tasks to allow.
+concurrent_materialized_view_builders: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this accounts for all types
+# of compaction, including validation compaction (building Merkle trees
+# for repairs).
+compaction_throughput: 64MiB/s
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads
+# between the sstables, reducing page cache churn and keeping hot rows hot
+# Set sstable_preemptive_open_interval to null for disabled which is equivalent to
+# sstable_preemptive_open_interval_in_mb being negative
+# Min unit: MiB
+sstable_preemptive_open_interval: 50MiB
+
+# Starting from 4.1 sstables support UUID based generation identifiers. They are disabled by default
+# because once enabled, there is no easy way to downgrade. When the node is restarted with this option
+# set to true, each newly created sstable will have a UUID based generation identifier and such files are
+# not readable by previous Cassandra versions. At some point, this option will become true by default
+# and eventually get removed from the configuration.
+uuid_sstable_identifiers_enabled: true
+
+# When enabled, permits Cassandra to zero-copy stream entire eligible
+# SSTables between nodes, including every component.
+# This speeds up the network transfer significantly subject to
+# throttling specified by entire_sstable_stream_throughput_outbound,
+# and entire_sstable_inter_dc_stream_throughput_outbound
+# for inter-DC transfers.
+# Enabling this will reduce the GC pressure on sending and receiving node.
+# When unset, the default is enabled. While this feature tries to keep the
+# disks balanced, it cannot guarantee it. This feature will be automatically
+# disabled if internode encryption is enabled.
+stream_entire_sstables: true
+
+# Throttles entire SSTable outbound streaming file transfers on
+# this node to the given total throughput in Mbps.
+# Setting this value to 0 it disables throttling.
+# When unset, the default is 200 Mbps or 24 MiB/s.
+# entire_sstable_stream_throughput_outbound: 24MiB/s
+
+# Throttles entire SSTable file streaming between datacenters.
+# Setting this value to 0 disables throttling for entire SSTable inter-DC file streaming.
+# When unset, the default is 200 Mbps or 24 MiB/s.
+# entire_sstable_inter_dc_stream_throughput_outbound: 24MiB/s
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 24 MiB/s.
+# stream_throughput_outbound: 24MiB/s
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 24 MiB/s.
+# inter_dc_stream_throughput_outbound: 24MiB/s
+
+# Server side timeouts for requests. The server will return a timeout exception
+# to the client if it can't complete an operation within the corresponding
+# timeout. Those settings are a protection against:
+#   1) having client wait on an operation that might never terminate due to some
+#      failures.
+#   2) operations that use too much CPU/read too much data (leading to memory build
+#      up) by putting a limit to how long an operation will execute.
+# For this reason, you should avoid putting these settings too high. In other words,
+# if you are timing out requests because of underlying resource constraints then
+# increasing the timeout will just cause more problems. Of course putting them too
+# low is equally ill-advised since clients could get timeouts even for successful
+# operations just because the timeout setting is too tight.
+
+# How long the coordinator should wait for read operations to complete.
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+read_request_timeout: 5000ms
+# How long the coordinator should wait for seq or index scans to complete.
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+range_request_timeout: 10000ms
+# How long the coordinator should wait for writes to complete.
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+write_request_timeout: 10000ms
+# How long the coordinator should wait for counter writes to complete.
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+counter_write_request_timeout: 1000ms
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row.
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+cas_contention_timeout: 5000ms
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+truncate_request_timeout: 60000ms
+# The default timeout for other, miscellaneous operations.
+# Lowest acceptable value is 10 ms.
+# Min unit: ms
+request_timeout: 10000ms
+
+# Defensive settings for protecting Cassandra from true network partitions.
+# See (CASSANDRA-14358) for details.
+#
+# The amount of time to wait for internode tcp connections to establish.
+# Min unit: ms
+# internode_tcp_connect_timeout: 2000ms
+#
+# The amount of time unacknowledged data is allowed on a connection before we throw out the connection
+# Note this is only supported on Linux + epoll, and it appears to behave oddly above a setting of 30000
+# (it takes much longer than 30s) as of Linux 4.12. If you want something that high set this to 0
+# which picks up the OS default and configure the net.ipv4.tcp_retries2 sysctl to be ~8.
+# Min unit: ms
+# internode_tcp_user_timeout: 30000ms
+
+# The amount of time unacknowledged data is allowed on a streaming connection.
+# The default is 5 minutes. Increase it or set it to 0 in order to increase the timeout.
+# Min unit: ms
+# internode_streaming_tcp_user_timeout: 300000ms
+
+# Global, per-endpoint and per-connection limits imposed on messages queued for delivery to other nodes
+# and waiting to be processed on arrival from other nodes in the cluster.  These limits are applied to the on-wire
+# size of the message being sent or received.
+#
+# The basic per-link limit is consumed in isolation before any endpoint or global limit is imposed.
+# Each node-pair has three links: urgent, small and large.  So any given node may have a maximum of
+# N*3*(internode_application_send_queue_capacity+internode_application_receive_queue_capacity)
+# messages queued without any coordination between them although in practice, with token-aware routing, only RF*tokens
+# nodes should need to communicate with significant bandwidth.
+#
+# The per-endpoint limit is imposed on all messages exceeding the per-link limit, simultaneously with the global limit,
+# on all links to or from a single node in the cluster.
+# The global limit is imposed on all messages exceeding the per-link limit, simultaneously with the per-endpoint limit,
+# on all links to or from any node in the cluster.
+#
+# Min unit: B
+# internode_application_send_queue_capacity: 4MiB
+# internode_application_send_queue_reserve_endpoint_capacity: 128MiB
+# internode_application_send_queue_reserve_global_capacity: 512MiB
+# internode_application_receive_queue_capacity: 4MiB
+# internode_application_receive_queue_reserve_endpoint_capacity: 128MiB
+# internode_application_receive_queue_reserve_global_capacity: 512MiB
+
+
+# How long before a node logs slow queries. Select queries that take longer than
+# this timeout to execute, will generate an aggregated log message, so that slow queries
+# can be identified. Set this value to zero to disable slow query logging.
+# Min unit: ms
+slow_query_log_timeout: 500ms
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing
+# already-timed-out requests.
+#
+# Warning: It is generally assumed that users have setup NTP on their clusters, and that clocks are modestly in sync,
+# since this is a requirement for general correctness of last write wins.
+# internode_timeout: true
+
+# Set period for idle state control messages for earlier detection of failed streams
+# This node will send a keep-alive message periodically on the streaming's control channel.
+# This ensures that any eventual SocketTimeoutException will occur within 2 keep-alive cycles
+# If the node cannot send, or timeouts sending, the keep-alive message on the netty control channel
+# the stream session is closed.
+# Default value is 300s (5 minutes), which means stalled streams
+# are detected within 10 minutes
+# Specify 0 to disable.
+# Min unit: s
+# streaming_keep_alive_period: 300s
+
+# Limit number of connections per host for streaming
+# Increase this when you notice that joins are CPU-bound rather that network
+# bound (for example a few nodes with big files).
+# streaming_connections_per_host: 1
+
+# Settings for stream stats tracking; used by system_views.streaming table
+# How long before a stream is evicted from tracking; this impacts both historic and currently running
+# streams.
+# streaming_state_expires: 3d
+# How much memory may be used for tracking before evicting session from tracking; once crossed
+# historic and currently running streams maybe impacted.
+# streaming_state_size: 40MiB
+# Enable/Disable tracking of streaming stats
+# streaming_stats_enabled: true
+
+# Allows denying configurable access (rw/rr) to operations on configured ks, table, and partitions, intended for use by
+# operators to manage cluster health vs application access. See CASSANDRA-12106 and CEP-13 for more details.
+# partition_denylist_enabled: false
+
+# denylist_writes_enabled: true
+# denylist_reads_enabled: true
+# denylist_range_reads_enabled: true
+
+# The interval at which keys in the cache for denylisting will "expire" and async refresh from the backing DB.
+# Note: this serves only as a fail-safe, as the usage pattern is expected to be "mutate state, refresh cache" on any
+# changes to the underlying denylist entries. See documentation for details.
+# Min unit: s
+# denylist_refresh: 600s
+
+# In the event of errors on attempting to load the denylist cache, retry on this interval.
+# Min unit: s
+# denylist_initial_load_retry: 5s
+
+# We cap the number of denylisted keys allowed per table to keep things from growing unbounded. Nodes will warn above
+# this limit while allowing new denylisted keys to be inserted. Denied keys are loaded in natural query / clustering
+# ordering by partition key in case of overflow.
+# denylist_max_keys_per_table: 1000
+
+# We cap the total number of denylisted keys allowed in the cluster to keep things from growing unbounded.
+# Nodes will warn on initial cache load that there are too many keys and be direct the operator to trim down excess
+# entries to within the configured limits.
+# denylist_max_keys_total: 10000
+
+# Since the denylist in many ways serves to protect the health of the cluster from partitions operators have identified
+# as being in a bad state, we usually want more robustness than just CL.ONE on operations to/from these tables to
+# ensure that these safeguards are in place. That said, we allow users to configure this if they're so inclined.
+# denylist_consistency_level: QUORUM
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# The settings in the following section are intended to supercede the use of endpoint_snitch:
+# initial_location_provider
+# node_proximity
+# addresses_config (optional)
+# prefer_local_connections (optional, defaults to false)
+
+# The initial location provider supplies the datacenter and rack for a new node joining the
+# cluster for the first time. This DC/rack is used to register the node with the cluster and
+# is then persisted in and propagated by cluster metadata. The initial location provider is
+# not used after this initial phase of the node lifecycle is complete. Cassandra provides the
+# following implementations:
+#
+# SimpleLocationProvider:
+#    Hardcoded to supply a static location of `datacenter1/rack1`. Replicates the behaviour of
+#    SimpleSnitch.
+#
+# RackDCFileLocationProvider:
+#    The rack and datacenter for the local node are defined in cassandra-rackdc.properties,
+#    and is backwards compatible with the configuration of GossipingPropertyFileSnitch.
+#
+# TopologyFileLocationProvider:
+#    The rack and datacenter for the local node are defined in cassandra-topology.properties,
+#    and is backwards compatible with the configuration of PropertyFileSnitch. Only the location
+#    info for the local node is relevant now, rack/dc specifications for other endpoints are
+#    ignored.
+#
+# AlibabaCloudLocationProvider:
+#    Obtains datacenter and rack of the node from the metadata service of Alibaba cloud. This
+#    maps the ECS region to datacenter and the ECS availability zone to the rack. Intended to
+#    replace use of AlibabaCloudSnitch.
+#
+# AzureCloudLocationProvider:
+#    Maps datacenter to `location` and rack to `zone` fields of the `compute` object obtained
+#    from the Azure metadata service. If the availablity zone is not enabled, it will use the
+#    failure domain and get its respective value. Intended to replace use of AzureSnitch.
+#
+# CloudstackLocationProvider:
+#    Assumes a Cloudstack Zone follows the typical convention country-location-az, using a
+#    country/location tuple as a datacenter and the availability zone as a rack. Intended to
+#    replace use of CloudstackSnitch.
+#    WARNING: This legacy snitch has been deprecated and is scheduled to be removed in a future
+#    version of Cassandra.
+#
+# Ec2LocationProvider:
+#    Loads Region and Availability Zone information from the EC2 API. The Region is treated as the
+#    datacenter and the AvailablilityZone as the rack. Intended to replace use of Ec2Snitch and
+#    Ec2MultiRegionSnitch.
+#
+# GoogleCloudLocationProvider:
+#    Fetches source data from the metadata service of Google Cloud. This provider maps the GCE
+#    region to datacenter and the availibility zone to the rack. Intended to replace use of
+#    GoogleCloudSnitch.
+initial_location_provider: SimpleLocationProvider
+
+# Node proximity controls sorting and ranking of replica lists in order to route requests efficiently.
+# Dynamic snitch (not configured here) provides an additional level of sorting on top of whatever is
+# specified here of sorting based on recorded latencies between peers.
+#
+# Out of the box Cassandra provides:
+#
+# NoOpProximity:
+#    Performs no reordering of replica lists and assigns every endpoint equal proximity, regardless of
+#    actual topology. This replicates the behaviour of SimpleSnitch.
+#
+# NetworkTopologyProximity:
+#    Ranks proximity of nodes based on datacenter and rack. Nodes in the same rack are considered
+#    closest, followed by those in the same datacenter. Nodes in different datacenters are
+#    considered furthest apart. Replicates the behaviour of topology aware snitches such as
+#    GossipingPropertyFileSnitch, PropertyFileSnitch and the multiple cloud platform snitches.
+node_proximity: NetworkTopologyProximity
+
+# Address configuration (public and private endpoint addresses) is almost always derived directly
+# from this configuration file using broadcast_address. In certain deployments, both the public and
+# private addresses may be configured from an external source. For instance, in EC2 a node will have
+# discover both of its own addresses at startup by querying the appropriate cloud metadata service.
+# In multi-region EC2 deployments, this should be set to Ec2MultiRegionAddressConfig, to replicate the
+# behaviour of Ec2MultiRegionSnitch.
+#addresses_config: Ec2MultiRegionAddressConfig
+
+# Controls whether or not to ensure that connections to peers in the same datacenter are established
+# using private addresses. Typically, this is for situations like EC2 where a node will have a public
+# address and a private address. We may initially connect on the public, then discover the private, and
+# reconnect on the private.
+# In Ec2MultiRegionSnitch (now deprecated), this behaviour was hard coded so if migrating from that
+# snitch to modern config, set this to true.
+# In GossipingPropertyFileSnitch (now deprecated), this behaviour was configured by the `prefer_local`
+# property so if migrating from that snitch to modern config, set this accordingly.
+#prefer_local_connections: false
+
+# controls how often to perform the more expensive part of host score
+# calculation
+# Min unit: ms
+dynamic_snitch_update_interval: 100ms
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+# Min unit: ms
+dynamic_snitch_reset_interval: 600000ms
+# if set greater than zero, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 1.0
+
+# Configures Java crypto provider. By default, it will use DefaultCryptoProvider
+# which will install Amazon Correto Crypto Provider.
+#
+# Amazon Correto Crypto Provider works currently for x86_64 and aarch_64 platforms.
+# If this provider fails it will fall back to the default crypto provider in the JRE.
+#
+# To force failure when the provider was not installed properly, set the property "fail_on_missing_provider" to "true".
+#
+# To bypass the installation of a crypto provider use class 'org.apache.cassandra.security.JREProvider'
+#
+crypto_provider:
+  - class_name: org.apache.cassandra.security.DefaultCryptoProvider
+    parameters:
+      - fail_on_missing_provider: "false"
+
+# Configure server-to-server internode encryption
+#
+# JVM and netty defaults for supported SSL socket protocols and cipher suites can
+# be replaced using custom encryption options. This is not recommended
+# unless you have policies in place that dictate certain settings, or
+# need to disable vulnerable ciphers or protocols in case the JVM cannot
+# be updated.
+#
+# FIPS compliant settings can be configured at JVM level and should not
+# involve changing encryption settings here:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/FIPS.html
+#
+# **NOTE** this default configuration is an insecure configuration. If you need to
+# enable server-to-server encryption generate server keystores (and truststores for mutual
+# authentication) per:
+# http://download.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# Then perform the following configuration changes:
+#
+# Step 1: Set internode_encryption=<dc|rack|all> and explicitly set optional=true. Restart all nodes
+#
+# Step 2: Set optional=false (or remove it) and if you generated truststores and want to use mutual
+# auth set require_client_auth=true. Restart all nodes
+server_encryption_options:
+  # On outbound connections, determine which type of peers to securely connect to.
+  #   The available options are :
+  #     none : Do not encrypt outgoing connections
+  #     dc   : Encrypt connections to peers in other datacenters but not within datacenters
+  #     rack : Encrypt connections to peers in other racks but not within racks
+  #     all  : Always use encrypted connections
+  internode_encryption: none
+  # When set to true, encrypted and unencrypted connections are allowed on the storage_port
+  # This should _only be true_ while in unencrypted or transitional operation
+  # optional defaults to true if internode_encryption is none
+  # optional: true
+  # If enabled, will open up an encrypted listening socket on ssl_storage_port. Should only be used
+  # during upgrade to 4.0; otherwise, set to false.
+  legacy_ssl_storage_port_enabled: false
+  # Set to a valid keystore if internode_encryption is dc, rack or all
+  keystore: conf/.keystore
+  #keystore_password: cassandra
+  # Optional configuration to specify password for keystore in a separate file
+  # When keystore_password and keystore_password_file both are specified, the keystore_password will take precedence
+  # The password in the file should be on the first line
+  #keystore_password_file: conf/keystore_passwordfile.txt
+  # Configure the way Cassandra creates SSL contexts.
+  # To use PEM-based key material, see org.apache.cassandra.security.PEMBasedSslContextFactory
+  # ssl_context_factory:
+  #     # Must be an instance of org.apache.cassandra.security.ISslContextFactory
+  #     class_name: org.apache.cassandra.security.DefaultSslContextFactory
+  # During internode mTLS authentication, inbound connections (acting as servers) use keystore, keystore_password
+  # containing server certificate to create SSLContext and
+  # outbound connections (acting as clients) use outbound_keystore & outbound_keystore_password with client certificates
+  # to create SSLContext. By default, outbound_keystore is the same as keystore indicating mTLS is not enabled.
+#  outbound_keystore: conf/.keystore
+#  outbound_keystore_password: cassandra
+  # Optional configuration to specify password for keystore in a separate file
+  # When outbound_keystore_password and outbound_keystore_password_file both are specified,
+  # the outbound_keystore_password will take precedence
+  # The password in the file should be on the first line
+  #outbound_keystore_password_file: conf/outbound_keystore_passwordfile.txt
+  # Verify peer server certificates
+  require_client_auth: false
+  # Set to a valid trustore if require_client_auth is true
+  truststore: conf/.truststore
+  #truststore_password: cassandra
+  # Optional configuration to specify password for truststore in a separate file
+  # When truststore_password and truststore_password_file both are specified, the truststore_password will take precedence
+  # The password in the file should be on the first line
+  #truststore_password_file: conf/truststore_passwordfile.txt
+  # Verify that the host name in the certificate matches the connected host
+  require_endpoint_verification: false
+  # More advanced defaults:
+  # protocol: TLS
+  # store_type: JKS
+  # cipher_suites: [
+  #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+  #   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_RSA_WITH_AES_256_CBC_SHA
+  # ]
+
+# Configure client-to-server encryption.
+#
+# **NOTE** this default configuration is an insecure configuration. If you need to
+# enable client-to-server encryption generate server keystores (and truststores for mutual
+# authentication) per:
+# http://download.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+# Then perform the following configuration changes:
+#
+# Step 1: Set enabled=true and explicitly set optional=true. Restart all nodes
+#
+# Step 2: Set optional=false (or remove it) and if you generated truststores and want to use mutual
+# auth set require_client_auth=true. Restart all nodes
+client_encryption_options:
+  # Enable client-to-server encryption
+  enabled: false
+  # When set to true, encrypted and unencrypted connections are allowed on the native_transport_port
+  # This should _only be true_ while in unencrypted or transitional operation
+  # optional defaults to true when enabled is false, and false when enabled is true.
+  # optional: true
+  # Set keystore and keystore_password to valid keystores if enabled is true
+  keystore: conf/.keystore
+  #keystore_password: cassandra
+  # Optional configuration to specify password for keystore in a separate file
+  # When keystore_password and keystore_password_file both are specified, the keystore_password will take precedence
+  # The password in the file should be on the first line
+  #keystore_password_file: conf/keystore_passwordfile.txt
+  # Configure the way Cassandra creates SSL contexts.
+  # To use PEM-based key material, see org.apache.cassandra.security.PEMBasedSslContextFactory
+  # ssl_context_factory:
+  #     # Must be an instance of org.apache.cassandra.security.ISslContextFactory
+  #     class_name: org.apache.cassandra.security.DefaultSslContextFactory
+  # Verify client certificates
+  # - true/REQUIRED, Verifies the client and forces the client to send client certificate
+  # - false/NOT_REQUIRED, Doesn't verify the client
+  # - optional, Optionally verifies the client if client certificate is sent, but doesn't force client certificate to send certificates
+  require_client_auth: false
+  # require_endpoint_verification: false
+  # Set trustore and truststore_password if require_client_auth is true
+  # truststore: conf/.truststore
+  # truststore_password: cassandra
+  # Optional configuration to specify password for truststore in a separate file
+  # When truststore_password and truststore_password_file both are specified, the truststore_password will take precedence
+  # The password in the file should be on the first line
+  #truststore_password_file: conf/truststore_passwordfile.txt
+  # More advanced defaults:
+  # protocol: TLS
+  # store_type: JKS
+  # cipher_suites: [
+  #   TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+  #   TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA,
+  #   TLS_RSA_WITH_AES_256_CBC_SHA
+  # ]
+
+# Configure SSL for JMX
+#
+# Using system properties via cassandra-env.sh to configure JMX SSL is
+# considered legacy and only supported for backward compatibility. If SSL
+# is enabled via both methods, a configuration error will occur at
+# startup. Hot reloading of the `SSLContext` is not yet supported for the
+# JMX SSL.
+# Similar to `client/server_encryption_options`, you can specify PEM-based
+# key material or customize the SSL configuration using `ssl_context_factory` in `jmx_encryption_options`.
+# If you uncomment this section, please be sure that you comment out configure_jmx function call in cassandra-env.sh
+# as it is errorneous to have JMX set by two ways, both in cassandra-env.sh and in this yaml.
+#jmx_server_options:
+  # enabled: true
+  # remote: false
+  # jmx_port: 7199
+  #
+  # Port used by the RMI registry when remote connections are enabled.
+  # To simplify firewall configs, this can be set to the same as the JMX server port (port). See CASSANDRA-7087.
+  # However, if ssl is enabled the same port cannot be used for both jmx and rmi so either
+  # pick another value for this property. Alternatively, comment out or set to 0 to use a random
+  # port (pre-CASSANDRA-7087 behaviour)
+  # rmi_port: 7199
+  #
+  # jmx ssl options - only apply when remote connections are enabled
+  #
+  # jmx_encryption_options:
+  #   enabled: true
+  #   cipher_suites: [TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256]
+  #   accepted_protocols: [TLSv1.2,TLSv1.3,TLSv1.1]
+  #   keystore: conf/cassandra_ssl.keystore
+  #   keystore_password: cassandra
+  #   Optional configuration to specify password for keystore in a separate file
+  #   When keystore_password and keystore_password_file both are specified, the keystore_password will take precedence
+  #   The password in the file should be on the first line
+  #   keystore_password_file: conf/keystore_passwordfile.txt
+  #   truststore: conf/cassandra_ssl.truststore
+  #   truststore_password: cassandra
+  #   Optional configuration to specify password for truststore in a separate file
+  #   When truststore_password and truststore_password_file both are specified, the truststore_password will take precedence
+  #   The password in the file should be on the first line
+  #   truststore_password_file: conf/truststore_passwordfile.txt
+  #
+  # jmx authentication and authorization options.
+  # authenticate: false
+  #
+  # Options for basic file based authentication & authorization
+  # password_file: /etc/cassandra/jmxremote.password
+  # access_file: /etc/cassandra/jmxremote.access
+  #
+  # Custom auth settings which can be used as alternatives to JMX's out of the box auth utilities.
+  # JAAS login modules can be used for authentication using this property.Cassandra ships with a
+  # LoginModule implementation - org.apache.cassandra.auth.CassandraLoginModule - which delegates
+  # to the IAuthenticator configured in cassandra.yaml.
+  #
+  # login_config_name refers to the Application Name in the JAAS configuration under which the
+  # desired LoginModule(s) are configured.
+  # The location of the JAAS config file may be set using the standard JVM mechanism, by setting
+  # the system property "java.security.auth.login.config". If this property is set, it's value
+  # will be used to locate the config file. For convenience, if the property is not already set
+  # at startup, a value can be supplied here via the login_config_file setting.
+  #
+  # The Application Name specified must be present in the JAAS config or an error will be thrown
+  # when authentication is attempted.
+  # See the sample JAAS configuration file conf/cassandra-jaas.config
+  # login_config_name: CassandraLogin
+  # login_config_file: conf/cassandra-jaas.config
+  #
+  # Cassandra also ships with a helper for delegating JMX authz calls to the configured IAuthorizer,
+  # uncomment this to use it. Requires one of the two authentication options to be enabled
+  # authorizer: org.apache.cassandra.auth.jmx.AuthorizationProxy
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# Can be:
+#
+# all
+#   all traffic is compressed
+#
+# dc
+#   traffic between different datacenters is compressed
+#
+# none
+#   nothing is compressed.
+internode_compression: dc
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+# Min unit: s
+trace_type_query_ttl: 1d
+# Min unit: s
+trace_type_repair_ttl: 7d
+
+# If unset, all GC Pauses greater than gc_log_threshold will log at
+# INFO level
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+user_defined_functions_enabled: false
+
+# Triggers are enabled by default.
+# `enabled` executes queries and their triggers.
+# `disabled` executes queries but skips trigger execution, and logs a warning.
+# `forbidden` fails queries that would execute triggers with TriggerDisabledException.
+triggers_policy: enabled
+
+# Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
+# a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
+# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# can still (and should!) be in the keystore and will be used on decrypt operations
+# (to handle the case of key rotation).
+#
+# It is strongly recommended to download and install Java Cryptography Extension (JCE)
+# Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
+# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+#
+# Currently, only the following file types are supported for transparent data encryption, although
+# more are coming in future cassandra releases: commitlog, hints
+transparent_data_encryption_options:
+  enabled: false
+  chunk_length_kb: 64
+  cipher: AES/CBC/PKCS5Padding
+  key_alias: testing:1
+  # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+  # iv_length: 16
+  key_provider:
+    - class_name: org.apache.cassandra.security.JKSKeyProvider
+      parameters:
+        - keystore: conf/.keystore
+          keystore_password: cassandra
+          store_type: JCEKS
+          key_password: cassandra
+
+# Storage Attached Indexing options.
+# sai_options:
+  ## Total permitted memory allowed for writing SAI index segments. This memory
+  ## is split between all SAI indexes being built so more indexes will mean smaller
+  ## segment sizes.
+  # segment_write_buffer_size: 1024MiB
+
+#####################
+# SAFETY THRESHOLDS #
+#####################
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Controls the granularity of purgeable tombstones reported to PurgeableTombstoneScannedHistogram table metric
+# Possible values:
+# 'disabled' - do not collect the metric at all
+# 'row'      - track only partition/range/row level tombstone,
+#              a good compromise between overheads and usability.
+#              For CPU-bound workload you may get less than 1% of overhead for throughput.
+#              For IO-bound workload the overhead is negligible.
+# 'cell'     - track partition/range/row/cell level tombstones.
+#              This is the most granular option,
+#              but it has some performance overheads due to iteration over cells.
+#              For CPU-bound workload you may get about 5% of overhead for throughput.
+#              For IO-bound workload the overhead is almost negligible.
+# tombstone_read_purgeable_metric_granularity: disabled
+
+# Filtering and secondary index queries at read consistency levels above ONE/LOCAL_ONE use a
+# mechanism called replica filtering protection to ensure that results from stale replicas do
+# not violate consistency. (See CASSANDRA-8272 and CASSANDRA-15907 for more details.) This
+# mechanism materializes replica results by partition on-heap at the coordinator. The more possibly
+# stale results returned by the replicas, the more rows materialized during the query.
+replica_filtering_protection:
+    # These thresholds exist to limit the damage severely out-of-date replicas can cause during these
+    # queries. They limit the number of rows from all replicas individual index and filtering queries
+    # can materialize on-heap to return correct results at the desired read consistency level.
+    #
+    # "cached_replica_rows_warn_threshold" is the per-query threshold at which a warning will be logged.
+    # "cached_replica_rows_fail_threshold" is the per-query threshold at which the query will fail.
+    #
+    # These thresholds may also be adjusted at runtime using the StorageService mbean.
+    #
+    # If the failure threshold is breached, it is likely that either the current page/fetch size
+    # is too large or one or more replicas is severely out-of-sync and in need of repair.
+    cached_rows_warn_threshold: 2000
+    cached_rows_fail_threshold: 32000
+
+# Log WARN on any multiple-partition batch size exceeding this value. 5KiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+# Min unit: KiB
+batch_size_warn_threshold: 5KiB
+
+# Fail any multiple-partition batch exceeding this value. 50KiB (10x warn threshold) by default.
+# Min unit: KiB
+batch_size_fail_threshold: 50KiB
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# GCInspector configs:
+# For GC like ShenandoahGC/ZGC etc., there are GC events that do not have STW pauses.
+# Such events are called Concurrent phases. Operator might find it reasonable to use lower thresholds
+# for events require STW pauses and higher thresholds for concurrent phases.
+#
+# GC Pauses greater than 200 ms will be logged at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# Min unit: ms
+# gc_log_threshold: 200ms
+
+# GC Pauses greater than gc_warn_threshold will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement. Setting to 0
+# will deactivate the feature.
+# Min unit: ms
+# gc_warn_threshold: 1000ms
+
+# GC Concurrent phase greater than 1000 ms will be logged at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# Min unit: ms
+# gc_concurrent_phase_log_threshold: 1000ms
+
+# GC Concurrent phase than gc_concurrent_phase_warn_threshold will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement. Setting to 0
+# will deactivate the feature.
+# Min unit: ms
+# gc_concurrent_phase_warn_threshold: 2000ms
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted. This should be positive and less than 2GiB.
+# Min unit: MiB
+# max_value_size: 256MiB
+
+# ** Impact on keyspace creation **
+# If replication factor is not mentioned as part of keyspace creation, default_keyspace_rf would apply.
+# Changing this configuration would only take effect for keyspaces created after the change, but does not impact
+# existing keyspaces created prior to the change.
+# ** Impact on keyspace alter **
+# When altering a keyspace from NetworkTopologyStrategy to SimpleStrategy, default_keyspace_rf is applied if rf is not
+# explicitly mentioned.
+# ** Impact on system keyspaces **
+# This would also apply for any system keyspaces that need replication factor.
+# A further note about system keyspaces - system_traces and system_distributed keyspaces take RF of 2 or default,
+# whichever is higher, and system_auth keyspace takes RF of 1 or default, whichever is higher.
+# Suggested value for use in production: 3
+# default_keyspace_rf: 1
+
+# Track a metric per keyspace indicating whether replication achieved the ideal consistency
+# level for writes without timing out. This is different from the consistency level requested by
+# each write which may be lower in order to facilitate availability.
+# ideal_consistency_level: EACH_QUORUM
+
+# Automatically upgrade sstables after upgrade - if there is no ordinary compaction to do, the
+# oldest non-upgraded sstable will get upgraded to the latest version
+# automatic_sstable_upgrade: false
+# Limit the number of concurrent sstable upgrades
+# max_concurrent_automatic_sstable_upgrades: 1
+
+# Audit logging - Logs every incoming CQL command request, authentication to a node. See the docs
+# on audit_logging for full details about the various configuration options and production tips.
+audit_logging_options:
+  enabled: false
+  logger:
+    - class_name: BinAuditLogger
+  # audit_logs_dir:
+  # included_keyspaces:
+  # excluded_keyspaces: system, system_schema, system_virtual_schema
+  # included_categories:
+  # excluded_categories:
+  # included_users:
+  # excluded_users:
+  # roll_cycle: HOURLY
+  # block: true
+  # max_queue_weight: 268435456 # 256 MiB
+  # max_log_size: 17179869184 # 16 GiB
+  #
+  ## If archive_command is empty or unset, Cassandra uses a built-in DeletingArchiver that deletes the oldest files if ``max_log_size`` is reached.
+  ## If archive_command is set, Cassandra does not use DeletingArchiver, so it is the responsibility of the script to make any required cleanup.
+  ## Example: "/path/to/script.sh %path" where %path is replaced with the file being rolled.
+  # archive_command:
+  # max_archive_retries: 10
+
+# default options for full query logging - these can be overridden from command line when executing
+# nodetool enablefullquerylog
+# full_query_logging_options:
+  # log_dir:
+  # roll_cycle: HOURLY
+  # block: true
+  # max_queue_weight: 268435456 # 256 MiB
+  # max_log_size: 17179869184 # 16 GiB
+  ## archive command is "/path/to/script.sh %path" where %path is replaced with the file being rolled:
+  # archive_command:
+  ## note that enabling this allows anyone with JMX/nodetool access to run local shell commands as the user running cassandra
+  # allow_nodetool_archive_command: false
+  # max_archive_retries: 10
+
+# validate tombstones on reads and compaction
+# can be either "disabled", "warn" or "exception"
+# corrupted_tombstone_strategy: disabled
+
+# Diagnostic Events #
+# If enabled, diagnostic events can be helpful for troubleshooting operational issues. Emitted events contain details
+# on internal state and temporal relationships across events, accessible by clients via JMX.
+diagnostic_events_enabled: false
+
+# Use native transport TCP message coalescing. If on upgrade to 4.0 you found your throughput decreasing, and in
+# particular you run an old kernel or have very fewer client connections, this option might be worth evaluating.
+#native_transport_flush_in_batches_legacy: false
+
+# Enable tracking of repaired state of data during reads and comparison between replicas
+# Mismatches between the repaired sets of replicas can be characterized as either confirmed
+# or unconfirmed. In this context, unconfirmed indicates that the presence of pending repair
+# sessions, unrepaired partition tombstones, or some other condition means that the disparity
+# cannot be considered conclusive. Confirmed mismatches should be a trigger for investigation
+# as they may be indicative of corruption or data loss.
+# There are separate flags for range vs partition reads as single partition reads are only tracked
+# when CL > 1 and a digest mismatch occurs. Currently, range queries don't use digests so if
+# enabled for range reads, all range reads will include repaired data tracking. As this adds
+# some overhead, operators may wish to disable it whilst still enabling it for partition reads
+repaired_data_tracking_for_range_reads_enabled: false
+repaired_data_tracking_for_partition_reads_enabled: false
+# If false, only confirmed mismatches will be reported. If true, a separate metric for unconfirmed
+# mismatches will also be recorded. This is to avoid potential signal:noise issues are unconfirmed
+# mismatches are less actionable than confirmed ones.
+report_unconfirmed_repaired_data_mismatches: false
+
+# configure the read and write consistency levels for modifications to auth tables
+# auth_read_consistency_level: LOCAL_QUORUM
+# auth_write_consistency_level: EACH_QUORUM
+
+# Delays on auth resolution can lead to a thundering herd problem on reconnects; this option will enable
+# warming of auth caches prior to node completing startup. See CASSANDRA-16958
+# auth_cache_warming_enabled: false
+
+# If enabled, dynamic data masking allows to attach CQL masking functions to the columns of a table.
+# Users without the UNMASK permission will see an obscured version of the values of the columns with an attached mask.
+# If dynamic data masking is disabled it won't be allowed to create new column masks, although it will still be possible
+# to drop any previously existing masks. Also, any existing mask will be ignored at query time, so all users will see
+# the clear values of the masked columns.
+# Defaults to false to disable dynamic data masking.
+# dynamic_data_masking_enabled: false
+
+#########################
+# EXPERIMENTAL FEATURES #
+#########################
+
+# Enables materialized view creation on this node.
+# Materialized views are considered experimental and are not recommended for production use.
+materialized_views_enabled: false
+
+# Specify whether Materialized View mutations are replayed through the write path on streaming, e.g. repair.
+# When enabled, Materialized View data streamed to the destination node will be written into commit log first. When setting to false,
+# the streamed Materialized View data is written into SSTables just the same as normal streaming. The default is true.
+# If this is set to false, streaming will be considerably faster however it's possible that, in extreme situations
+# (losing > quorum # nodes in a replica set), you may have data in your SSTables that never makes it to the Materialized View.
+# materialized_views_on_repair_enabled: true
+
+# Enables SASI index creation on this node.
+# SASI indexes are considered experimental and are not recommended for production use.
+sasi_indexes_enabled: false
+
+# Enables creation of transiently replicated keyspaces on this node.
+# Transient replication is experimental and is not recommended for production use.
+transient_replication_enabled: false
+
+# Enables the used of 'ALTER ... DROP COMPACT STORAGE' statements on this node.
+# 'ALTER ... DROP COMPACT STORAGE' is considered experimental and is not recommended for production use.
+drop_compact_storage_enabled: false
+
+# Whether or not USE <keyspace> is allowed. This is enabled by default to avoid failure on upgrade.
+#use_statements_enabled: true
+
+# When the client triggers a protocol exception or unknown issue (Cassandra bug) we increment
+# a client metric showing this; this logic will exclude specific subnets from updating these
+# metrics
+#client_error_reporting_exclusions:
+#  subnets:
+#    - 127.0.0.1
+#    - 127.0.0.0/31
+
+# Enables read thresholds (warn/fail) across all replicas for reporting back to the client.
+# See: CASSANDRA-16850
+# read_thresholds_enabled: false # scheduled to be set true in 4.2
+# When read_thresholds_enabled: true, this tracks the materialized size of a query on the
+# coordinator. If coordinator_read_size_warn_threshold is defined, this will emit a warning
+# to clients with details on what query triggered this as well as the size of the result set; if
+# coordinator_read_size_fail_threshold is defined, this will fail the query after it
+# has exceeded this threshold, returning a read error to the user.
+# coordinator_read_size_warn_threshold:
+# coordinator_read_size_fail_threshold:
+# When read_thresholds_enabled: true, this tracks the size of the local read (as defined by
+# heap size), and will warn/fail based off these thresholds; undefined disables these checks.
+# local_read_size_warn_threshold:
+# local_read_size_fail_threshold:
+# When read_thresholds_enabled: true, this tracks the expected memory size of the RowIndexEntry
+# and will warn/fail based off these thresholds; undefined disables these checks
+# row_index_read_size_warn_threshold:
+# row_index_read_size_fail_threshold:
+
+# Guardrail to warn or fail when creating more user keyspaces than threshold.
+# The two thresholds default to -1 to disable.
+# keyspaces_warn_threshold: -1
+# keyspaces_fail_threshold: -1
+#
+# Guardrail to warn or fail when creating more user tables than threshold.
+# The two thresholds default to -1 to disable.
+# tables_warn_threshold: -1
+# tables_fail_threshold: -1
+#
+# Guardrail to enable or disable the ability to create uncompressed tables
+# uncompressed_tables_enabled: true
+#
+# Guardrail to warn or fail when creating/altering a table with more columns per table than threshold.
+# The two thresholds default to -1 to disable.
+# columns_per_table_warn_threshold: -1
+# columns_per_table_fail_threshold: -1
+#
+# Guardrail to warn or fail when creating more secondary indexes per table than threshold.
+# The two thresholds default to -1 to disable.
+# secondary_indexes_per_table_warn_threshold: -1
+# secondary_indexes_per_table_fail_threshold: -1
+#
+# Guardrail to enable or disable the creation of secondary indexes
+# secondary_indexes_enabled: true
+#
+# Guardrail to warn or fail when creating more materialized views per table than threshold.
+# The two thresholds default to -1 to disable.
+# materialized_views_per_table_warn_threshold: -1
+# materialized_views_per_table_fail_threshold: -1
+#
+# Guardrail to warn about, ignore or reject properties when creating tables. By default all properties are allowed.
+# table_properties_warned: []
+# table_properties_ignored: []
+# table_properties_disallowed: []
+#
+# Guardrail to allow/disallow user-provided timestamps. Defaults to true.
+# user_timestamps_enabled: true
+#
+# Guardrail to bound user-provided timestamps within a given range. Default is infinite (denoted by null).
+# Accepted values are durations of the form 12h, 24h, etc.
+# maximum_timestamp_warn_threshold:
+# maximum_timestamp_fail_threshold:
+# minimum_timestamp_warn_threshold:
+# minimum_timestamp_fail_threshold:
+#
+# Guardrail to allow/disallow GROUP BY functionality.
+# group_by_enabled: true
+#
+# Guardrail to allow/disallow TRUNCATE and DROP TABLE statements
+# drop_truncate_table_enabled: true
+#
+# Guardrail to allow/disallow DROP KEYSPACE statements
+# drop_keyspace_enabled: true
+#
+# Guardrail to allow/disallow bulk load of SSTables
+# bulk_load_enabled: true
+#
+# Guardrail to warn or fail when using a page size greater than threshold.
+# The two thresholds default to -1 to disable.
+# page_size_warn_threshold: -1
+# page_size_fail_threshold: -1
+#
+# Guardrail to allow/disallow list operations that require read before write, i.e. setting list element by index and
+# removing list elements by either index or value. Defaults to true.
+# read_before_write_list_operations_enabled: true
+#
+# Guardrail to warn or fail when querying with an IN restriction selecting more partition keys than threshold.
+# The two thresholds default to -1 to disable.
+# partition_keys_in_select_warn_threshold: -1
+# partition_keys_in_select_fail_threshold: -1
+#
+# Guardrail to warn or fail when an IN query creates a cartesian product with a size exceeding threshold,
+# eg. "a in (1,2,...10) and b in (1,2...10)" results in cartesian product of 100.
+# The two thresholds default to -1 to disable.
+# in_select_cartesian_product_warn_threshold: -1
+# in_select_cartesian_product_fail_threshold: -1
+#
+# Guardrail to warn about or reject read consistency levels. By default, all consistency levels are allowed.
+# read_consistency_levels_warned: []
+# read_consistency_levels_disallowed: []
+#
+# Guardrail to warn about or reject write consistency levels. By default, all consistency levels are allowed.
+# write_consistency_levels_warned: []
+# write_consistency_levels_disallowed: []
+#
+# Guardrail to warn or fail when writing partitions larger than threshold, expressed as 100MiB, 1GiB, etc.
+# The guardrail is only checked when writing sstables (flush and compaction), and exceeding the fail threshold on that
+# moment will only log an error message, without interrupting the operation.
+# This operates on a per-sstable basis, so it won't detect a large partition if it is spread across multiple sstables.
+# The warning threshold replaces the deprecated config property compaction_large_partition_warning_threshold.
+# The two thresholds default to null to disable.
+# partition_size_warn_threshold:
+# partition_size_fail_threshold:
+#
+# Guardrail to warn or fail when writing partitions with more tombstones than threshold.
+# The guardrail is only checked when writing sstables (flush and compaction), and exceeding the fail threshold on that
+# moment will only log an error message, without interrupting the operation.
+# This operates on a per-sstable basis, so it won't detect a large partition if it is spread across multiple sstables.
+# The warning threshold replaces the deprecated config property compaction_tombstone_warning_threshold.
+# The two thresholds default to -1 to disable.
+# partition_tombstones_warn_threshold: -1
+# partition_tombstones_fail_threshold: -1
+#
+# Guardrail to warn or fail when writing column values larger than threshold.
+# This guardrail is only applied to the values of regular columns because both the serialized partitions keys and the
+# values of the components of the clustering key already have a fixed, relatively small size limit of 65535 bytes, which
+# is probably lesser than the thresholds defined here.
+# Deleting individual elements of non-frozen sets and maps involves creating tombstones that contain the value of the
+# deleted element, independently on whether the element existed or not. That tombstone value is also guarded by this
+# guardrail, to prevent the insertion of tombstones over the threshold. The downside is that enabling or raising this
+# threshold can prevent users from deleting set/map elements that were written when the guardrail was disabled or with a
+# lower value. Deleting the entire column, row or partition is always allowed, since the tombstones created for those
+# operations don't contain the CQL column values.
+# This guardrail is different to max_value_size. max_value_size is checked when deserializing any value to detect
+# sstable corruption, whereas this guardrail is checked on the CQL layer at write time to reject regular user queries
+# inserting too large columns.
+# The two thresholds default to null to disable.
+# Min unit: B
+# column_value_size_warn_threshold:
+# column_value_size_fail_threshold:
+#
+# Guardrail to warn or fail when encountering larger size of collection data than threshold.
+# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
+# prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
+# although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
+# The two thresholds default to null to disable.
+# Min unit: B
+# collection_size_warn_threshold:
+# Min unit: B
+# collection_size_fail_threshold:
+#
+# Guardrail to warn or fail when encountering more elements in collection than threshold.
+# At query time this guardrail is applied only to the collection fragment that is being writen, even though in the case
+# of non-frozen collections there could be unaccounted parts of the collection on the sstables. This is done this way to
+# prevent read-before-write. The guardrail is also checked at sstable write time to detect large non-frozen collections,
+# although in that case exceeding the fail threshold will only log an error message, without interrupting the operation.
+# The two thresholds default to -1 to disable.
+# items_per_collection_warn_threshold: -1
+# items_per_collection_fail_threshold: -1
+#
+# Guardrail to allow/disallow querying with ALLOW FILTERING. Defaults to true.
+# ALLOW FILTERING can potentially visit all the data in the table and have unpredictable performance.
+# allow_filtering_enabled: true
+#
+# Guardrail to allow/disallow setting SimpleStrategy via keyspace creation or alteration. Defaults to true.
+# simplestrategy_enabled: true
+#
+# Guardrail to warn or fail when creating a user-defined-type with more fields in than threshold.
+# Default -1 to disable.
+# fields_per_udt_warn_threshold: -1
+# fields_per_udt_fail_threshold: -1
+#
+# Guardrail to warn or fail when creating a vector column with more dimensions than threshold.
+# Default -1 to disable.
+# vector_dimensions_warn_threshold: -1
+# vector_dimensions_fail_threshold: -1
+#
+# Guardrail to indicate whether or not users are allowed to use ALTER TABLE commands to make column changes to tables
+# alter_table_enabled: true
+#
+# Guardrail to warn or fail when local data disk usage percentage exceeds threshold. Valid values are in [1, 100].
+# This is only used for the disks storing data directories, so it won't count any separate disks used for storing
+# the commitlog, hints nor saved caches. The disk usage is the ratio between the amount of space used by the data
+# directories and the addition of that same space and the remaining free space on disk. The main purpose of this
+# guardrail is rejecting user writes when the disks are over the defined usage percentage, so the writes done by
+# background processes such as compaction and streaming don't fail due to a full disk. The limits should be defined
+# accordingly to the expected data growth due to those background processes, so for example a compaction strategy
+# doubling the size of the data would require to keep the disk usage under 50%.
+# The two thresholds default to -1 to disable.
+# data_disk_usage_percentage_warn_threshold: -1
+# data_disk_usage_percentage_fail_threshold: -1
+#
+# Guardrail that allows users to define the max disk size of the data directories when calculating thresholds for
+# disk_usage_percentage_warn_threshold and disk_usage_percentage_fail_threshold, so if this is greater than zero they
+# become percentages of a fixed size on disk instead of percentages of the physically available disk size. This should
+# be useful when we have a large disk and we only want to use a part of it for Cassandra's data directories.
+# Valid values are in [1, max available disk size of all data directories].
+# Defaults to null to disable and use the physically available disk size of data directories during calculations.
+# Min unit: B
+# data_disk_usage_max_disk_size:
+#
+# Guardrail to warn or fail when the minimum replication factor is lesser than threshold.
+# This would also apply to system keyspaces.
+# Suggested value for use in production: 2 or higher
+# minimum_replication_factor_warn_threshold: -1
+# minimum_replication_factor_fail_threshold: -1
+#
+# Guardrail to warn or fail when the maximum replication factor is greater than threshold.
+# This would also apply to system keyspaces.
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+#role_name_policy:
+#  # Implementation class of a validator. When not in form of FQCN, the
+#  # package name org.apache.cassandra.db.guardrails is prepended.
+#  # By default, there is no validator.
+#  #validator_class_name: YourValidatorOfRoleNames
+#  # Implementation class of related generator which generates values which are valid when
+#  # tested against this validator. When not in form of FQCN, the
+#  # package name org.apache.cassandra.db.guardrails is prepended.
+#  # By default, there is no generator.
+#  # There is currently only one generator possible to configure - UUIDRoleNameGenerator
+#  generator_class_name: UUIDRoleNameGenerator
+#  # Minimum generated size of a name when name_size option is specified in CQL.
+#  # This can not be less than 10 and more than 32.
+#  #min_generated_name_size: 10
+
+# If this is set to false, then it is not possible to call reconfiguration
+# method in GuardrailsMBean. It will effectively forbid the reconfiguration of role_name_policy in runtime.
+# You would need to stop the node, change the configuration in cassandra.yaml and start the node again.
+# Defaults to true, which means that reconfiguration of role_name_policy via JMX is possible.
+#role_name_policy_reconfiguration_enabled: true
+
+# If this is set to false, then it is not possible to call reconfiguration
+# method in GuardrailsMBean. It will effectively forbid the reconfiguration of role_name_policy in runtime.
+# You would need to stop the node, change the configuration in cassandra.yaml and start the node again.
+# Defaults to true, which means that reconfiguration of role_name_policy via JMX is possible.
+#rolename_validator_reconfiguration_enabled: true
+
+# Guardrail to warn or fail when setting / altering a password.
+# Supported character sets are (both upper and lower-case): English, Cyrillic and modern Cyrillic, Czech, German, Polish.
+# Password is invalid if all characters are from non-supported character set. If a password is otherwise valid,
+# but it contains characters from unsupported language, these characters contribute only to password length rule.
+# All digits and all following special characters are supported too: !"#$%&()*+,-./:;<=>?@[\]^_`{|}~
+#password_policy:
+#  # Implementation class of a validator. When not in form of FQCN, the
+#  # package name org.apache.cassandra.db.guardrails is prepended.
+#  # By default, there is no validator.
+#  validator_class_name: CassandraPasswordValidator
+#  # Implementation class of related generator which generates values which are valid when
+#  # tested against this validator. When not in form of FQCN, the
+#  # package name org.apache.cassandra.db.guardrails is prepended.
+#  # By default, there is no generator.
+#  generator_class_name: CassandraPasswordGenerator
+#  # There are four characteristics:
+#  # upper-case, lower-case, special character and digit.
+#  # If this value is set e.g. to 3, a password has to consist of 3 out of 4 characteristics.
+#  # For example, it has to contain at least 2 upper-case characters, 2 lower-case, and 2 digits to pass,
+#  # but it does not have to contain any special characters.
+#  # If number of characteristics found in the password is less than or equal to this number, it will emit warning.
+#  characteristic_warn: 3
+#  # If number of characteristics found in the password is less than or equal to this number, it will emit failure.
+#  characteristic_fail: 2
+#  # Maximum length of a password. Defaults to 1000.
+#  max_length: 1000
+#  # If password is shorter than this value, the validator will emit a warning.
+#  length_warn: 12
+#  # If a password is shorter than this value, the validator will emit a failure.
+#  length_fail: 8
+#  # If a password does not contain at least n upper-case characters, the validator will emit a warning.
+#  upper_case_warn: 2
+#  # If a password does not contain at least n upper-case characters, the validator will emit a failure.
+#  upper_case_fail: 1
+#  # If a password does not contain at least n lower-case characters, the validator will emit a warning.
+#  lower_case_warn: 2
+#  # If a password does not contain at least n lower-case characters, the validator will emit a failure.
+#  lower_case_fail: 1
+#  # If a password does not contain at least n digits, the validator will emit a warning.
+#  digit_warn: 2
+#  # If a password does not contain at least n digits, the validator will emit a failure.
+#  digit_fail: 1
+#  # If a password does not contain at least n special characters, the validator will emit a warning.
+#  special_warn: 2
+#  # If a password does not contain at least n special characters, the validator will emit a failure.
+#  special_fail: 1
+#  # If a password contain illegal sequences that at least this long, it is invalid.
+#  # Illegal sequences might be either alphabetical (form 'abcde'),
+#  # numerical (form '34567'), or US qwerty (form 'asdfg') as well as sequencies from supported character sets.
+#  # The minimum value for this property is 3, by default it is set to 5.
+#  illegal_sequence_length: 5
+#  # Dictionary to check the passwords against. Defaults to no dictionary.
+#  # Whole dictionary is cached into memory. Use with caution with relatively big dictionaries.
+#  # Entries in a dictionary, one per line, have to be sorted per String's compareTo contract.
+#  #dictionary: /path/to/dictionary/file
+#  # If set to true, a user will be informed what policies a suggested password is missing in order to be valid.
+#  # Defaults to true.
+#  detailed_messages: true
+
+# If this is set to false, then it is not possible to call reconfiguration
+# method in GuardrailsMBean. It will effectively forbid the reconfiguration of password validator in runtime.
+# You would need to stop the node, change the configuration in cassandra.yaml and start the node again.
+# Defaults to true, which means that reconfiguration of password validator via JMX is possible.
+#password_policy_reconfiguration_enabled: true
+
+# Guardrail to enable a CREATE or ALTER TABLE statement when default_time_to_live is set to 0
+# and the table is using TimeWindowCompactionStrategy compaction or a subclass of it.
+# It is suspicious to use default_time_to_live set to 0 with such compaction strategy.
+# Please keep in mind that data will not start to automatically expire after they are older than
+# a respective compaction window unit of a certain size. Please set TTL for your INSERT or UPDATE
+# statements if you expect data to be expired as table settings will not do it.
+# Defaults to true. If set to false, such statements fail and zero_ttl_on_twcs_warned flag is irrelevant.
+#zero_ttl_on_twcs_enabled: true
+# Guardrail to warn a user upon executing CREATE or ALTER TABLE statement when default_time_to_live is set to 0
+# and the table is using TimeWindowCompactionStrategy compaction or a subclass of it. Defaults to true.
+# if zero_ttl_on_twcs_enabled is set to false, this property is irrelevant as such statements will fail.
+#zero_ttl_on_twcs_warned: true
+
+# Guardrail enabling secondary index queries that do not restrict on partition key (defaults to true)
+#non_partition_restricted_index_query_enabled: true
+# Maximum number of referenced SAI indexes on a replica when executing a SELECT query
+# before emitting a warning (defaults to 32)
+#sai_sstable_indexes_per_query_warn_threshold: 32
+# Maximum number of referenced SAI indexes on a replica when executing a SELECT query
+# before emitting a failure (defaults to -1 to disable)
+#sai_sstable_indexes_per_query_fail_threshold: -1
+
+# The default secondary index implementation when CREATE INDEX does not specify one via USING.
+# ex. "legacy_local_table" - (default) legacy secondary index, implemented as a hidden table
+# ex. "sai" - "storage-attched" index, implemented via optimized SSTable/Memtable-attached indexes
+default_secondary_index: sai
+
+# Whether a default secondary index implementation is allowed. If this is "false", CREATE INDEX must
+# specify an index implementation via USING.
+default_secondary_index_enabled: true
+
+# Startup Checks are executed as part of Cassandra startup process, not all of them
+# are configurable (so you can disable them) but these which are enumerated bellow.
+# Uncomment the startup checks and configure them appropriately to cover your needs.
+#
+#startup_checks:
+# Verifies correct ownership of attached locations on disk at startup. See CASSANDRA-16879 for more details.
+#  check_filesystem_ownership:
+#    enabled: false
+#    ownership_token: "sometoken" # (overriden by "CassandraOwnershipToken" system property)
+#    ownership_filename: ".cassandra_fs_ownership" # (overriden by "cassandra.fs_ownership_filename")
+# Enable this property to fail startup if the node is down for longer than gc_grace_seconds, to potentially
+# prevent data resurrection on tables with deletes. By default, this will run against all keyspaces and tables
+# except the ones specified on excluded_keyspaces and excluded_tables.
+#  check_data_resurrection:
+#    enabled: false
+# file where Cassandra periodically writes the last time it was known to run
+#    heartbeat_file: /var/lib/cassandra/data/cassandra-heartbeat
+#    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
+#    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
+
+# This property indicates with what Cassandra major version the storage format will be compatible with.
+#
+# The chosen storage compatibility mode will determine the versions of the written sstables, commitlogs, hints, etc.
+# For example, if we're going to remain compatible with Cassandra 4.x, the value of this property should be 4, which
+# will make us use sstables in the latest N version of the BIG format.
+#
+# This will also determine if certain features that depend on newer formats are available. For example, extended TTL
+# (up to 2106) depends on the sstable, commit-log, hints, and messaging versions introduced by Cassandra 5.0, so that
+# feature won't be available if this property is set to CASSANDRA_4. See the upgrade guide for more details.
+#
+# Possible values are:
+#
+# ** CASSANDRA_4: Stays compatible with the 4.x line in features, formats and component versions.
+# ** UPGRADING:   The cluster monitors the version of each node during this interim stage. This has a cost but ensures
+#                all new features, formats, versions, etc. are enabled safely.
+# ** NONE:        Start with all the new features and formats enabled.
+#
+# A typical upgrade would be:
+#
+# . Do a rolling upgrade, starting all nodes in CASSANDRA_X compatibility mode.
+# . Once the new binary is rendered stable, do a rolling restart with the UPGRADING mode. The cluster will keep new
+#   features disabled until all nodes are started in the UPGRADING mode; when that happens, new features controlled by
+#   the storage compatibility mode are enabled.
+# . Do a rolling restart with all nodes starting with the NONE mode. This eliminates the cost of checking node versions
+#   and ensures stability. If Cassandra was started at the previous version by accident, a node with disabled
+#   compatibility mode would no longer toggle behaviors as when it was running in the UPGRADING mode.
+#
+storage_compatibility_mode: NONE
+
+# Prevents preparing a repair session or beginning a repair streaming session if pending compactions is over
+# the given value.  Defaults to disabled.
+# reject_repair_compaction_threshold: 1024
+
+# At least 20% of disk must be unused to run repair. It is useful to avoid disks filling up during
+# repair as anti-compaction during repair may contribute to additional space temporarily.
+# if you want to disable this feature (the recommendation is not to, but if you want to disable it for whatever reason)
+# then set the ratio to 0.0
+# repair_disk_headroom_reject_ratio: 0.2;
+
+# Configuration for Auto Repair Scheduler.
+#
+# This feature is disabled by default.
+#
+# See: https://cassandra.apache.org/doc/latest/cassandra/managing/operating/auto_repair.html for an overview of this
+# feature.
+#
+# auto_repair:
+#   # Enable/Disable the auto-repair scheduler.
+#   # If set to false, the scheduler thread will not be started.
+#   # If set to true, the repair scheduler thread will be created. The thread will
+#   # check for secondary configuration available for each repair type (full, incremental,
+#   # and preview_repaired), and based on that, it will schedule repairs.
+#   enabled: true
+#   repair_type_overrides:
+#     full:
+#       # Enable/Disable full auto-repair
+#       enabled: true
+#       # Minimum duration between repairing the same node again. This is useful for tiny clusters,
+#       # such as clusters with 5 nodes that finish repairs quickly. This means that if the scheduler completes one
+#       # round on all nodes in less than this duration, it will not start a new repair round on a given node until
+#       # this much time has passed since the last repair completed. Consider increasing to a larger value to reduce
+#       # the impact of repairs, however note that one should attempt to run repairs at a smaller interval than
+#       # gc_grace_seconds to avoid potential data resurrection.
+#       min_repair_interval: 24h
+#       token_range_splitter:
+#         # Implementation of IAutoRepairTokenRangeSplitter; responsible for splitting token ranges
+#         # for repair assignments.
+#         #
+#         # Out of the box, Cassandra provides org.apache.cassandra.repair.autorepair.{RepairTokenRangeSplitter,
+#         # FixedTokenRangeSplitter}.
+#         #
+#         # - RepairTokenRangeSplitter (default) attempts to intelligently split ranges based on data size and partition
+#         #   count.
+#         # - FixedTokenRangeSplitter splits into fixed ranges based on the 'number_of_subranges' option.
+#         # class_name: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+#
+#         # Optional parameters can be specified in the form of:
+#         #   parameters:
+#         #    param_key1: param_value1
+#         parameters:
+#           # The target and maximum amount of compressed bytes that should be included in a repair assignment.
+#           # This scopes the amount of work involved in a repair and includes the data covering the range being
+#           # repaired.
+#           bytes_per_assignment: 50GiB
+#           # The maximum number of bytes to cover in an individual schedule. This serves as
+#           # a mechanism to throttle the work done in each repair cycle. You may reduce this
+#           # value if the impact of repairs is causing too much load on the cluster or increase it
+#           # if writes outpace the amount of data being repaired. Alternatively, adjust the
+#           # min_repair_interval.
+#           # This is set to a large value for full repair to attempt to repair all data per repair schedule.
+#           max_bytes_per_schedule: 100000GiB
+#     incremental:
+#       # Enable incremental repair by default for new clusters.
+#       enabled: true
+#       # Incremental repairs operate over unrepaired data and should finish quickly. Running incremental repair
+#       # frequently keeps the unrepaired set smaller and thus causes repairs to operate over a smaller set of data,
+#       # so a more frequent schedule such as 1h is recommended.
+#       min_repair_interval: 1h
+#       token_range_splitter:
+#         parameters:
+#           # Configured to attempt repairing 50GiB of compressed data per repair.
+#           # This throttles the amount of incremental repair and anticompaction done per schedule after incremental
+#           # repairs are turned on.
+#           bytes_per_assignment: 50GiB
+#           # Restricts the maximum number of bytes to cover in an individual schedule to the configured
+#           # max_bytes_per_schedule value (defaults to 100GiB for incremental).
+#           # Consider increasing this value if more data is written than this limit within the min_repair_interval.
+#           max_bytes_per_schedule: 100GiB
+#     preview_repaired:
+#       # Performs preview repair over repaired SSTables, useful to detect possible inconsistencies in the repaired
+#       # data set.
+#       enabled: false
+#       min_repair_interval: 24h
+#       token_range_splitter:
+#         parameters:
+#           bytes_per_assignment: 50GiB
+#           max_bytes_per_schedule: 100000GiB
+#   # Time interval between successive checks to see if ongoing repairs are complete or if it is time to schedule
+#   # repairs.
+#   repair_check_interval: 5m
+#   # Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
+#   # the node by scheduling too many repair tasks in a short period of time.
+#   repair_task_min_duration: 5s
+#   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
+#   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
+#   history_clear_delete_hosts_buffer_interval: 2h
+#   # By default repair is disabled if there are mixed major versions detected - which would happen
+#   # if a major version upgrade is being performed on the cluster, but a user can enable it using this flag
+#   mixed_major_version_repair_enabled: false
+#   # NOTE: Each of the below settings can be overridden per repair type under repair_type_overrides
+#   global_settings:
+#     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
+#     # individually.
+#     repair_by_keyspace: true
+#     # Number of threads to use for each repair job scheduled by the scheduler. Similar to the -j option in nodetool
+#     # repair.
+#     number_of_repair_threads: 1
+#     # Number of nodes running repair in parallel. If parallel_repair_percentage is set, the larger value is used.
+#     parallel_repair_count: 3
+#     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
+#     # is used.
+#     parallel_repair_percentage: 3
+#     # Whether to allow a node to take its turn running repair while one or more of its replicas are running repair.
+#     # Defaults to false, as running repairs concurrently on replicas can increase load and also cause anticompaction
+#     # conflicts while running incremental repair.
+#     allow_parallel_replica_repair: false
+#     # An addition to allow_parallel_replica_repair that also blocks repairs when replicas (including this node itself)
+#     # are repairing in any schedule. For example, if a replica is executing full repairs, a value of false will
+#     # prevent starting incremental repairs for this node. Defaults to true and is only evaluated when
+#     # allow_parallel_replica_repair is false.
+#     allow_parallel_replica_repair_across_schedules: true
+#     # Repairs materialized views if true.
+#     materialized_view_repair_enabled: false
+#     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.
+#     initial_scheduler_delay: 5m
+#     # Timeout for retrying stuck repair sessions.
+#     repair_session_timeout: 3h
+#     # Force immediate repair on new nodes after they join the ring.
+#     force_repair_new_node: false
+#     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
+#     # tables.
+#     sstable_upper_threshold: 50000
+#     # Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
+#     # next table.
+#     table_max_repair_time: 6h
+#     # Avoid running repairs in specific data centers. By default, repairs run in all data centers. Specify data
+#     # centers to exclude in this list. Note that repair sessions will still consider all replicas from excluded
+#     # data centers. Useful if you have keyspaces that are not replicated in certain data centers, and you want to
+#     # not run repair schedule in certain data centers.
+#     ignore_dcs: []
+#     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
+#     # to true. General advice is to keep this true.
+#     repair_primary_token_range_only: true
+#     # Maximum number of retries for a repair session.
+#     repair_max_retries: 3
+#     # Backoff time before retrying a repair session.
+#     repair_retry_backoff: 30s
+#     token_range_splitter:
+#       # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
+#       class_name: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+#       parameters:
+#         # Maximum number of partitions to include in a repair assignment. Used to reduce number of partitions
+#         # present in merkle tree leaf nodes to avoid overstreaming.
+#         partitions_per_assignment: 1048576
+#         # Maximum number of tables to include in a repair assignment. This reduces the number of repairs,
+#         # especially in keyspaces with many tables. The splitter avoids batching tables together if they
+#         # exceed other configuration parameters like bytes_per_assignment or partitions_per_assignment.
+#         max_tables_per_assignment: 64
+
+# Dictionary compression settings for ZSTD dictionary-based compression
+# These settings control the automatic training and caching of compression dictionaries
+# for tables that use ZSTD dictionary compression.
+
+# How often to refresh compression dictionaries across the cluster.
+# During refresh, nodes will check for newer dictionary versions and update their caches.
+# Min unit: s
+compression_dictionary_refresh_interval: 3600s
+
+# Initial delay before starting the first dictionary refresh cycle after node startup.
+# This prevents all nodes from refreshing simultaneously when the cluster starts.
+# Min unit: s
+compression_dictionary_refresh_initial_delay: 10s
+
+# Maximum number of compression dictionaries to cache per table.
+# Each table using dictionary compression can have multiple dictionaries cached
+# (current version plus recently used versions for reading older SSTables).
+compression_dictionary_cache_size: 10
+
+# How long to keep compression dictionaries in the cache before they expire.
+# Expired dictionaries will be removed from memory but can be reloaded if needed.
+# Min unit: s
+compression_dictionary_cache_expire: 24h
+
+# Dictionary training configuration (advanced settings)
+# These settings control how compression dictionaries are trained from sample data.
+
+# Maximum size of a trained compression dictionary.
+# Larger dictionaries may provide better compression but use more memory.
+compression_dictionary_training_max_dictionary_size: 64KiB
+
+# Maximum total size of sample data to collect for dictionary training.
+# More sample data generally produces better dictionaries but takes longer to train.
+# The recommended sample size is 100x the dictionary size.
+compression_dictionary_training_max_total_sample_size: 10MiB
+
+# Enable automatic dictionary training based on sampling of write operations.
+# When enabled, the system will automatically collect samples and train new dictionaries.
+# Manual training via nodetool is always available regardless of this setting.
+compression_dictionary_training_auto_train_enabled: false
+
+# Sampling rate for automatic dictionary training (1-10000).
+# Value of 100 means 1% of writes are sampled. Lower values reduce overhead but may
+# result in less representative sample data for dictionary training.
+compression_dictionary_training_sampling_rate: 0.01


### PR DESCRIPTION
## Summary

Implement the basic GET configuration flow in the Configuration Manager. When handling retrieval requests, the manager fetches the current overlay from the `ConfigurationProvider`, merges it with the base template to compute the effective configuration, and returns the result with its SHA-256 hash and last modified timestamp.

### New classes

- **`ConfigurationManager`**: Retrieves effective configuration by loading the base template via `ConfigUtils.loadConfiguration` and merging it with the provider overlay via `ConfigurationOverlaySnapshot.overlay()`. Wraps provider failures in `ConfigurationManagerException`.
- **`ConfigurationManagerException`**: Unchecked exception wrapping provider failures with a descriptive message.
- **`ConfigUtils`**: Utilities for YAML loading (`loadYaml`), deep merge of configurations (`mergeConfigurations`), and loading a YAML file as a `ConfigurationOverlaySnapshot` (`loadConfiguration`).

### Changes to existing classes

- **`ConfigurationOverlaySnapshot`**: Adds an `overlay()` method that produces a new snapshot by deep-merging another snapshot on top, combining `cassandraYaml` recursively, merging `extraJvmOpts`, and using the max of both `lastModified` timestamps. Renames `overlay` field/accessor to `configuration` to better reflect its role when representing the effective (merged) configuration.

## Test plan

- [ ] `ConfigurationManagerTest`: Verifies effective configuration retrieval with no overlay, with overlay (merge semantics), and provider failure propagation
- [ ] `ConfigUtilsTest`: Verifies YAML loading, deep merge logic (overlay wins, new keys, nested objects, empty overlay), and `loadConfiguration` snapshot creation
- [ ] `ConfigurationOverlaySnapshotTest`: Verifies `overlay()` merge of yaml keys, JVM opts, max lastModified, and deep nested object merging
- [ ] `FileBasedConfigurationProviderTest`: Updated to use renamed `configuration()` accessor
- [ ] Run `./gradlew :server:test --tests "org.apache.cassandra.sidecar.configmanagement.*"` - all 50 tests pass