### PR TITLE
CASSSIDECAR-374: Implement durable operational job tracker

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.5.0
 -----
+ * Implement durable operational job tracker (CASSSIDECAR-374)
  * Remove filesystem path from Http response (CASSSIDECAR-477)
  * Add basic configuration retrieval logic to ConfigurationManager (CASSSIDECAR-427)
  * RPM package is created with wrong version (CASSSIDECAR-472)

--- a/server/src/main/java/org/apache/cassandra/sidecar/db/ClusterOpsDatabaseAccessor.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/db/ClusterOpsDatabaseAccessor.java
@@ -166,12 +166,19 @@ public class ClusterOpsDatabaseAccessor extends DatabaseAccessor<ClusterOpsSchem
             nodeExecutionOrder = null;
         }
         Map<String, String> operationMetadata = row.getMap("operation_metadata", String.class, String.class);
-        if (operationMetadata.isEmpty())
+        if (operationMetadata != null && operationMetadata.isEmpty())
         {
             operationMetadata = null;
         }
-        return new OperationalJobRecord(operationId, operationType, status,
-                                        startTime, lastUpdate, failureReason,
-                                        nodeExecutionOrder, operationMetadata);
+        return OperationalJobRecord.builder()
+                                   .jobId(operationId)
+                                   .operationType(operationType)
+                                   .status(status)
+                                   .startTime(startTime)
+                                   .lastUpdate(lastUpdate)
+                                   .failureReason(failureReason)
+                                   .nodeExecutionOrder(nodeExecutionOrder)
+                                   .operationMetadata(operationMetadata)
+                                   .build();
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.config.ServiceConfiguration;
 import org.apache.cassandra.sidecar.job.storage.OperationalJobRecord;
 import org.apache.cassandra.sidecar.job.storage.StorageProvider;
@@ -54,13 +55,16 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
 
     private final ConcurrentHashMap<UUID, OperationalJob> liveJobs;
     private final StorageProvider storageProvider;
+    private final TaskExecutorPool executor;
 
     @Inject
     public DurableOperationalJobTracker(ServiceConfiguration serviceConfiguration,
-                                        StorageProvider storageProvider)
+                                        StorageProvider storageProvider,
+                                        TaskExecutorPool executor)
     {
         this.liveJobs = new ConcurrentHashMap<>(serviceConfiguration.operationalJobTrackerSize());
         this.storageProvider = storageProvider;
+        this.executor = executor;
     }
 
     /**
@@ -121,31 +125,28 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
      */
     private void updateTerminalStatus(OperationalJob job)
     {
-        OperationalJobStatus terminalStatus = job.status();
-        String failureReason = job.failureReason();
-        for (int attempt = 1; attempt <= MAX_STATUS_UPDATE_ATTEMPTS; attempt++)
+        updateTerminalStatus(job, 1);
+    }
+
+    private void updateTerminalStatus(OperationalJob job, int attempt)
+    {
+        try
         {
-            try
+            storageProvider.updateJobStatus(job.jobId(), job.operationType(), job.status(), job.failureReason());
+        }
+        catch (RuntimeException e)
+        {
+            LOGGER.warn("Failed to update terminal status for job {} (attempt {}/{}). error={}",
+                        job.jobId(), attempt, MAX_STATUS_UPDATE_ATTEMPTS, e.getMessage());
+            if (attempt < MAX_STATUS_UPDATE_ATTEMPTS)
             {
-                storageProvider.updateJobStatus(job.jobId(), job.operationType(), terminalStatus, failureReason);
-                return;
+                executor.setTimer(RETRY_DELAY_MS * attempt,
+                                  id -> updateTerminalStatus(job, attempt + 1));
             }
-            catch (RuntimeException e)
+            else
             {
-                LOGGER.warn("Failed to update terminal status for job {} (attempt {}/{}). error={}",
-                            job.jobId(), attempt, MAX_STATUS_UPDATE_ATTEMPTS, e.getMessage());
-                if (attempt < MAX_STATUS_UPDATE_ATTEMPTS)
-                {
-                    try
-                    {
-                        Thread.sleep(RETRY_DELAY_MS * attempt);
-                    }
-                    catch (InterruptedException ie)
-                    {
-                        Thread.currentThread().interrupt();
-                        return;
-                    }
-                }
+                LOGGER.error("Exhausted retries when updating terminal status for job {}. " +
+                             "Manual intervention may be required to correct job metadata.", job.jobId(), e);
             }
         }
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -80,8 +80,8 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
             storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
 
             job.asyncResult().onComplete(ar -> {
-                liveJobs.remove(job.jobId());
                 updateTerminalStatus(job);
+                liveJobs.remove(job.jobId());
             });
 
             return job;

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -96,9 +96,11 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
                 updateTerminalStatus(job);
                 liveJobs.remove(job.jobId());
             })).onFailure(e -> {
-                liveJobs.remove(jobId, job);
-                LOGGER.error("Failed to persist job {} to storage. Job will not be tracked durably.",
+                // The persist failed, but the job is already executing on a separate executor. Keep it in
+                // liveJobs so in-process status queries and conflict detection still see it.
+                LOGGER.error("Failed to persist job {} to storage. Job will be tracked in-memory only.",
                              jobId, e);
+                job.asyncResult().onComplete(ar -> liveJobs.remove(job.jobId()));
             });
         }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -47,6 +47,16 @@ import org.jetbrains.annotations.Nullable;
  * {@link OperationalJob} references for the current process, since executing jobs
  * with Vert.x promises cannot be reconstituted from storage. Once a job completes,
  * it is removed from the local map, and subsequent lookups are served from storage.
+ *
+ * <p>Storage currently receives only two writes per job: the initial
+ * {@link OperationalJobStatus#CREATED CREATED} record on submission and the terminal status on
+ * completion. As a result, if the sidecar restarts mid-operation, or if the
+ * terminal-status update exhausts its retries (see {@link #updateTerminalStatus}), the persisted
+ * record can remain stuck at {@code CREATED} even though the operation has since progressed or
+ * finished. There is currently no marker distinguishing a record that is genuinely still
+ * {@code CREATED} from one whose true state was simply never recorded; adding such a marker together
+ * with a reconciliation sweep (leveraging {@link StorageProvider#findAllJobs(int)}) is tracked as
+ * follow-up work.
  */
 @Singleton
 public class DurableOperationalJobTracker implements OperationalJobTracker

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -53,6 +54,7 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
     private static final Logger LOGGER = LoggerFactory.getLogger(DurableOperationalJobTracker.class);
     private static final int MAX_STATUS_UPDATE_ATTEMPTS = 3;
     private static final long RETRY_DELAY_MS = 100;
+    private static final long RETRY_JITTER_MS = 100;
 
     private final ConcurrentHashMap<UUID, OperationalJob> liveJobs;
     private final StorageProvider storageProvider;
@@ -218,8 +220,10 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
                         job.jobId(), attempt, MAX_STATUS_UPDATE_ATTEMPTS, e.getMessage());
             if (attempt < MAX_STATUS_UPDATE_ATTEMPTS)
             {
-                executor.setTimer(RETRY_DELAY_MS * attempt,
-                                  id -> updateTerminalStatus(job, attempt + 1));
+                // Add jitter so that concurrent sidecar processes retrying against the same transient
+                // Cassandra blip do not all retry in lockstep
+                long delay = RETRY_DELAY_MS * attempt + ThreadLocalRandom.current().nextLong(RETRY_JITTER_MS);
+                executor.setTimer(delay, id -> updateTerminalStatus(job, attempt + 1));
             }
             else
             {

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -51,7 +51,7 @@ import org.jetbrains.annotations.Nullable;
 public class DurableOperationalJobTracker implements OperationalJobTracker
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DurableOperationalJobTracker.class);
-    private static final int MAX_STATUS_UPDATE_ATTEMPTS = 2;
+    private static final int MAX_STATUS_UPDATE_ATTEMPTS = 3;
     private static final long RETRY_DELAY_MS = 100;
 
     private final ConcurrentHashMap<UUID, OperationalJob> liveJobs;

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -90,15 +90,13 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
             executor.executeBlocking(() -> {
                 storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
                 return null;
-            }).onFailure(e -> {
+            }).onSuccess(v -> job.asyncResult().onComplete(ar -> {
+                updateTerminalStatus(job);
+                liveJobs.remove(job.jobId());
+            })).onFailure(e -> {
                 liveJobs.remove(jobId, job);
                 LOGGER.error("Failed to persist job {} to storage. Job will not be tracked durably.",
                              jobId, e);
-            });
-
-            job.asyncResult().onComplete(ar -> {
-                updateTerminalStatus(job);
-                liveJobs.remove(job.jobId());
             });
         }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -74,18 +74,35 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
     @Override
     public OperationalJob computeIfAbsent(UUID jobId, Function<UUID, OperationalJob> mappingFunction)
     {
-        return liveJobs.computeIfAbsent(jobId, id -> {
-            OperationalJob job = mappingFunction.apply(id);
+        if (!storageProvider.isAvailable())
+        {
+            throw new IllegalStateException("Storage provider is not available");
+        }
 
-            storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
+        boolean[] created = {false};
+        OperationalJob job = liveJobs.computeIfAbsent(jobId, id -> {
+            created[0] = true;
+            return mappingFunction.apply(id);
+        });
+
+        if (created[0])
+        {
+            executor.executeBlocking(() -> {
+                storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
+                return null;
+            }).onFailure(e -> {
+                liveJobs.remove(jobId, job);
+                LOGGER.error("Failed to persist job {} to storage. Job will not be tracked durably.",
+                             jobId, e);
+            });
 
             job.asyncResult().onComplete(ar -> {
                 updateTerminalStatus(job);
                 liveJobs.remove(job.jobId());
             });
+        }
 
-            return job;
-        });
+        return job;
     }
 
     @Nullable

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.config.ServiceConfiguration;
 import org.apache.cassandra.sidecar.job.storage.OperationalJobRecord;
 import org.apache.cassandra.sidecar.job.storage.StorageProvider;
+import org.apache.cassandra.sidecar.utils.InvocationTrackingFunction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -92,13 +93,11 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
             throw new IllegalStateException("Storage provider is not available");
         }
 
-        boolean[] created = {false};
-        OperationalJob job = liveJobs.computeIfAbsent(jobId, id -> {
-            created[0] = true;
-            return mappingFunction.apply(id);
-        });
+        InvocationTrackingFunction<UUID, OperationalJob> mappingFunctionTracker =
+        new InvocationTrackingFunction<>(mappingFunction);
+        OperationalJob job = liveJobs.computeIfAbsent(jobId, mappingFunctionTracker);
 
-        if (created[0])
+        if (mappingFunctionTracker.wasInvoked())
         {
             persistInitialRecord(job, 1);
         }
@@ -108,31 +107,30 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
 
     private void persistInitialRecord(OperationalJob job, int attempt)
     {
-        executor.executeBlocking(() -> {
-            storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
-            return null;
-        }).onSuccess(v -> job.asyncResult().onComplete(ar -> {
-            updateTerminalStatus(job);
-            liveJobs.remove(job.jobId());
-        })).onFailure(e -> {
-            LOGGER.warn("Failed to persist job {} to storage (attempt {}/{}). error={}",
-                        job.jobId(), attempt, MAX_STORAGE_WRITE_ATTEMPTS, e.getMessage());
-            if (attempt < MAX_STORAGE_WRITE_ATTEMPTS)
-            {
-                // Add jitter so that concurrent sidecar processes retrying against the same transient
-                // Cassandra blip do not all retry in lockstep
-                long delay = RETRY_DELAY_MS * attempt + ThreadLocalRandom.current().nextLong(RETRY_JITTER_MS);
-                executor.setTimer(delay, id -> persistInitialRecord(job, attempt + 1));
-            }
-            else
-            {
-                // Persist exhausted its retries, but the job is already executing on a separate executor.
-                // Keep it in liveJobs so in-process status queries and conflict detection still see it.
-                LOGGER.error("Failed to persist job {} to storage after {} attempts. "
-                             + "Job will be tracked in-memory only.", job.jobId(), MAX_STORAGE_WRITE_ATTEMPTS, e);
-                job.asyncResult().onComplete(ar -> liveJobs.remove(job.jobId()));
-            }
-        });
+        executor.runBlocking(() -> storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job)))
+                .onSuccess(v -> job.asyncResult().onComplete(ar -> {
+                    updateTerminalStatus(job);
+                    liveJobs.remove(job.jobId());
+                }))
+                .onFailure(e -> {
+                    LOGGER.warn("Failed to persist job {} to storage (attempt {}/{}). error={}",
+                                job.jobId(), attempt, MAX_STORAGE_WRITE_ATTEMPTS, e.getMessage());
+                    if (attempt < MAX_STORAGE_WRITE_ATTEMPTS)
+                    {
+                        // Add jitter so that concurrent sidecar processes retrying against the same transient
+                        // Cassandra blip do not all retry in lockstep
+                        long delay = RETRY_DELAY_MS * attempt + ThreadLocalRandom.current().nextLong(RETRY_JITTER_MS);
+                        executor.setTimer(delay, id -> persistInitialRecord(job, attempt + 1));
+                    }
+                    else
+                    {
+                        // Persist exhausted its retries, but the job is already executing on a separate executor.
+                        // Keep it in liveJobs so in-process status queries and conflict detection still see it.
+                        LOGGER.error("Failed to persist job {} to storage after {} attempts. "
+                                     + "Job will be tracked in-memory only.", job.jobId(), MAX_STORAGE_WRITE_ATTEMPTS, e);
+                        job.asyncResult().onComplete(ar -> liveJobs.remove(job.jobId()));
+                    }
+                });
     }
 
     @Nullable
@@ -216,17 +214,24 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
                     failed.add(entry.getKey());
                     break;
                 default:
-                    break;
+                    throw new IllegalStateException("Invalid state = " + entry.getValue());
             }
         }
 
-        return new OperationalJobRecord(record.jobId(), record.operationType(), record.status(),
-                                        record.startTime(), record.lastUpdate(), record.failureReason(),
-                                        record.nodeExecutionOrder(), record.operationMetadata(),
-                                        Collections.unmodifiableList(pending),
-                                        Collections.unmodifiableList(executing),
-                                        Collections.unmodifiableList(succeeded),
-                                        Collections.unmodifiableList(failed));
+        return OperationalJobRecord.builder()
+                                   .jobId(record.jobId())
+                                   .operationType(record.operationType())
+                                   .status(record.status())
+                                   .startTime(record.startTime())
+                                   .lastUpdate(record.lastUpdate())
+                                   .failureReason(record.failureReason())
+                                   .nodeExecutionOrder(record.nodeExecutionOrder())
+                                   .operationMetadata(record.operationMetadata())
+                                   .nodesPending(Collections.unmodifiableList(pending))
+                                   .nodesExecuting(Collections.unmodifiableList(executing))
+                                   .nodesSucceeded(Collections.unmodifiableList(succeeded))
+                                   .nodesFailed(Collections.unmodifiableList(failed))
+                                   .build();
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -56,7 +56,8 @@ import org.jetbrains.annotations.Nullable;
  * finished. There is currently no marker distinguishing a record that is genuinely still
  * {@code CREATED} from one whose true state was simply never recorded; adding such a marker together
  * with a reconciliation sweep (leveraging {@link StorageProvider#findAllJobs(int)}) is tracked as
- * follow-up work.
+ * follow-up work in
+ * <a href="https://issues.apache.org/jira/browse/CASSSIDECAR-482">CASSSIDECAR-482</a>.
  */
 @Singleton
 public class DurableOperationalJobTracker implements OperationalJobTracker

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.sidecar.job;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -97,7 +98,12 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
             return liveJob;
         }
 
-        return storageProvider.findJob(jobId);
+        OperationalJobRecord record = storageProvider.findJob(jobId);
+        if (record == null)
+        {
+            return null;
+        }
+        return enrichWithNodeStatuses(record);
     }
 
     @NotNull
@@ -117,6 +123,63 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
                                     (j.status() == OperationalJobStatus.RUNNING ||
                                      j.status() == OperationalJobStatus.CREATED))
                        .collect(Collectors.toList());
+    }
+
+    /**
+     * Enriches an {@link OperationalJobRecord} with per-node status data from storage.
+     * If the record already has non-empty node lists (e.g. populated by a storage provider
+     * that joins the data in a single query), the record is returned as is.
+     */
+    private OperationalJobRecord enrichWithNodeStatuses(OperationalJobRecord record)
+    {
+        if (!record.nodesPending().isEmpty()
+            || !record.nodesExecuting().isEmpty()
+            || !record.nodesSucceeded().isEmpty()
+            || !record.nodesFailed().isEmpty())
+        {
+            return record;
+        }
+
+        Map<UUID, OperationalJobStatus> nodeStatuses =
+        storageProvider.getNodeStatusesForOperation(record.jobId());
+        if (nodeStatuses.isEmpty())
+        {
+            return record;
+        }
+
+        List<UUID> pending = new ArrayList<>();
+        List<UUID> executing = new ArrayList<>();
+        List<UUID> succeeded = new ArrayList<>();
+        List<UUID> failed = new ArrayList<>();
+
+        for (Map.Entry<UUID, OperationalJobStatus> entry : nodeStatuses.entrySet())
+        {
+            switch (entry.getValue())
+            {
+                case CREATED:
+                    pending.add(entry.getKey());
+                    break;
+                case RUNNING:
+                    executing.add(entry.getKey());
+                    break;
+                case SUCCEEDED:
+                    succeeded.add(entry.getKey());
+                    break;
+                case FAILED:
+                    failed.add(entry.getKey());
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return new OperationalJobRecord(record.jobId(), record.operationType(), record.status(),
+                                        record.startTime(), record.lastUpdate(), record.failureReason(),
+                                        record.nodeExecutionOrder(), record.operationMetadata(),
+                                        Collections.unmodifiableList(pending),
+                                        Collections.unmodifiableList(executing),
+                                        Collections.unmodifiableList(succeeded),
+                                        Collections.unmodifiableList(failed));
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -62,7 +62,7 @@ import org.jetbrains.annotations.Nullable;
 public class DurableOperationalJobTracker implements OperationalJobTracker
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DurableOperationalJobTracker.class);
-    private static final int MAX_STATUS_UPDATE_ATTEMPTS = 3;
+    private static final int MAX_STORAGE_WRITE_ATTEMPTS = 3;
     private static final long RETRY_DELAY_MS = 100;
     private static final long RETRY_JITTER_MS = 100;
 
@@ -99,22 +99,39 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
 
         if (created[0])
         {
-            executor.executeBlocking(() -> {
-                storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
-                return null;
-            }).onSuccess(v -> job.asyncResult().onComplete(ar -> {
-                updateTerminalStatus(job);
-                liveJobs.remove(job.jobId());
-            })).onFailure(e -> {
-                // The persist failed, but the job is already executing on a separate executor. Keep it in
-                // liveJobs so in-process status queries and conflict detection still see it.
-                LOGGER.error("Failed to persist job {} to storage. Job will be tracked in-memory only.",
-                             jobId, e);
-                job.asyncResult().onComplete(ar -> liveJobs.remove(job.jobId()));
-            });
+            persistInitialRecord(job, 1);
         }
 
         return job;
+    }
+
+    private void persistInitialRecord(OperationalJob job, int attempt)
+    {
+        executor.executeBlocking(() -> {
+            storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
+            return null;
+        }).onSuccess(v -> job.asyncResult().onComplete(ar -> {
+            updateTerminalStatus(job);
+            liveJobs.remove(job.jobId());
+        })).onFailure(e -> {
+            LOGGER.warn("Failed to persist job {} to storage (attempt {}/{}). error={}",
+                        job.jobId(), attempt, MAX_STORAGE_WRITE_ATTEMPTS, e.getMessage());
+            if (attempt < MAX_STORAGE_WRITE_ATTEMPTS)
+            {
+                // Add jitter so that concurrent sidecar processes retrying against the same transient
+                // Cassandra blip do not all retry in lockstep
+                long delay = RETRY_DELAY_MS * attempt + ThreadLocalRandom.current().nextLong(RETRY_JITTER_MS);
+                executor.setTimer(delay, id -> persistInitialRecord(job, attempt + 1));
+            }
+            else
+            {
+                // Persist exhausted its retries, but the job is already executing on a separate executor.
+                // Keep it in liveJobs so in-process status queries and conflict detection still see it.
+                LOGGER.error("Failed to persist job {} to storage after {} attempts. "
+                             + "Job will be tracked in-memory only.", job.jobId(), MAX_STORAGE_WRITE_ATTEMPTS, e);
+                job.asyncResult().onComplete(ar -> liveJobs.remove(job.jobId()));
+            }
+        });
     }
 
     @Nullable
@@ -229,8 +246,8 @@ public class DurableOperationalJobTracker implements OperationalJobTracker
         catch (RuntimeException e)
         {
             LOGGER.warn("Failed to update terminal status for job {} (attempt {}/{}). error={}",
-                        job.jobId(), attempt, MAX_STATUS_UPDATE_ATTEMPTS, e.getMessage());
-            if (attempt < MAX_STATUS_UPDATE_ATTEMPTS)
+                        job.jobId(), attempt, MAX_STORAGE_WRITE_ATTEMPTS, e.getMessage());
+            if (attempt < MAX_STORAGE_WRITE_ATTEMPTS)
             {
                 // Add jitter so that concurrent sidecar processes retrying against the same transient
                 // Cassandra blip do not all retry in lockstep

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTracker.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.config.ServiceConfiguration;
+import org.apache.cassandra.sidecar.job.storage.OperationalJobRecord;
+import org.apache.cassandra.sidecar.job.storage.StorageProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A durable implementation of {@link OperationalJobTracker} that persists job state
+ * via a {@link StorageProvider}. A local {@link ConcurrentHashMap} caches live
+ * {@link OperationalJob} references for the current process, since executing jobs
+ * with Vert.x promises cannot be reconstituted from storage. Once a job completes,
+ * it is removed from the local map, and subsequent lookups are served from storage.
+ */
+@Singleton
+public class DurableOperationalJobTracker implements OperationalJobTracker
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DurableOperationalJobTracker.class);
+    private static final int MAX_STATUS_UPDATE_ATTEMPTS = 2;
+    private static final long RETRY_DELAY_MS = 100;
+
+    private final ConcurrentHashMap<UUID, OperationalJob> liveJobs;
+    private final StorageProvider storageProvider;
+
+    @Inject
+    public DurableOperationalJobTracker(ServiceConfiguration serviceConfiguration,
+                                        StorageProvider storageProvider)
+    {
+        this.liveJobs = new ConcurrentHashMap<>(serviceConfiguration.operationalJobTrackerSize());
+        this.storageProvider = storageProvider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OperationalJob computeIfAbsent(UUID jobId, Function<UUID, OperationalJob> mappingFunction)
+    {
+        return liveJobs.computeIfAbsent(jobId, id -> {
+            OperationalJob job = mappingFunction.apply(id);
+
+            storageProvider.persistJob(OperationalJobRecord.fromOperationalJob(job));
+
+            job.asyncResult().onComplete(ar -> {
+                liveJobs.remove(job.jobId());
+                updateTerminalStatus(job);
+            });
+
+            return job;
+        });
+    }
+
+    @Nullable
+    @Override
+    public OperationalJobInfo get(UUID jobId)
+    {
+        OperationalJob liveJob = liveJobs.get(jobId);
+        if (liveJob != null)
+        {
+            return liveJob;
+        }
+
+        return storageProvider.findJob(jobId);
+    }
+
+    @NotNull
+    @Override
+    public Map<UUID, OperationalJob> jobsView()
+    {
+        return Collections.unmodifiableMap(liveJobs);
+    }
+
+    @NotNull
+    @Override
+    public List<OperationalJob> inflightJobsByOperation(String operation)
+    {
+        return liveJobs.values()
+                       .stream()
+                       .filter(j -> j.name().equals(operation) &&
+                                    (j.status() == OperationalJobStatus.RUNNING ||
+                                     j.status() == OperationalJobStatus.CREATED))
+                       .collect(Collectors.toList());
+    }
+
+    /**
+     * Attempts to update the terminal status in storage with retry.
+     * If all attempts fail, logs a warning and continues.
+     */
+    private void updateTerminalStatus(OperationalJob job)
+    {
+        OperationalJobStatus terminalStatus = job.status();
+        String failureReason = job.failureReason();
+        for (int attempt = 1; attempt <= MAX_STATUS_UPDATE_ATTEMPTS; attempt++)
+        {
+            try
+            {
+                storageProvider.updateJobStatus(job.jobId(), job.operationType(), terminalStatus, failureReason);
+                return;
+            }
+            catch (RuntimeException e)
+            {
+                LOGGER.warn("Failed to update terminal status for job {} (attempt {}/{}). error={}",
+                            job.jobId(), attempt, MAX_STATUS_UPDATE_ATTEMPTS, e.getMessage());
+                if (attempt < MAX_STATUS_UPDATE_ATTEMPTS)
+                {
+                    try
+                    {
+                        Thread.sleep(RETRY_DELAY_MS * attempt);
+                    }
+                    catch (InterruptedException ie)
+                    {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/NodeDecommissionJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/NodeDecommissionJob.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.jetbrains.annotations.NotNull;
@@ -101,6 +102,15 @@ public class NodeDecommissionJob extends OperationalJob
         LOGGER.info("Executing decommission operation. jobId={}", this.jobId());
         storageOperations.decommission(isForce);
         return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OperationType operationType()
+    {
+        return OperationType.DECOMMISSION;
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/NodeDrainJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/NodeDrainJob.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
@@ -134,6 +135,15 @@ public class NodeDrainJob extends OperationalJob
         }
 
         return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OperationType operationType()
+    {
+        return OperationType.DRAIN;
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/NodeMoveJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/NodeMoveJob.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.Future;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
 import org.jetbrains.annotations.NotNull;
@@ -81,6 +82,15 @@ public class NodeMoveJob extends OperationalJob
         }
 
         return Future.succeededFuture();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OperationType operationType()
+    {
+        return OperationType.MOVE;
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.datastax.driver.core.utils.UUIDs;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
 import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
@@ -238,6 +239,12 @@ public abstract class OperationalJob implements Task<Void>, OperationalJobInfo
         String simpleName = this.getClass().getSimpleName();
         return simpleName.isEmpty() ? this.getClass().getName() : simpleName;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public abstract OperationType operationType();
 
     /**
      * Determines the status of the job. OperationalJob subclasses could choose to override the method.

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobInfo.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobInfo.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -47,6 +48,11 @@ public interface OperationalJobInfo
      * @return the name of the operation the job performs
      */
     String name();
+
+    /**
+     * @return the {@link OperationType} of this job
+     */
+    OperationType operationType();
 
     /**
      * @return the current status of the job

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -100,11 +100,12 @@ public class OperationalJobManager
         {
             checkConflict(job);
 
-            // New job is submitted for all cases when we do not have a corresponding downstream job
-            jobTracker.computeIfAbsent(job.jobId(), jobId -> {
+            // Track the job first, then start execution separately
+            OperationalJob tracked = jobTracker.computeIfAbsent(job.jobId(), jobId -> job);
+            if (tracked == job)
+            {
                 internalExecutorPool.executeBlocking(job::execute);
-                return job;
-            });
+            }
         }
         catch (OperationalJobConflictException oje)
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/RepairJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/RepairJob.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import org.apache.cassandra.sidecar.adapters.base.RepairOptions;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.request.data.RepairPayload;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
@@ -182,6 +183,15 @@ public class RepairJob extends OperationalJob
     {
         refreshStatusFromCassandra();
         return currentStatus != null ? currentStatus : super.status();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OperationType operationType()
+    {
+        return OperationType.REPAIR;
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
@@ -55,6 +55,14 @@ public class OperationalJobRecord implements OperationalJobInfo
     private final List<List<UUID>> nodeExecutionOrder;
     @Nullable
     private final Map<String, String> operationMetadata;
+    @NotNull
+    private final List<UUID> nodesPending;
+    @NotNull
+    private final List<UUID> nodesExecuting;
+    @NotNull
+    private final List<UUID> nodesSucceeded;
+    @NotNull
+    private final List<UUID> nodesFailed;
 
     /**
      * Constructs an OperationalJobRecord with the given fields.
@@ -69,7 +77,7 @@ public class OperationalJobRecord implements OperationalJobInfo
     }
 
     /**
-     * Constructs an OperationalJobRecord with all fields.
+     * Constructs an OperationalJobRecord with all fields except per-node status lists.
      *
      * @param jobId             time-based v1 UUID identifying the job
      * @param operationType     the operation type
@@ -87,6 +95,39 @@ public class OperationalJobRecord implements OperationalJobInfo
                                 @Nullable List<List<UUID>> nodeExecutionOrder,
                                 @Nullable Map<String, String> operationMetadata)
     {
+        this(jobId, operationType, status, startTime, lastUpdate, failureReason,
+             nodeExecutionOrder, operationMetadata,
+             Collections.emptyList(), Collections.emptyList(),
+             Collections.emptyList(), Collections.emptyList());
+    }
+
+    /**
+     * Constructs an OperationalJobRecord with all fields including per-node status lists.
+     *
+     * @param jobId              time-based v1 UUID identifying the job
+     * @param operationType      the operation type
+     * @param status             the current status of the job
+     * @param startTime          the timestamp when execution started, or null if not yet started
+     * @param lastUpdate         the timestamp of the last status update, or null for pre-existing rows
+     * @param failureReason      the failure reason if the job failed, or null
+     * @param nodeExecutionOrder the ordered list of parallel node groups for execution, or null
+     * @param operationMetadata  the operation parameters, or null
+     * @param nodesPending       node UUIDs with CREATED status
+     * @param nodesExecuting     node UUIDs with RUNNING status
+     * @param nodesSucceeded     node UUIDs with SUCCEEDED status
+     * @param nodesFailed        node UUIDs with FAILED status
+     */
+    public OperationalJobRecord(UUID jobId, OperationType operationType, OperationalJobStatus status,
+                                @Nullable Instant startTime,
+                                @Nullable Instant lastUpdate,
+                                @Nullable String failureReason,
+                                @Nullable List<List<UUID>> nodeExecutionOrder,
+                                @Nullable Map<String, String> operationMetadata,
+                                @NotNull List<UUID> nodesPending,
+                                @NotNull List<UUID> nodesExecuting,
+                                @NotNull List<UUID> nodesSucceeded,
+                                @NotNull List<UUID> nodesFailed)
+    {
         Preconditions.checkArgument(jobId != null, "jobId must not be null");
         Preconditions.checkArgument(jobId.version() == 1, "jobId must be a time-based (v1) UUID");
         Preconditions.checkArgument(operationType != null, "operationType must not be null");
@@ -100,6 +141,10 @@ public class OperationalJobRecord implements OperationalJobInfo
         this.failureReason = failureReason;
         this.nodeExecutionOrder = nodeExecutionOrder;
         this.operationMetadata = operationMetadata;
+        this.nodesPending = nodesPending;
+        this.nodesExecuting = nodesExecuting;
+        this.nodesSucceeded = nodesSucceeded;
+        this.nodesFailed = nodesFailed;
     }
 
     /**
@@ -202,28 +247,28 @@ public class OperationalJobRecord implements OperationalJobInfo
     @NotNull
     public List<UUID> nodesPending()
     {
-        return Collections.emptyList();
+        return nodesPending;
     }
 
     @Override
     @NotNull
     public List<UUID> nodesExecuting()
     {
-        return Collections.emptyList();
+        return nodesExecuting;
     }
 
     @Override
     @NotNull
     public List<UUID> nodesSucceeded()
     {
-        return Collections.emptyList();
+        return nodesSucceeded;
     }
 
     @Override
     @NotNull
     public List<UUID> nodesFailed()
     {
-        return Collections.emptyList();
+        return nodesFailed;
     }
 
     @Override
@@ -256,6 +301,10 @@ public class OperationalJobRecord implements OperationalJobInfo
                ", failureReason=" + failureReason +
                ", nodeExecutionOrder=" + nodeExecutionOrder +
                ", operationMetadata=" + operationMetadata +
+               ", nodesPending=" + nodesPending +
+               ", nodesExecuting=" + nodesExecuting +
+               ", nodesSucceeded=" + nodesSucceeded +
+               ", nodesFailed=" + nodesFailed +
                '}';
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
@@ -23,9 +23,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import com.datastax.driver.core.utils.UUIDs;
+import org.apache.cassandra.sidecar.common.DataObjectBuilder;
 import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.utils.Preconditions;
@@ -65,86 +67,29 @@ public class OperationalJobRecord implements OperationalJobInfo
     private final List<UUID> nodesFailed;
 
     /**
-     * Constructs an OperationalJobRecord with the given fields.
+     * Constructs an OperationalJobRecord from its {@link Builder}.
      *
-     * @param jobId         time-based v1 UUID identifying the job
-     * @param operationType the operation type
-     * @param status        the current status of the job
+     * @param builder the builder holding the field values
      */
-    public OperationalJobRecord(UUID jobId, OperationType operationType, OperationalJobStatus status)
+    private OperationalJobRecord(Builder builder)
     {
-        this(jobId, operationType, status, null, Instant.now(), null, null, null);
-    }
-
-    /**
-     * Constructs an OperationalJobRecord with all fields except per-node status lists.
-     *
-     * @param jobId             time-based v1 UUID identifying the job
-     * @param operationType     the operation type
-     * @param status            the current status of the job
-     * @param startTime         the timestamp when execution started, or null if not yet started
-     * @param lastUpdate        the timestamp of the last status update, or null for pre-existing rows
-     * @param failureReason     the failure reason if the job failed, or null
-     * @param nodeExecutionOrder        the ordered list of parallel node groups for execution, or null
-     * @param operationMetadata the operation parameters, or null
-     */
-    public OperationalJobRecord(UUID jobId, OperationType operationType, OperationalJobStatus status,
-                                @Nullable Instant startTime,
-                                @Nullable Instant lastUpdate,
-                                @Nullable String failureReason,
-                                @Nullable List<List<UUID>> nodeExecutionOrder,
-                                @Nullable Map<String, String> operationMetadata)
-    {
-        this(jobId, operationType, status, startTime, lastUpdate, failureReason,
-             nodeExecutionOrder, operationMetadata,
-             Collections.emptyList(), Collections.emptyList(),
-             Collections.emptyList(), Collections.emptyList());
-    }
-
-    /**
-     * Constructs an OperationalJobRecord with all fields including per-node status lists.
-     *
-     * @param jobId              time-based v1 UUID identifying the job
-     * @param operationType      the operation type
-     * @param status             the current status of the job
-     * @param startTime          the timestamp when execution started, or null if not yet started
-     * @param lastUpdate         the timestamp of the last status update, or null for pre-existing rows
-     * @param failureReason      the failure reason if the job failed, or null
-     * @param nodeExecutionOrder the ordered list of parallel node groups for execution, or null
-     * @param operationMetadata  the operation parameters, or null
-     * @param nodesPending       node UUIDs with CREATED status
-     * @param nodesExecuting     node UUIDs with RUNNING status
-     * @param nodesSucceeded     node UUIDs with SUCCEEDED status
-     * @param nodesFailed        node UUIDs with FAILED status
-     */
-    public OperationalJobRecord(UUID jobId, OperationType operationType, OperationalJobStatus status,
-                                @Nullable Instant startTime,
-                                @Nullable Instant lastUpdate,
-                                @Nullable String failureReason,
-                                @Nullable List<List<UUID>> nodeExecutionOrder,
-                                @Nullable Map<String, String> operationMetadata,
-                                @NotNull List<UUID> nodesPending,
-                                @NotNull List<UUID> nodesExecuting,
-                                @NotNull List<UUID> nodesSucceeded,
-                                @NotNull List<UUID> nodesFailed)
-    {
-        Preconditions.checkArgument(jobId != null, "jobId must not be null");
-        Preconditions.checkArgument(jobId.version() == 1, "jobId must be a time-based (v1) UUID");
-        Preconditions.checkArgument(operationType != null, "operationType must not be null");
-        Preconditions.checkArgument(status != null, "status must not be null");
-        this.jobId = jobId;
-        this.operationType = operationType;
-        this.status = status;
-        this.creationTimeMillis = UUIDs.unixTimestamp(jobId);
-        this.startTime = startTime;
-        this.lastUpdate = lastUpdate;
-        this.failureReason = failureReason;
-        this.nodeExecutionOrder = nodeExecutionOrder;
-        this.operationMetadata = operationMetadata;
-        this.nodesPending = nodesPending;
-        this.nodesExecuting = nodesExecuting;
-        this.nodesSucceeded = nodesSucceeded;
-        this.nodesFailed = nodesFailed;
+        Preconditions.checkArgument(builder.jobId != null, "jobId must not be null");
+        Preconditions.checkArgument(builder.jobId.version() == 1, "jobId must be a time-based (v1) UUID");
+        Preconditions.checkArgument(builder.operationType != null, "operationType must not be null");
+        Preconditions.checkArgument(builder.status != null, "status must not be null");
+        jobId = builder.jobId;
+        operationType = builder.operationType;
+        status = builder.status;
+        creationTimeMillis = UUIDs.unixTimestamp(builder.jobId);
+        startTime = builder.startTime;
+        lastUpdate = builder.lastUpdate;
+        failureReason = builder.failureReason;
+        nodeExecutionOrder = builder.nodeExecutionOrder;
+        operationMetadata = builder.operationMetadata;
+        nodesPending = builder.nodesPending;
+        nodesExecuting = builder.nodesExecuting;
+        nodesSucceeded = builder.nodesSucceeded;
+        nodesFailed = builder.nodesFailed;
     }
 
     /**
@@ -285,7 +230,11 @@ public class OperationalJobRecord implements OperationalJobInfo
      */
     public static OperationalJobRecord fromOperationalJob(OperationalJob job)
     {
-        return new OperationalJobRecord(job.jobId(), job.operationType(), job.status());
+        return builder().jobId(job.jobId())
+                        .operationType(job.operationType())
+                        .status(job.status())
+                        .lastUpdate(Instant.now())
+                        .build();
     }
 
     @Override
@@ -306,5 +255,107 @@ public class OperationalJobRecord implements OperationalJobInfo
                ", nodesSucceeded=" + nodesSucceeded +
                ", nodesFailed=" + nodesFailed +
                '}';
+    }
+
+    /**
+     * @return a new {@link Builder} for constructing an {@link OperationalJobRecord}
+     */
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    /**
+     * {@link DataObjectBuilder} for {@link OperationalJobRecord}.
+     */
+    public static final class Builder implements DataObjectBuilder<Builder, OperationalJobRecord>
+    {
+        private UUID jobId;
+        private OperationType operationType;
+        private OperationalJobStatus status;
+        private @Nullable Instant startTime;
+        private @Nullable Instant lastUpdate;
+        private @Nullable String failureReason;
+        private @Nullable List<List<UUID>> nodeExecutionOrder;
+        private @Nullable Map<String, String> operationMetadata;
+        private @NotNull List<UUID> nodesPending = Collections.emptyList();
+        private @NotNull List<UUID> nodesExecuting = Collections.emptyList();
+        private @NotNull List<UUID> nodesSucceeded = Collections.emptyList();
+        private @NotNull List<UUID> nodesFailed = Collections.emptyList();
+
+        private Builder()
+        {
+        }
+
+        @Override
+        public Builder self()
+        {
+            return this;
+        }
+
+        public Builder jobId(UUID jobId)
+        {
+            return update(b -> b.jobId = jobId);
+        }
+
+        public Builder operationType(OperationType operationType)
+        {
+            return update(b -> b.operationType = operationType);
+        }
+
+        public Builder status(OperationalJobStatus status)
+        {
+            return update(b -> b.status = status);
+        }
+
+        public Builder startTime(@Nullable Instant startTime)
+        {
+            return update(b -> b.startTime = startTime);
+        }
+
+        public Builder lastUpdate(@Nullable Instant lastUpdate)
+        {
+            return update(b -> b.lastUpdate = lastUpdate);
+        }
+
+        public Builder failureReason(@Nullable String failureReason)
+        {
+            return update(b -> b.failureReason = failureReason);
+        }
+
+        public Builder nodeExecutionOrder(@Nullable List<List<UUID>> nodeExecutionOrder)
+        {
+            return update(b -> b.nodeExecutionOrder = nodeExecutionOrder);
+        }
+
+        public Builder operationMetadata(@Nullable Map<String, String> operationMetadata)
+        {
+            return update(b -> b.operationMetadata = operationMetadata);
+        }
+
+        public Builder nodesPending(@NotNull List<UUID> nodesPending)
+        {
+            return update(b -> b.nodesPending = Objects.requireNonNull(nodesPending, "nodesPending cannot be null"));
+        }
+
+        public Builder nodesExecuting(@NotNull List<UUID> nodesExecuting)
+        {
+            return update(b -> b.nodesExecuting = Objects.requireNonNull(nodesExecuting, "nodesExecuting cannot be null"));
+        }
+
+        public Builder nodesSucceeded(@NotNull List<UUID> nodesSucceeded)
+        {
+            return update(b -> b.nodesSucceeded = Objects.requireNonNull(nodesSucceeded, "nodesSucceeded cannot be null"));
+        }
+
+        public Builder nodesFailed(@NotNull List<UUID> nodesFailed)
+        {
+            return update(b -> b.nodesFailed = Objects.requireNonNull(nodesFailed, "nodesFailed cannot be null"));
+        }
+
+        public OperationalJobRecord build()
+        {
+            return new OperationalJobRecord(this);
+        }
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.job.storage;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,12 +29,17 @@ import com.datastax.driver.core.utils.UUIDs;
 import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.utils.Preconditions;
+import org.apache.cassandra.sidecar.job.OperationalJob;
+import org.apache.cassandra.sidecar.job.OperationalJobInfo;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A data transfer object representing the persisted state of an operational job.
+ * Implements {@link OperationalJobInfo} so that completed jobs stored in a persistent storage
+ * can be returned directly through the tracker without requiring a live {@link OperationalJob}.
  */
-public class OperationalJobRecord
+public class OperationalJobRecord implements OperationalJobInfo
 {
     private final UUID jobId;
     private final OperationType operationType;
@@ -171,6 +177,70 @@ public class OperationalJobRecord
     public Map<String, String> operationMetadata()
     {
         return operationMetadata;
+    }
+
+    @Override
+    @Nullable
+    public UUID nodeId()
+    {
+        return null;
+    }
+
+    @Override
+    public String name()
+    {
+        return operationType.name();
+    }
+
+    @Override
+    public long creationTime()
+    {
+        return creationTimeMillis;
+    }
+
+    @Override
+    @NotNull
+    public List<UUID> nodesPending()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    @NotNull
+    public List<UUID> nodesExecuting()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    @NotNull
+    public List<UUID> nodesSucceeded()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    @NotNull
+    public List<UUID> nodesFailed()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isExecuting()
+    {
+        return status == OperationalJobStatus.RUNNING;
+    }
+
+    /**
+     * Creates an {@link OperationalJobRecord} from a live {@link OperationalJob}.
+     *
+     * @param job the operational job to convert
+     * @return a new record capturing the job's current state
+     */
+    public static OperationalJobRecord fromOperationalJob(OperationalJob job)
+    {
+        return new OperationalJobRecord(job.jobId(), job.operationType(), job.status());
     }
 
     @Override

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/storage/OperationalJobRecord.java
@@ -234,7 +234,7 @@ public class OperationalJobRecord implements OperationalJobInfo
     @Override
     public String name()
     {
-        return operationType.name();
+        return operationType.name().toLowerCase();
     }
 
     @Override

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InvocationTrackingFunction.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InvocationTrackingFunction.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.utils;
+
+import java.util.function.Function;
+
+/**
+ * A {@link Function} decorator that records whether the wrapped function was ever invoked.
+ *
+ * @param <T> the function input type
+ * @param <R> the function result type
+ */
+public class InvocationTrackingFunction<T, R> implements Function<T, R>
+{
+    private final Function<T, R> delegate;
+    private boolean invoked;
+
+    public InvocationTrackingFunction(Function<T, R> delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public R apply(T input)
+    {
+        invoked = true;
+        return delegate.apply(input);
+    }
+
+    public boolean wasInvoked()
+    {
+        return invoked;
+    }
+}

--- a/server/src/test/integration/org/apache/cassandra/sidecar/db/ClusterOpsDatabaseAccessorIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/db/ClusterOpsDatabaseAccessorIntegrationTest.java
@@ -61,8 +61,14 @@ class ClusterOpsDatabaseAccessorIntegrationTest extends IntegrationTestBase
                 Arrays.asList(UUID.randomUUID())
         );
         Map<String, String> metadata = Map.of("key1", "value1", "key2", "value2");
-        OperationalJobRecord job1 = new OperationalJobRecord(jobId1, OperationType.REPAIR, OperationalJobStatus.CREATED,
-                                                             null, Instant.now(), null, nodeOrder, metadata);
+        OperationalJobRecord job1 = OperationalJobRecord.builder()
+                                                        .jobId(jobId1)
+                                                        .operationType(OperationType.REPAIR)
+                                                        .status(OperationalJobStatus.CREATED)
+                                                        .lastUpdate(Instant.now())
+                                                        .nodeExecutionOrder(nodeOrder)
+                                                        .operationMetadata(metadata)
+                                                        .build();
         accessor.persistJob(clusterName, job1);
 
         OperationalJobRecord found = accessor.findJob(clusterName, jobId1);
@@ -81,7 +87,11 @@ class ClusterOpsDatabaseAccessorIntegrationTest extends IntegrationTestBase
                 });
 
         UUID jobId2 = UUIDs.timeBased();
-        OperationalJobRecord job2 = new OperationalJobRecord(jobId2, OperationType.DECOMMISSION, OperationalJobStatus.CREATED);
+        OperationalJobRecord job2 = OperationalJobRecord.builder()
+                                                        .jobId(jobId2)
+                                                        .operationType(OperationType.DECOMMISSION)
+                                                        .status(OperationalJobStatus.CREATED)
+                                                        .build();
         accessor.persistJob(clusterName, job2);
 
         OperationalJobRecord found2 = accessor.findJob(clusterName, jobId2);
@@ -133,7 +143,11 @@ class ClusterOpsDatabaseAccessorIntegrationTest extends IntegrationTestBase
                 });
 
         UUID jobId3 = UUIDs.timeBased();
-        accessor.persistJob(clusterName, new OperationalJobRecord(jobId3, OperationType.REPAIR, OperationalJobStatus.CREATED));
+        accessor.persistJob(clusterName, OperationalJobRecord.builder()
+                                                             .jobId(jobId3)
+                                                             .operationType(OperationType.REPAIR)
+                                                             .status(OperationalJobStatus.CREATED)
+                                                             .build());
         List<OperationalJobRecord> allJobs = accessor.findAllJobs(clusterName, 10);
         assertThat(allJobs)
                 .withFailMessage("findAllJobs should return every persisted job when the limit exceeds total count")
@@ -148,9 +162,14 @@ class ClusterOpsDatabaseAccessorIntegrationTest extends IntegrationTestBase
                 .withFailMessage("findAllJobs should return the most recently created job first")
                 .isEqualTo(jobId3);
 
-        OperationalJobRecord job1Updated = new OperationalJobRecord(jobId1, OperationType.REPAIR,
-                                                                     OperationalJobStatus.SUCCEEDED,
-                                                                     null, Instant.now(), null, nodeOrder, metadata);
+        OperationalJobRecord job1Updated = OperationalJobRecord.builder()
+                                                               .jobId(jobId1)
+                                                               .operationType(OperationType.REPAIR)
+                                                               .status(OperationalJobStatus.SUCCEEDED)
+                                                               .lastUpdate(Instant.now())
+                                                               .nodeExecutionOrder(nodeOrder)
+                                                               .operationMetadata(metadata)
+                                                               .build();
         accessor.persistJob(clusterName, job1Updated);
         OperationalJobRecord afterUpsert = accessor.findJob(clusterName, jobId1);
         assertThat(afterUpsert)

--- a/server/src/test/integration/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerIntegrationTest.java
@@ -60,15 +60,17 @@ class DurableOperationalJobTrackerIntegrationTest extends IntegrationTestBase
 
         tracker.computeIfAbsent(jobId1, id -> job1);
 
-        OperationalJobRecord record1 = storageProvider.findJob(jobId1);
-        assertThat(record1)
-            .withFailMessage("Job should be persisted to Cassandra on creation")
-            .isNotNull()
-            .satisfies(r -> {
-                assertThat(r.jobId()).isEqualTo(jobId1);
-                assertThat(r.operationType()).isEqualTo(job1.operationType());
-                assertThat(r.status()).isEqualTo(OperationalJobStatus.CREATED);
-            });
+        loopAssert(2, () -> {
+            OperationalJobRecord record1 = storageProvider.findJob(jobId1);
+            assertThat(record1)
+                .withFailMessage("Job should be persisted to Cassandra on creation")
+                .isNotNull()
+                .satisfies(r -> {
+                    assertThat(r.jobId()).isEqualTo(jobId1);
+                    assertThat(r.operationType()).isEqualTo(job1.operationType());
+                    assertThat(r.status()).isEqualTo(OperationalJobStatus.CREATED);
+                });
+        });
 
         UUID jobId2 = UUIDs.timeBased();
         OperationalJob job2 = OperationalJobTest.createOperationalJob(jobId2, MillisecondBoundConfiguration.parse("50ms"));

--- a/server/src/test/integration/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerIntegrationTest.java
@@ -49,10 +49,11 @@ class DurableOperationalJobTrackerIntegrationTest extends IntegrationTestBase
         StorageProvider storageProvider = injector.getInstance(StorageProvider.class);
         storageProvider.initialize();
 
-        DurableOperationalJobTracker tracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(),
-                                                                                storageProvider);
         ExecutorPools executorPools = injector.getInstance(ExecutorPools.class);
         TaskExecutorPool executorPool = executorPools.internal();
+        DurableOperationalJobTracker tracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(),
+                                                                                storageProvider,
+                                                                                executorPool);
 
         UUID jobId1 = UUIDs.timeBased();
         OperationalJob job1 = OperationalJobTest.createOperationalJob(jobId1, OperationalJobStatus.CREATED);

--- a/server/src/test/integration/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import com.datastax.driver.core.utils.UUIDs;
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
+import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
+import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
+import org.apache.cassandra.sidecar.config.yaml.ServiceConfigurationImpl;
+import org.apache.cassandra.sidecar.job.storage.OperationalJobRecord;
+import org.apache.cassandra.sidecar.job.storage.StorageProvider;
+import org.apache.cassandra.sidecar.testing.IntegrationTestBase;
+import org.apache.cassandra.testing.CassandraIntegrationTest;
+
+import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DurableOperationalJobTracker} with a Cassandra-backed {@link StorageProvider}.
+ */
+class DurableOperationalJobTrackerIntegrationTest extends IntegrationTestBase
+{
+    @CassandraIntegrationTest
+    void testDurableOperationalJobTrackerOperations() throws InterruptedException
+    {
+        waitForSchemaReady(10, TimeUnit.SECONDS);
+
+        StorageProvider storageProvider = injector.getInstance(StorageProvider.class);
+        storageProvider.initialize();
+
+        DurableOperationalJobTracker tracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(),
+                                                                                storageProvider);
+        ExecutorPools executorPools = injector.getInstance(ExecutorPools.class);
+        TaskExecutorPool executorPool = executorPools.internal();
+
+        UUID jobId1 = UUIDs.timeBased();
+        OperationalJob job1 = OperationalJobTest.createOperationalJob(jobId1, OperationalJobStatus.CREATED);
+
+        tracker.computeIfAbsent(jobId1, id -> job1);
+
+        OperationalJobRecord record1 = storageProvider.findJob(jobId1);
+        assertThat(record1)
+            .withFailMessage("Job should be persisted to Cassandra on creation")
+            .isNotNull()
+            .satisfies(r -> {
+                assertThat(r.jobId()).isEqualTo(jobId1);
+                assertThat(r.operationType()).isEqualTo(job1.operationType());
+                assertThat(r.status()).isEqualTo(OperationalJobStatus.CREATED);
+            });
+
+        UUID jobId2 = UUIDs.timeBased();
+        OperationalJob job2 = OperationalJobTest.createOperationalJob(jobId2, MillisecondBoundConfiguration.parse("50ms"));
+        CountDownLatch latch = new CountDownLatch(1);
+
+        tracker.computeIfAbsent(jobId2, id -> job2);
+        executorPool.executeBlocking(job2::execute);
+
+        job2.asyncResult().onComplete(ar -> latch.countDown());
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            OperationalJobRecord record2 = storageProvider.findJob(jobId2);
+            assertThat(record2)
+                .withFailMessage("Job status should be updated to SUCCEEDED in Cassandra")
+                .isNotNull()
+                .satisfies(r -> assertThat(r.status()).isEqualTo(OperationalJobStatus.SUCCEEDED));
+        });
+
+        loopAssert(2, () -> {
+            assertThat(tracker.jobsView())
+                .withFailMessage("Job should be removed from local map after completion")
+                .doesNotContainKey(jobId2);
+        });
+
+        OperationalJobInfo retrieved = tracker.get(jobId2);
+        assertThat(retrieved)
+            .withFailMessage("get() should return an OperationalJobRecord from storage after completion")
+            .isNotNull()
+            .isInstanceOf(OperationalJobRecord.class);
+        assertThat(retrieved.jobId()).isEqualTo(jobId2);
+        assertThat(retrieved.status()).isEqualTo(OperationalJobStatus.SUCCEEDED);
+        assertThat(retrieved.operationType()).isEqualTo(job2.operationType());
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/ListOperationalJobsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/ListOperationalJobsHandlerTest.java
@@ -47,6 +47,7 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.cassandra.sidecar.TestModule;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.response.ListOperationalJobsResponse;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
 import org.apache.cassandra.sidecar.job.OperationalJob;
@@ -155,6 +156,12 @@ class ListOperationalJobsHandlerTest
         public boolean hasConflict(List<OperationalJob> jobs)
         {
             return false;
+        }
+
+        @Override
+        public OperationType operationType()
+        {
+            return OperationType.DECOMMISSION;
         }
 
         @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/ListOperationalJobsHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/ListOperationalJobsHandlerTest.java
@@ -161,7 +161,7 @@ class ListOperationalJobsHandlerTest
         @Override
         public OperationType operationType()
         {
-            return OperationType.DECOMMISSION;
+            return OperationType.DRAIN;
         }
 
         @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.datastax.driver.core.utils.UUIDs;
+import io.vertx.core.Vertx;
+import org.apache.cassandra.sidecar.TestResourceReaper;
+import org.apache.cassandra.sidecar.common.data.OperationType;
+import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
+import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
+import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
+import org.apache.cassandra.sidecar.config.yaml.ServiceConfigurationImpl;
+import org.apache.cassandra.sidecar.job.storage.OperationalJobRecord;
+import org.apache.cassandra.sidecar.job.storage.StorageProvider;
+import org.apache.cassandra.sidecar.job.storage.StorageProviderException;
+
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.CREATED;
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.FAILED;
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCCEEDED;
+import static org.apache.cassandra.sidecar.job.OperationalJobTest.createOperationalJob;
+import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DurableOperationalJobTracker}
+ */
+class DurableOperationalJobTrackerTest
+{
+    private StorageProvider storageProvider;
+    private DurableOperationalJobTracker tracker;
+    private Vertx vertx;
+    private ExecutorPools executorPools;
+    private TaskExecutorPool executorPool;
+
+    @BeforeEach
+    void setUp()
+    {
+        storageProvider = mock(StorageProvider.class);
+        tracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(), storageProvider);
+        vertx = Vertx.vertx();
+        executorPools = new ExecutorPools(vertx, new ServiceConfigurationImpl());
+        executorPool = executorPools.internal();
+    }
+
+    @AfterEach
+    void cleanup()
+    {
+        TestResourceReaper.create().with(vertx).with(executorPools).close();
+    }
+
+    @Test
+    void testComputeIfAbsentPersistsNewJob()
+    {
+        OperationalJob job = createOperationalJob(CREATED);
+
+        OperationalJob result = tracker.computeIfAbsent(job.jobId(), id -> job);
+
+        assertThat(result).isSameAs(job);
+        verify(storageProvider).persistJob(argThat(record ->
+            record.jobId().equals(job.jobId()) &&
+            record.operationType() == job.operationType() &&
+            record.status() == CREATED
+        ));
+    }
+
+    @Test
+    void testComputeIfAbsentDoesNotPersistExistingJob()
+    {
+        OperationalJob job = createOperationalJob(CREATED);
+
+        tracker.computeIfAbsent(job.jobId(), id -> job);
+        OperationalJob secondCall = tracker.computeIfAbsent(job.jobId(), id -> createOperationalJob(CREATED));
+
+        assertThat(secondCall).isSameAs(job);
+        verify(storageProvider, times(1)).persistJob(any());
+    }
+
+    @Test
+    void testComputeIfAbsentUpdatesStatusOnCompletion() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+        CountDownLatch latch = new CountDownLatch(1);
+
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+
+        job.asyncResult().onComplete(ar -> latch.countDown());
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+        });
+    }
+
+    @Test
+    void testComputeIfAbsentUpdatesStatusOnFailure() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId,
+            MillisecondBoundConfiguration.parse("50ms"),
+            new org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException("test failure"));
+        CountDownLatch latch = new CountDownLatch(1);
+
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+
+        job.asyncResult().onComplete(ar -> latch.countDown());
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(FAILED), eq("test failure"));
+        });
+    }
+
+    @Test
+    void testComputeIfAbsentRemovesJobFromLocalMapOnCompletion() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+        CountDownLatch latch = new CountDownLatch(1);
+
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+
+        assertThat(tracker.jobsView()).containsKey(jobId);
+
+        job.asyncResult().onComplete(ar -> latch.countDown());
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            assertThat(tracker.jobsView()).doesNotContainKey(jobId);
+        });
+    }
+
+    @Test
+    void testGetReturnsLiveJobFromLocalMap()
+    {
+        OperationalJob job = createOperationalJob(CREATED);
+        tracker.computeIfAbsent(job.jobId(), id -> job);
+
+        OperationalJobInfo result = tracker.get(job.jobId());
+
+        assertThat(result).isSameAs(job);
+        verify(storageProvider, never()).findJob(any());
+    }
+
+    @Test
+    void testGetFallsBackToStorage()
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
+        when(storageProvider.findJob(jobId)).thenReturn(record);
+
+        OperationalJobInfo result = tracker.get(jobId);
+
+        assertThat(result).isInstanceOf(OperationalJobRecord.class);
+        assertThat(result.jobId()).isEqualTo(jobId);
+        assertThat(result.status()).isEqualTo(SUCCEEDED);
+        assertThat(result.name()).isEqualTo(OperationType.DECOMMISSION.name());
+        assertThat(result.operationType()).isEqualTo(OperationType.DECOMMISSION);
+        verify(storageProvider).findJob(jobId);
+    }
+
+    @Test
+    void testGetReturnsNullWhenNotFoundAnywhere()
+    {
+        UUID jobId = UUIDs.timeBased();
+        when(storageProvider.findJob(jobId)).thenReturn(null);
+
+        OperationalJobInfo result = tracker.get(jobId);
+
+        assertThat(result).isNull();
+        verify(storageProvider).findJob(jobId);
+    }
+
+    @Test
+    void testJobsViewReturnsOnlyLocalMapContents()
+    {
+        OperationalJob job1 = createOperationalJob(CREATED);
+        OperationalJob job2 = createOperationalJob(CREATED);
+        tracker.computeIfAbsent(job1.jobId(), id -> job1);
+        tracker.computeIfAbsent(job2.jobId(), id -> job2);
+
+        Map<UUID, OperationalJob> view = tracker.jobsView();
+
+        assertThat(view).hasSize(2);
+        assertThat(view).containsEntry(job1.jobId(), job1);
+        assertThat(view).containsEntry(job2.jobId(), job2);
+        verify(storageProvider, never()).findJob(any());
+        verify(storageProvider, never()).findAllJobs(any(int.class));
+    }
+
+    @Test
+    void testJobsViewIsImmutable()
+    {
+        OperationalJob job = createOperationalJob(CREATED);
+        tracker.computeIfAbsent(job.jobId(), id -> job);
+
+        Map<UUID, OperationalJob> view = tracker.jobsView();
+
+        assertThatThrownBy(() -> view.put(UUIDs.timeBased(), job))
+            .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testInflightJobsByOperationFiltersLocalMap()
+    {
+        OperationalJob createdJob = createOperationalJob("decommission", CREATED);
+        OperationalJob runningJob = createOperationalJob("decommission", RUNNING);
+        OperationalJob succeededJob = createOperationalJob("decommission", SUCCEEDED);
+        OperationalJob drainJob = createOperationalJob("drain", RUNNING);
+
+        tracker.computeIfAbsent(createdJob.jobId(), id -> createdJob);
+        tracker.computeIfAbsent(runningJob.jobId(), id -> runningJob);
+        tracker.computeIfAbsent(succeededJob.jobId(), id -> succeededJob);
+        tracker.computeIfAbsent(drainJob.jobId(), id -> drainJob);
+
+        List<OperationalJob> inflightDecommission = tracker.inflightJobsByOperation("decommission");
+
+        assertThat(inflightDecommission)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(createdJob, runningJob);
+        verify(storageProvider, never()).findJob(any());
+    }
+
+    @Test
+    void testComputeIfAbsentPropagatesPersistenceFailure()
+    {
+        doThrow(new StorageProviderException("Storage unavailable"))
+            .when(storageProvider).persistJob(any());
+        OperationalJob job = createOperationalJob(CREATED);
+
+        assertThatThrownBy(() -> tracker.computeIfAbsent(job.jobId(), id -> job))
+            .isInstanceOf(StorageProviderException.class)
+            .hasMessage("Storage unavailable");
+    }
+
+    @Test
+    void testGetPropagatesStorageFallbackFailure()
+    {
+        UUID jobId = UUIDs.timeBased();
+        when(storageProvider.findJob(jobId)).thenThrow(new StorageProviderException("Storage unavailable"));
+
+        assertThatThrownBy(() -> tracker.get(jobId))
+            .isInstanceOf(StorageProviderException.class)
+            .hasMessage("Storage unavailable");
+    }
+
+    @Test
+    void testOnCompleteRetrySucceedsAfterTransientFailure() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+
+        doThrow(new StorageProviderException("Transient failure"))
+            .doNothing()
+            .when(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+
+        job.asyncResult().onComplete(ar -> latch.countDown());
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+        });
+    }
+
+    @Test
+    void testOnCompleteRemovesJobFromLocalMapWhenAllRetriesFail() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+
+        doThrow(new StorageProviderException("Persistent failure"))
+            .when(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+
+        job.asyncResult().onComplete(ar -> latch.countDown());
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+            assertThat(tracker.jobsView()).doesNotContainKey(jobId);
+        });
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.cassandra.sidecar.job;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,6 +34,7 @@ import com.datastax.driver.core.utils.UUIDs;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.sidecar.TestResourceReaper;
 import org.apache.cassandra.sidecar.common.data.OperationType;
+import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
@@ -189,6 +192,7 @@ class DurableOperationalJobTrackerTest
         UUID jobId = UUIDs.timeBased();
         OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
         when(storageProvider.findJob(jobId)).thenReturn(record);
+        when(storageProvider.getNodeStatusesForOperation(jobId)).thenReturn(Collections.emptyMap());
 
         OperationalJobInfo result = tracker.get(jobId);
 
@@ -283,6 +287,88 @@ class DurableOperationalJobTrackerTest
         assertThatThrownBy(() -> tracker.get(jobId))
             .isInstanceOf(StorageProviderException.class)
             .hasMessage("Storage unavailable");
+    }
+
+    @Test
+    void testGetEnrichesRecordWithNodeStatuses()
+    {
+        UUID jobId = UUIDs.timeBased();
+        UUID pendingNode = UUIDs.timeBased();
+        UUID runningNode = UUIDs.timeBased();
+        UUID succeededNode = UUIDs.timeBased();
+        UUID failedNode = UUIDs.timeBased();
+
+        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, RUNNING);
+        when(storageProvider.findJob(jobId)).thenReturn(record);
+
+        Map<UUID, OperationalJobStatus> nodeStatuses = new HashMap<>();
+        nodeStatuses.put(pendingNode, CREATED);
+        nodeStatuses.put(runningNode, RUNNING);
+        nodeStatuses.put(succeededNode, SUCCEEDED);
+        nodeStatuses.put(failedNode, FAILED);
+        when(storageProvider.getNodeStatusesForOperation(jobId)).thenReturn(nodeStatuses);
+
+        OperationalJobInfo result = tracker.get(jobId);
+
+        assertThat(result).isInstanceOf(OperationalJobRecord.class);
+        assertThat(result.nodesPending()).containsExactly(pendingNode);
+        assertThat(result.nodesExecuting()).containsExactly(runningNode);
+        assertThat(result.nodesSucceeded()).containsExactly(succeededNode);
+        assertThat(result.nodesFailed()).containsExactly(failedNode);
+        verify(storageProvider).getNodeStatusesForOperation(jobId);
+    }
+
+    @Test
+    void testGetSkipsEnrichmentWhenNodeListsAlreadyPopulated()
+    {
+        UUID jobId = UUIDs.timeBased();
+        UUID succeededNode = UUIDs.timeBased();
+
+        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED,
+                                                                null, null, null, null, null,
+                                                                Collections.emptyList(),
+                                                                Collections.emptyList(),
+                                                                Collections.singletonList(succeededNode),
+                                                                Collections.emptyList());
+        when(storageProvider.findJob(jobId)).thenReturn(record);
+
+        OperationalJobInfo result = tracker.get(jobId);
+
+        assertThat(result).isSameAs(record);
+        assertThat(result.nodesSucceeded()).containsExactly(succeededNode);
+        verify(storageProvider, never()).getNodeStatusesForOperation(any());
+    }
+
+    @Test
+    void testGetReturnsUnenrichedRecordWhenNoNodeStatuses()
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
+        when(storageProvider.findJob(jobId)).thenReturn(record);
+        when(storageProvider.getNodeStatusesForOperation(jobId)).thenReturn(Collections.emptyMap());
+
+        OperationalJobInfo result = tracker.get(jobId);
+
+        assertThat(result).isSameAs(record);
+        assertThat(result.nodesPending()).isEmpty();
+        assertThat(result.nodesExecuting()).isEmpty();
+        assertThat(result.nodesSucceeded()).isEmpty();
+        assertThat(result.nodesFailed()).isEmpty();
+        verify(storageProvider).getNodeStatusesForOperation(jobId);
+    }
+
+    @Test
+    void testGetPropagatesNodeStatusQueryFailure()
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
+        when(storageProvider.findJob(jobId)).thenReturn(record);
+        when(storageProvider.getNodeStatusesForOperation(jobId))
+            .thenThrow(new StorageProviderException("Node state unavailable"));
+
+        assertThatThrownBy(() -> tracker.get(jobId))
+            .isInstanceOf(StorageProviderException.class)
+            .hasMessage("Node state unavailable");
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -77,6 +77,7 @@ class DurableOperationalJobTrackerTest
     void setUp()
     {
         storageProvider = mock(StorageProvider.class);
+        when(storageProvider.isAvailable()).thenReturn(true);
         vertx = Vertx.vertx();
         executorPools = new ExecutorPools(vertx, new ServiceConfigurationImpl());
         executorPool = executorPools.internal();
@@ -97,11 +98,13 @@ class DurableOperationalJobTrackerTest
         OperationalJob result = tracker.computeIfAbsent(job.jobId(), id -> job);
 
         assertThat(result).isSameAs(job);
-        verify(storageProvider).persistJob(argThat(record ->
-            record.jobId().equals(job.jobId()) &&
-            record.operationType() == job.operationType() &&
-            record.status() == CREATED
-        ));
+        loopAssert(2, () -> {
+            verify(storageProvider).persistJob(argThat(record ->
+                record.jobId().equals(job.jobId()) &&
+                record.operationType() == job.operationType() &&
+                record.status() == CREATED
+            ));
+        });
     }
 
     @Test
@@ -113,7 +116,9 @@ class DurableOperationalJobTrackerTest
         OperationalJob secondCall = tracker.computeIfAbsent(job.jobId(), id -> createOperationalJob(CREATED));
 
         assertThat(secondCall).isSameAs(job);
-        verify(storageProvider, times(1)).persistJob(any());
+        loopAssert(2, () -> {
+            verify(storageProvider, times(1)).persistJob(any());
+        });
     }
 
     @Test
@@ -267,15 +272,28 @@ class DurableOperationalJobTrackerTest
     }
 
     @Test
-    void testComputeIfAbsentPropagatesPersistenceFailure()
+    void testComputeIfAbsentRemovesJobFromMapOnPersistenceFailure()
     {
         doThrow(new StorageProviderException("Storage unavailable"))
             .when(storageProvider).persistJob(any());
         OperationalJob job = createOperationalJob(CREATED);
 
+        tracker.computeIfAbsent(job.jobId(), id -> job);
+
+        loopAssert(2, () -> {
+            assertThat(tracker.jobsView()).doesNotContainKey(job.jobId());
+        });
+    }
+
+    @Test
+    void testComputeIfAbsentFailsWhenStorageUnavailable()
+    {
+        when(storageProvider.isAvailable()).thenReturn(false);
+        OperationalJob job = createOperationalJob(CREATED);
+
         assertThatThrownBy(() -> tracker.computeIfAbsent(job.jobId(), id -> job))
-            .isInstanceOf(StorageProviderException.class)
-            .hasMessage("Storage unavailable");
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Storage provider is not available");
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -215,7 +215,11 @@ class DurableOperationalJobTrackerTest
     void testGetFallsBackToStorage()
     {
         UUID jobId = UUIDs.timeBased();
-        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
+        OperationalJobRecord record = OperationalJobRecord.builder()
+                                                          .jobId(jobId)
+                                                          .operationType(OperationType.DECOMMISSION)
+                                                          .status(SUCCEEDED)
+                                                          .build();
         when(storageProvider.findJob(jobId)).thenReturn(record);
         when(storageProvider.getNodeStatusesForOperation(jobId)).thenReturn(Collections.emptyMap());
 
@@ -350,7 +354,11 @@ class DurableOperationalJobTrackerTest
         UUID succeededNode = UUIDs.timeBased();
         UUID failedNode = UUIDs.timeBased();
 
-        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, RUNNING);
+        OperationalJobRecord record = OperationalJobRecord.builder()
+                                                          .jobId(jobId)
+                                                          .operationType(OperationType.DECOMMISSION)
+                                                          .status(RUNNING)
+                                                          .build();
         when(storageProvider.findJob(jobId)).thenReturn(record);
 
         Map<UUID, OperationalJobStatus> nodeStatuses = new HashMap<>();
@@ -376,12 +384,12 @@ class DurableOperationalJobTrackerTest
         UUID jobId = UUIDs.timeBased();
         UUID succeededNode = UUIDs.timeBased();
 
-        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED,
-                                                                null, null, null, null, null,
-                                                                Collections.emptyList(),
-                                                                Collections.emptyList(),
-                                                                Collections.singletonList(succeededNode),
-                                                                Collections.emptyList());
+        OperationalJobRecord record = OperationalJobRecord.builder()
+                                                          .jobId(jobId)
+                                                          .operationType(OperationType.DECOMMISSION)
+                                                          .status(SUCCEEDED)
+                                                          .nodesSucceeded(Collections.singletonList(succeededNode))
+                                                          .build();
         when(storageProvider.findJob(jobId)).thenReturn(record);
 
         OperationalJobInfo result = tracker.get(jobId);
@@ -395,7 +403,11 @@ class DurableOperationalJobTrackerTest
     void testGetReturnsUnenrichedRecordWhenNoNodeStatuses()
     {
         UUID jobId = UUIDs.timeBased();
-        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
+        OperationalJobRecord record = OperationalJobRecord.builder()
+                                                          .jobId(jobId)
+                                                          .operationType(OperationType.DECOMMISSION)
+                                                          .status(SUCCEEDED)
+                                                          .build();
         when(storageProvider.findJob(jobId)).thenReturn(record);
         when(storageProvider.getNodeStatusesForOperation(jobId)).thenReturn(Collections.emptyMap());
 
@@ -413,7 +425,11 @@ class DurableOperationalJobTrackerTest
     void testGetPropagatesNodeStatusQueryFailure()
     {
         UUID jobId = UUIDs.timeBased();
-        OperationalJobRecord record = new OperationalJobRecord(jobId, OperationType.DECOMMISSION, SUCCEEDED);
+        OperationalJobRecord record = OperationalJobRecord.builder()
+                                                          .jobId(jobId)
+                                                          .operationType(OperationType.DECOMMISSION)
+                                                          .status(SUCCEEDED)
+                                                          .build();
         when(storageProvider.findJob(jobId)).thenReturn(record);
         when(storageProvider.getNodeStatusesForOperation(jobId))
             .thenThrow(new StorageProviderException("Node state unavailable"));

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -291,16 +291,30 @@ class DurableOperationalJobTrackerTest
     }
 
     @Test
-    void testComputeIfAbsentRemovesJobFromMapOnPersistenceFailure()
+    void testComputeIfAbsentKeepsJobInMapOnPersistenceFailureUntilCompletion() throws InterruptedException
     {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("200ms"));
+
         doThrow(new StorageProviderException("Storage unavailable"))
             .when(storageProvider).persistJob(any());
-        OperationalJob job = createOperationalJob(CREATED);
 
-        tracker.computeIfAbsent(job.jobId(), id -> job);
+        CountDownLatch completed = new CountDownLatch(1);
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+        job.asyncResult().onComplete(ar -> completed.countDown());
 
+        // The persist failed, but the job is already executing, so it must remain in the live map
+        // (durability-degraded) rather than being dropped mid-flight.
         loopAssert(2, () -> {
-            assertThat(tracker.jobsView()).doesNotContainKey(job.jobId());
+            verify(storageProvider).persistJob(any());
+            assertThat(tracker.jobsView()).containsKey(jobId);
+        });
+
+        // Once the job completes, the completion handler removes it from the live map to avoid leaking.
+        assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+        loopAssert(2, () -> {
+            assertThat(tracker.jobsView()).doesNotContainKey(jobId);
         });
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -74,10 +74,10 @@ class DurableOperationalJobTrackerTest
     void setUp()
     {
         storageProvider = mock(StorageProvider.class);
-        tracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(), storageProvider);
         vertx = Vertx.vertx();
         executorPools = new ExecutorPools(vertx, new ServiceConfigurationImpl());
         executorPool = executorPools.internal();
+        tracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(), storageProvider, executorPool);
     }
 
     @AfterEach
@@ -127,7 +127,7 @@ class DurableOperationalJobTrackerTest
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
         loopAssert(2, () -> {
-            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
         });
     }
 
@@ -147,7 +147,7 @@ class DurableOperationalJobTrackerTest
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
         loopAssert(2, () -> {
-            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(FAILED), eq("test failure"));
+            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(FAILED), eq("test failure"));
         });
     }
 
@@ -293,7 +293,7 @@ class DurableOperationalJobTrackerTest
 
         doThrow(new StorageProviderException("Transient failure"))
             .doNothing()
-            .when(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+            .when(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
 
         CountDownLatch latch = new CountDownLatch(1);
 
@@ -304,7 +304,7 @@ class DurableOperationalJobTrackerTest
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
         loopAssert(2, () -> {
-            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
         });
     }
 
@@ -315,7 +315,7 @@ class DurableOperationalJobTrackerTest
         OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
 
         doThrow(new StorageProviderException("Persistent failure"))
-            .when(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+            .when(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
 
         CountDownLatch latch = new CountDownLatch(1);
         tracker.computeIfAbsent(jobId, id -> job);
@@ -325,7 +325,7 @@ class DurableOperationalJobTrackerTest
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
         loopAssert(2, () -> {
-            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DECOMMISSION), eq(SUCCEEDED), isNull());
+            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
             assertThat(tracker.jobsView()).doesNotContainKey(jobId);
         });
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -199,7 +199,7 @@ class DurableOperationalJobTrackerTest
         assertThat(result).isInstanceOf(OperationalJobRecord.class);
         assertThat(result.jobId()).isEqualTo(jobId);
         assertThat(result.status()).isEqualTo(SUCCEEDED);
-        assertThat(result.name()).isEqualTo(OperationType.DECOMMISSION.name());
+        assertThat(result.name()).isEqualTo(OperationType.DECOMMISSION.name().toLowerCase());
         assertThat(result.operationType()).isEqualTo(OperationType.DECOMMISSION);
         verify(storageProvider).findJob(jobId);
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -140,6 +140,25 @@ class DurableOperationalJobTrackerTest
     }
 
     @Test
+    void testTerminalStatusNotUpdatedWhenPersistFails() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+
+        doThrow(new StorageProviderException("persist failed")).when(storageProvider).persistJob(any());
+
+        CountDownLatch completed = new CountDownLatch(1);
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+        job.asyncResult().onComplete(ar -> completed.countDown());
+
+        assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+        // The tracker registers its completion handler before this test does, so a stale
+        // updateJobStatus would already have run once the job has completed.
+        verify(storageProvider, never()).updateJobStatus(any(), any(), any(), any());
+    }
+
+    @Test
     void testComputeIfAbsentUpdatesStatusOnFailure() throws InterruptedException
     {
         UUID jobId = UUIDs.timeBased();

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -153,8 +153,8 @@ class DurableOperationalJobTrackerTest
         job.asyncResult().onComplete(ar -> completed.countDown());
 
         assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
-        // The tracker registers its completion handler before this test does, so a stale
-        // updateJobStatus would already have run once the job has completed.
+        // The tracker only registers its completion handler after a successful persist. Since persist
+        // failed here, the handler is never registered, so updateJobStatus should not run.
         verify(storageProvider, never()).updateJobStatus(any(), any(), any(), any());
     }
 
@@ -448,7 +448,7 @@ class DurableOperationalJobTrackerTest
         assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
         loopAssert(2, () -> {
-            verify(storageProvider, times(2)).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
+            verify(storageProvider, times(3)).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
             assertThat(tracker.jobsView()).doesNotContainKey(jobId);
         });
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DurableOperationalJobTrackerTest.java
@@ -55,6 +55,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -307,7 +308,7 @@ class DurableOperationalJobTrackerTest
         // The persist failed, but the job is already executing, so it must remain in the live map
         // (durability-degraded) rather than being dropped mid-flight.
         loopAssert(2, () -> {
-            verify(storageProvider).persistJob(any());
+            verify(storageProvider, atLeastOnce()).persistJob(any());
             assertThat(tracker.jobsView()).containsKey(jobId);
         });
 
@@ -463,6 +464,47 @@ class DurableOperationalJobTrackerTest
 
         loopAssert(2, () -> {
             verify(storageProvider, times(3)).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
+            assertThat(tracker.jobsView()).doesNotContainKey(jobId);
+        });
+    }
+
+    @Test
+    void testInitialPersistRetrySucceedsAfterTransientFailure() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+
+        doThrow(new StorageProviderException("Transient failure"))
+            .doNothing()
+            .when(storageProvider).persistJob(any());
+
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+
+        loopAssert(2, () -> {
+            verify(storageProvider, times(2)).persistJob(any());
+            verify(storageProvider).updateJobStatus(eq(jobId), eq(OperationType.DRAIN), eq(SUCCEEDED), isNull());
+        });
+    }
+
+    @Test
+    void testInitialPersistExhaustsRetriesAndTracksInMemoryOnly() throws InterruptedException
+    {
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+
+        doThrow(new StorageProviderException("Persistent failure")).when(storageProvider).persistJob(any());
+
+        CountDownLatch completed = new CountDownLatch(1);
+        tracker.computeIfAbsent(jobId, id -> job);
+        executorPool.executeBlocking(job::execute);
+        job.asyncResult().onComplete(ar -> completed.countDown());
+
+        assertThat(completed.await(5, TimeUnit.SECONDS)).isTrue();
+
+        loopAssert(2, () -> {
+            verify(storageProvider, times(3)).persistJob(any());
+            verify(storageProvider, never()).updateJobStatus(any(), any(), any(), any());
             assertThat(tracker.jobsView()).doesNotContainKey(jobId);
         });
     }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobInfoTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobInfoTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import com.datastax.driver.core.utils.UUIDs;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,6 +98,12 @@ class OperationalJobInfoTest
         }
 
         @Override
+        public OperationType operationType()
+        {
+            return OperationType.DECOMMISSION;
+        }
+
+        @Override
         protected Future<Void> executeInternal()
         {
             return Future.succeededFuture();
@@ -111,6 +118,12 @@ class OperationalJobInfoTest
             public boolean hasConflict(List<OperationalJob> sameOperationJobs)
             {
                 return false;
+            }
+
+            @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
             }
 
             @Override
@@ -130,6 +143,12 @@ class OperationalJobInfoTest
             public boolean hasConflict(List<OperationalJob> sameOperationJobs)
             {
                 return false;
+            }
+
+            @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
             }
 
             @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobInfoTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobInfoTest.java
@@ -100,7 +100,7 @@ class OperationalJobInfoTest
         @Override
         public OperationType operationType()
         {
-            return OperationType.DECOMMISSION;
+            return OperationType.DRAIN;
         }
 
         @Override
@@ -123,7 +123,7 @@ class OperationalJobInfoTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override
@@ -148,7 +148,7 @@ class OperationalJobInfoTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -44,11 +44,12 @@ import org.apache.cassandra.sidecar.job.storage.StorageProviderException;
 
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCCEEDED;
+import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests to validate the Job submission behavior for scenarios which are a combination of values for
@@ -182,9 +183,10 @@ class OperationalJobManagerTest
     }
 
     @Test
-    void testJobNotExecutedWhenPersistenceFails()
+    void testJobRemovedFromTrackerWhenPersistenceFails()
     {
         StorageProvider storageProvider = mock(StorageProvider.class);
+        when(storageProvider.isAvailable()).thenReturn(true);
         doThrow(new StorageProviderException("Storage unavailable"))
             .when(storageProvider).persistJob(any());
 
@@ -196,14 +198,13 @@ class OperationalJobManagerTest
         UUID jobId = UUIDs.timeBased();
         OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
 
-        assertThatThrownBy(() -> manager.trySubmitJob(job,
-                                                      (j, ex) -> {},
-                                                      executorPool.service(),
-                                                      SecondBoundConfiguration.parse("5s")))
-            .isInstanceOf(StorageProviderException.class);
+        manager.trySubmitJob(job,
+                             (j, ex) -> {},
+                             executorPool.service(),
+                             SecondBoundConfiguration.parse("5s"));
 
-        assertThat(job.isExecuting()).isFalse();
-        assertThat(job.asyncResult().isComplete()).isFalse();
-        assertThat(durableTracker.jobsView()).doesNotContainKey(jobId);
+        loopAssert(2, () -> {
+            assertThat(durableTracker.jobsView()).doesNotContainKey(jobId);
+        });
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -159,7 +159,7 @@ class OperationalJobManagerTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override
@@ -189,7 +189,8 @@ class OperationalJobManagerTest
             .when(storageProvider).persistJob(any());
 
         DurableOperationalJobTracker durableTracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(),
-                                                                                       storageProvider);
+                                                                                       storageProvider,
+                                                                                       executorPool.service());
         OperationalJobManager manager = new OperationalJobManager(durableTracker, executorPool);
 
         UUID jobId = UUIDs.timeBased();

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -32,15 +32,23 @@ import com.datastax.driver.core.utils.UUIDs;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.sidecar.TestResourceReaper;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
+import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
 import org.apache.cassandra.sidecar.common.server.utils.SecondBoundConfiguration;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.config.yaml.ServiceConfigurationImpl;
 import org.apache.cassandra.sidecar.exceptions.OperationalJobConflictException;
+import org.apache.cassandra.sidecar.job.storage.StorageProvider;
+import org.apache.cassandra.sidecar.job.storage.StorageProviderException;
 
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCCEEDED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests to validate the Job submission behavior for scenarios which are a combination of values for
@@ -149,6 +157,12 @@ class OperationalJobManagerTest
             }
 
             @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
+            }
+
+            @Override
             protected Future<Void> executeInternal() throws OperationalJobException
             {
                 throw new OperationalJobException(msg);
@@ -165,5 +179,30 @@ class OperationalJobManagerTest
         manager.trySubmitJob(failingJob, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
         assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
         assertThat(tracker.get(jobId)).isNotNull();
+    }
+
+    @Test
+    void testJobNotExecutedWhenPersistenceFails()
+    {
+        StorageProvider storageProvider = mock(StorageProvider.class);
+        doThrow(new StorageProviderException("Storage unavailable"))
+            .when(storageProvider).persistJob(any());
+
+        DurableOperationalJobTracker durableTracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(),
+                                                                                       storageProvider);
+        OperationalJobManager manager = new OperationalJobManager(durableTracker, executorPool);
+
+        UUID jobId = UUIDs.timeBased();
+        OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
+
+        assertThatThrownBy(() -> manager.trySubmitJob(job,
+                                                      (j, ex) -> {},
+                                                      executorPool.service(),
+                                                      SecondBoundConfiguration.parse("5s")))
+            .isInstanceOf(StorageProviderException.class);
+
+        assertThat(job.isExecuting()).isFalse();
+        assertThat(job.asyncResult().isComplete()).isFalse();
+        assertThat(durableTracker.jobsView()).doesNotContainKey(jobId);
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobTest.java
@@ -82,7 +82,7 @@ class OperationalJobTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override
@@ -118,7 +118,7 @@ class OperationalJobTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override
@@ -162,7 +162,7 @@ class OperationalJobTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override
@@ -207,7 +207,7 @@ class OperationalJobTest
             @Override
             public OperationType operationType()
             {
-                return OperationType.DECOMMISSION;
+                return OperationType.DRAIN;
             }
 
             @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobTest.java
@@ -30,6 +30,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.apache.cassandra.sidecar.TestResourceReaper;
+import org.apache.cassandra.sidecar.common.data.OperationType;
 import org.apache.cassandra.sidecar.common.data.OperationalJobStatus;
 import org.apache.cassandra.sidecar.common.server.exceptions.OperationalJobException;
 import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
@@ -79,6 +80,12 @@ class OperationalJobTest
             }
 
             @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
+            }
+
+            @Override
             public String name()
             {
                 return name;
@@ -106,6 +113,12 @@ class OperationalJobTest
             public OperationalJobStatus status()
             {
                 return jobStatus;
+            }
+
+            @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
             }
 
             @Override
@@ -147,6 +160,12 @@ class OperationalJobTest
             }
 
             @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
+            }
+
+            @Override
             public String name()
             {
                 return "Operation X";
@@ -183,6 +202,12 @@ class OperationalJobTest
             public boolean hasConflict(List<OperationalJob> jobs)
             {
                 return false;
+            }
+
+            @Override
+            public OperationType operationType()
+            {
+                return OperationType.DECOMMISSION;
             }
 
             @Override


### PR DESCRIPTION
## [CASSSIDECAR-374](https://issues.apache.org/jira/browse/CASSSIDECAR-374)

Original PR made against [CASSSIDECAR-373](https://github.com/apache/cassandra-sidecar/pull/339) branch with review comments: https://github.com/andresbeckruiz/cassandra-sidecar/pull/3. 

  ### Changes

  - `DurableOperationalJobTracker`: Implementation of `OperationalJobTracker` that persists job state via `StorageProvider`. Live local jobs are cached in a local `ConcurrentHashMap`,  completed jobs are served from storage
  - `OperationalJobManager`: Separate job tracking from execution — the job is registered in the tracker (and persisted) before execution begins, ensuring durable trackers always have a record before the job runs
  - Unit tests for `DurableOperationalJobTracker` and persist-before-execute verification in `OperationalJobManagerTest`
  - Integration test for `DurableOperationalJobTracker` with Cassandra-backed `StorageProvider`

  ### Future Work

  - [CASSSIDECAR-378](https://issues.apache.org/jira/browse/CASSSIDECAR-378): Add support for creation and coordination of local Sidecar Jobs