### PR TITLE
CASSSIDECAR-377: Implement job coordination for cluster-wide operations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.5.0
 -----
+ * Implement job coordination for cluster-wide operations (CASSSIDECAR-377)
  * Fix dead/dropped CDC lifecycle metrics and duplicate SidecarCdcStats interface (CASSSIDECAR-489)
  * Wire CDC configs in configs table to SidecarCdcOptions/SidecarStatePersister (CASSSIDECAR-483)
  * Implement durable operational job tracker (CASSSIDECAR-374)

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/DisabledOperationalJobCoordinator.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/DisabledOperationalJobCoordinator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.cassandra.sidecar.common.data.OperationType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An {@link OperationalJobCoordinator} used when a Sidecar instance is not configured to support
+ * coordinated cluster-wide operations.
+ * <p>
+ * Jobs that do not require coordination ({@link OperationalJob#requiresCoordination()} returns
+ * {@code false}) never reach this coordinator, so uncoordinated operations (e.g. decommission) are
+ * unaffected. 
+ */
+public class DisabledOperationalJobCoordinator implements OperationalJobCoordinator
+{
+    private static final String NOT_SUPPORTED_MESSAGE =
+    "Operational job coordination is not supported by this Sidecar instance. "
+    + "Configure a coordinator to enable coordinated cluster-wide operations.";
+
+    @Override
+    public boolean trySetActive(OperationType operationType, UUID operationId)
+    {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public boolean clearActive(OperationType operationType, UUID operationId)
+    {
+        throw new UnsupportedOperationException(NOT_SUPPORTED_MESSAGE);
+    }
+
+    @Override
+    @Nullable
+    public UUID getActiveOperation(OperationType operationType)
+    {
+        return null;
+    }
+
+    @Override
+    @NotNull
+    public Map<OperationType, UUID> getActiveOperations()
+    {
+        return Collections.emptyMap();
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
@@ -239,9 +239,9 @@ public abstract class OperationalJob implements Task<Void>, OperationalJobInfo
         String simpleName = this.getClass().getSimpleName();
         return simpleName.isEmpty() ? this.getClass().getName() : simpleName;
     }
-    
-    /** 
-     * @return the {@link OperationType} of this job
+
+    /**
+     * @return the type of operation this job performs
      */
     public abstract OperationType operationType();
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
@@ -183,6 +183,24 @@ public abstract class OperationalJob implements Task<Void>, OperationalJobInfo
         return false;
     }
 
+    /**
+     * Whether the manager should release the active operation lock (via
+     * {@link OperationalJobCoordinator#clearActive}) when this job completes locally. Only consulted for jobs that
+     * {@link #requiresCoordination() require coordination}.
+     * <p>
+     * Single-node coordinated jobs return {@code true} (the default): the Sidecar that acquires the lock also
+     * finishes the work, so releasing on local completion is correct. Distributed cluster-wide jobs whose work
+     * finishes on other nodes return {@code false} and rely on the orchestration layer to call
+     * {@link OperationalJobCoordinator#clearActive} once all nodes reach a terminal state.
+     *
+     * @return {@code true} if the manager should release the lock on local completion; {@code false} to defer
+     *         release to the orchestration layer
+     */
+    public boolean releasesOnCompletion()
+    {
+        return true;
+    }
+
     @Override
     public final Void result()
     {
@@ -239,11 +257,6 @@ public abstract class OperationalJob implements Task<Void>, OperationalJobInfo
         String simpleName = this.getClass().getSimpleName();
         return simpleName.isEmpty() ? this.getClass().getName() : simpleName;
     }
-
-    /**
-     * @return the type of operation this job performs
-     */
-    public abstract OperationType operationType();
 
     /**
      * {@inheritDoc}

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
@@ -349,6 +349,19 @@ public abstract class OperationalJob implements Task<Void>, OperationalJobInfo
     }
 
     /**
+     * Marks the job as failed before it begins executing, for example when it cannot be started due to a
+     * coordination conflict. The execution result is completed exceptionally so the job reports
+     * {@link OperationalJobStatus#FAILED} with the supplied reason, and {@link #executeInternal()} is never invoked.
+     *
+     * @param cause the reason the job could not be started
+     */
+    public void failToStart(Throwable cause)
+    {
+        lastUpdate = Instant.now();
+        executionPromise.tryFail(cause);
+    }
+
+    /**
      * OperationalJob body. The implementation returns a Future representing the job execution.
      */
     protected abstract Future<Void> executeInternal() throws Exception;

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJob.java
@@ -239,6 +239,11 @@ public abstract class OperationalJob implements Task<Void>, OperationalJobInfo
         String simpleName = this.getClass().getSimpleName();
         return simpleName.isEmpty() ? this.getClass().getName() : simpleName;
     }
+    
+    /** 
+     * @return the {@link OperationType} of this job
+     */
+    public abstract OperationType operationType();
 
     /**
      * {@inheritDoc}

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobCoordinator.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobCoordinator.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.cassandra.sidecar.common.data.OperationType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Coordinates cluster-wide operational jobs by managing active operation state.
+ * Ensures mutual exclusion so that only one operation of a given type is active
+ * at a time within a datacenter.
+ */
+public interface OperationalJobCoordinator
+{
+    /**
+     * Attempt to set an operation as active. Implementations must ensure mutual exclusion
+     * so that only one operation of the given type is active at a time.
+     *
+     * @param operationType the type of operation
+     * @param operationId   the unique identifier for this operation
+     * @return {@code true} if the operation was successfully set as active,
+     *         {@code false} if an operation of the same type is already active
+     */
+    boolean trySetActive(OperationType operationType, UUID operationId);
+
+    /**
+     * Clear the active operation lock, but only if the provided operation ID matches
+     * the currently active one.
+     * <p>
+     * This method is not called by {@code OperationalJobManager} during job submission.
+     * For cluster-wide operations, the Sidecar that creates the job is not necessarily
+     * the one that finishes it. Clearing is the responsibility of the orchestration layer
+     * once all participating nodes have completed their work.
+     *
+     * @param operationType the type of operation
+     * @param operationId   the operation ID to clear
+     * @return {@code true} if the active operation was cleared,
+     *         {@code false} if the provided operation ID did not match the active one
+     */
+    boolean clearActive(OperationType operationType, UUID operationId);
+
+    /**
+     * Get the active operation ID for a given operation type.
+     *
+     * @param operationType the type of operation
+     * @return the active operation ID, or {@code null} if no operation of this type is active
+     */
+    @Nullable
+    UUID getActiveOperation(OperationType operationType);
+
+    /**
+     * Get all active operations.
+     *
+     * @return a map of operation type to operation ID for all currently active operations,
+     *         or an empty map if no operations are active
+     */
+    @NotNull
+    Map<OperationType, UUID> getActiveOperations();
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -29,9 +29,11 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
+import org.apache.cassandra.sidecar.common.utils.Preconditions;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.exceptions.OperationalJobConflictException;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An abstraction of the management and tracking of long-running jobs running on the sidecar.
@@ -41,18 +43,33 @@ public class OperationalJobManager
 {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final OperationalJobTracker jobTracker;
-
+    @Nullable
+    private final OperationalJobCoordinator coordinator;
     private final TaskExecutorPool internalExecutorPool;
 
     /**
-     * Creates a manager instance with a default sized job-tracker.
+     * Creates a manager instance without a coordinator.
      *
      * @param jobTracker the tracker for the operational jobs
      */
-    @Inject
     public OperationalJobManager(OperationalJobTracker jobTracker, ExecutorPools executorPools)
     {
+        this(jobTracker, null, executorPools);
+    }
+
+    /**
+     * Creates a manager instance with a coordinator for cluster-wide operation mutual exclusion.
+     *
+     * @param jobTracker  the tracker for the operational jobs
+     * @param coordinator the coordinator for cluster-wide operations, or {@code null} if not needed
+     */
+    @Inject
+    public OperationalJobManager(OperationalJobTracker jobTracker,
+                                 @Nullable OperationalJobCoordinator coordinator,
+                                 ExecutorPools executorPools)
+    {
         this.jobTracker = jobTracker;
+        this.coordinator = coordinator;
         this.internalExecutorPool = executorPools.internal();
     }
 
@@ -104,6 +121,7 @@ public class OperationalJobManager
             OperationalJob tracked = jobTracker.computeIfAbsent(job.jobId(), jobId -> job);
             if (tracked == job)
             {
+                checkCoordination(job);
                 internalExecutorPool.executeBlocking(job::execute);
             }
         }
@@ -130,6 +148,28 @@ public class OperationalJobManager
         if (job.hasConflict(sameOperationJobs))
         {
             throw new OperationalJobConflictException("The same operational job is already running on Cassandra. operationName='" + job.name() + '\'');
+        }
+    }
+
+    /**
+     * For jobs that require cluster-wide coordination, attempts to acquire the active operation lock
+     * via the coordinator. Throws a conflict if another operation is already active.
+     *
+     * @param job instance of the job to coordinate
+     * @throws OperationalJobConflictException when the coordinator cannot activate the operation
+     */
+    private void checkCoordination(OperationalJob job) throws OperationalJobConflictException
+    {
+        if (job.requiresCoordination())
+        {
+            Preconditions.checkState(coordinator != null,
+                                     "Job requires coordination but no OperationalJobCoordinator is configured");
+            boolean activated = coordinator.trySetActive(job.operationType(), job.jobId());
+            if (!activated)
+            {
+                throw new OperationalJobConflictException("An active operation already exists. operationType='"
+                                                         + job.operationType() + '\'');
+            }
         }
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -121,7 +121,7 @@ public class OperationalJobManager
             OperationalJob tracked = jobTracker.computeIfAbsent(job.jobId(), jobId -> job);
             if (tracked == job)
             {
-                checkCoordination(job);
+                tryCoordination(job);
                 internalExecutorPool.executeBlocking(job::execute);
             }
         }
@@ -158,7 +158,7 @@ public class OperationalJobManager
      * @param job instance of the job to coordinate
      * @throws OperationalJobConflictException when the coordinator cannot activate the operation
      */
-    private void checkCoordination(OperationalJob job) throws OperationalJobConflictException
+    private void tryCoordination(OperationalJob job) throws OperationalJobConflictException
     {
         if (job.requiresCoordination())
         {

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -127,7 +127,12 @@ public class OperationalJobManager
         {
             if (ar.succeeded() && Boolean.TRUE.equals(ar.result()))
             {
-                job.asyncResult().onComplete(result -> releaseActiveOperationLock(job));
+                // Distributed jobs that finish on other nodes opt out of auto-release; the orchestration
+                // layer clears the lock once all nodes reach a terminal state.
+                if (job.releasesOnCompletion())
+                {
+                    job.asyncResult().onComplete(result -> releaseActiveOperationLock(job));
+                }
                 trackAndExecute(job, onComplete, serviceExecutorPool, waitTime);
             }
             else

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -43,29 +43,20 @@ public class OperationalJobManager
 {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final OperationalJobTracker jobTracker;
-    @Nullable
     private final OperationalJobCoordinator coordinator;
     private final TaskExecutorPool internalExecutorPool;
 
     /**
-     * Creates a manager instance without a coordinator.
-     *
-     * @param jobTracker the tracker for the operational jobs
-     */
-    public OperationalJobManager(OperationalJobTracker jobTracker, ExecutorPools executorPools)
-    {
-        this(jobTracker, null, executorPools);
-    }
-
-    /**
-     * Creates a manager instance with a coordinator for cluster-wide operation mutual exclusion.
+     * Creates a manager instance with a coordinator for cluster-wide operation mutual exclusion. Instances that
+     * do not support coordination bind a {@link DisabledOperationalJobCoordinator}, which fails coordination
+     * requests.
      *
      * @param jobTracker  the tracker for the operational jobs
-     * @param coordinator the coordinator for cluster-wide operations, or {@code null} if not needed
+     * @param coordinator the coordinator for cluster-wide operations
      */
     @Inject
     public OperationalJobManager(OperationalJobTracker jobTracker,
-                                 @Nullable OperationalJobCoordinator coordinator,
+                                 OperationalJobCoordinator coordinator,
                                  ExecutorPools executorPools)
     {
         this.jobTracker = jobTracker;
@@ -196,15 +187,11 @@ public class OperationalJobManager
      *
      * @param job the job requiring coordination
      * @return a future resolving to {@code true} if the lock was acquired, {@code false} if another operation
-     *         already holds it, or a failed future if coordination could not be attempted (e.g. no coordinator
-     *         is configured or the storage call failed)
+     *         already holds it, or a failed future if coordination could not be attempted (e.g. coordination is
+     *         disabled on this instance or the storage call failed)
      */
     private Future<Boolean> acquireActiveOperationLock(OperationalJob job)
     {
-        if (coordinator == null)
-        {
-            return Future.failedFuture("Job requires coordination but no OperationalJobCoordinator is configured");
-        }
         return internalExecutorPool.executeBlocking(() -> coordinator.trySetActive(job.operationType(), job.jobId()), false);
     }
 
@@ -217,10 +204,6 @@ public class OperationalJobManager
      */
     private void releaseActiveOperationLock(OperationalJob job)
     {
-        if (coordinator == null)
-        {
-            return;
-        }
         internalExecutorPool.executeBlocking(() -> coordinator.clearActive(job.operationType(), job.jobId()), false)
                             .onFailure(e -> logger.error("Failed to clear active operation lock. jobId={} operationType={}",
                                                          job.jobId(), job.operationType(), e));

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -136,6 +136,7 @@ public class OperationalJobManager
         {
             if (ar.succeeded() && Boolean.TRUE.equals(ar.result()))
             {
+                job.asyncResult().onComplete(result -> releaseActiveOperationLock(job));
                 trackAndExecute(job, onComplete, serviceExecutorPool, waitTime);
             }
             else
@@ -205,6 +206,24 @@ public class OperationalJobManager
             return Future.failedFuture("Job requires coordination but no OperationalJobCoordinator is configured");
         }
         return internalExecutorPool.executeBlocking(() -> coordinator.trySetActive(job.operationType(), job.jobId()), false);
+    }
+
+    /**
+     * Releases the active operation lock previously acquired for the given job. The release performs
+     * blocking storage I/O, so it runs on the internal executor pool off the event loop. A failure to clear is logged
+     * rather than surfaced, since the job has already completed by this point.
+     *
+     * @param job the job whose active operation lock should be released
+     */
+    private void releaseActiveOperationLock(OperationalJob job)
+    {
+        if (coordinator == null)
+        {
+            return;
+        }
+        internalExecutorPool.executeBlocking(() -> coordinator.clearActive(job.operationType(), job.jobId()), false)
+                            .onFailure(e -> logger.error("Failed to clear active operation lock. jobId={} operationType={}",
+                                                         job.jobId(), job.operationType(), e));
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/OperationalJobManager.java
@@ -28,8 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.vertx.core.Future;
 import org.apache.cassandra.sidecar.common.server.utils.DurationSpec;
-import org.apache.cassandra.sidecar.common.utils.Preconditions;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
 import org.apache.cassandra.sidecar.concurrent.TaskExecutorPool;
 import org.apache.cassandra.sidecar.exceptions.OperationalJobConflictException;
@@ -116,19 +116,57 @@ public class OperationalJobManager
         try
         {
             checkConflict(job);
-
-            // Track the job first, then start execution separately
-            OperationalJob tracked = jobTracker.computeIfAbsent(job.jobId(), jobId -> job);
-            if (tracked == job)
-            {
-                tryCoordination(job);
-                internalExecutorPool.executeBlocking(job::execute);
-            }
         }
         catch (OperationalJobConflictException oje)
         {
             onComplete.accept(job, oje);
             return;
+        }
+
+        if (!job.requiresCoordination())
+        {
+            trackAndExecute(job, onComplete, serviceExecutorPool, waitTime);
+            return;
+        }
+
+        // Acquiring the active operation lock might perform blocking storage I/O so it must
+        // run off the event loop
+        acquireActiveOperationLock(job)
+        .onComplete(ar ->
+        {
+            if (ar.succeeded() && Boolean.TRUE.equals(ar.result()))
+            {
+                trackAndExecute(job, onComplete, serviceExecutorPool, waitTime);
+            }
+            else
+            {
+                OperationalJobConflictException conflict = coordinationConflict(job, ar.cause());
+                job.failToStart(conflict);
+                jobTracker.computeIfAbsent(job.jobId(), jobId -> job);
+                onComplete.accept(job, conflict);
+            }
+        });
+    }
+
+    /**
+     * Tracks the job and submits it for asynchronous execution on the internal executor pool, then arranges for
+     * {@code onComplete} to be invoked with the result (or after {@code waitTime} elapses).
+     *
+     * @param job                 the job to track and execute
+     * @param onComplete          callback to invoke when the job completes
+     * @param serviceExecutorPool the executor pool to use for waiting on job completion
+     * @param waitTime            the maximum time to wait for job completion before returning
+     */
+    private void trackAndExecute(OperationalJob job,
+                                 BiConsumer<OperationalJob, OperationalJobConflictException> onComplete,
+                                 TaskExecutorPool serviceExecutorPool,
+                                 DurationSpec waitTime)
+    {
+        // New job is submitted for all cases when we do not have a corresponding downstream job
+        OperationalJob tracked = jobTracker.computeIfAbsent(job.jobId(), jobId -> job);
+        if (tracked == job)
+        {
+            internalExecutorPool.executeBlocking(job::execute);
         }
 
         // Get the result, waiting for the specified wait time for result
@@ -152,24 +190,39 @@ public class OperationalJobManager
     }
 
     /**
-     * For jobs that require cluster-wide coordination, attempts to acquire the active operation lock
-     * via the coordinator. Throws a conflict if another operation is already active.
+     * For jobs that require cluster-wide coordination, attempts to acquire the active operation lock via the
+     * coordinator. The acquisition runs on the internal executor pool because it might performs blocking storage I/O
      *
-     * @param job instance of the job to coordinate
-     * @throws OperationalJobConflictException when the coordinator cannot activate the operation
+     * @param job the job requiring coordination
+     * @return a future resolving to {@code true} if the lock was acquired, {@code false} if another operation
+     *         already holds it, or a failed future if coordination could not be attempted (e.g. no coordinator
+     *         is configured or the storage call failed)
      */
-    private void tryCoordination(OperationalJob job) throws OperationalJobConflictException
+    private Future<Boolean> acquireActiveOperationLock(OperationalJob job)
     {
-        if (job.requiresCoordination())
+        if (coordinator == null)
         {
-            Preconditions.checkState(coordinator != null,
-                                     "Job requires coordination but no OperationalJobCoordinator is configured");
-            boolean activated = coordinator.trySetActive(job.operationType(), job.jobId());
-            if (!activated)
-            {
-                throw new OperationalJobConflictException("An active operation already exists. operationType='"
-                                                         + job.operationType() + '\'');
-            }
+            return Future.failedFuture("Job requires coordination but no OperationalJobCoordinator is configured");
         }
+        return internalExecutorPool.executeBlocking(() -> coordinator.trySetActive(job.operationType(), job.jobId()), false);
+    }
+
+    /**
+     * Builds the conflict exception describing why the active operation lock could not be acquired.
+     *
+     * @param job   the job that could not be coordinated
+     * @param cause the failure cause when coordination could not be attempted, or {@code null} when the lock is
+     *              simply held by another active operation
+     * @return the conflict exception to report to the caller
+     */
+    private OperationalJobConflictException coordinationConflict(OperationalJob job, @Nullable Throwable cause)
+    {
+        if (cause != null)
+        {
+            return new OperationalJobConflictException("Unable to coordinate operation. operationType='"
+                                                       + job.operationType() + "', reason='" + cause.getMessage() + '\'');
+        }
+        return new OperationalJobConflictException("An active operation already exists. operationType='"
+                                                   + job.operationType() + '\'');
     }
 }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/StorageBackedOperationalJobCoordinator.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/StorageBackedOperationalJobCoordinator.java
@@ -33,12 +33,12 @@ import org.jetbrains.annotations.Nullable;
  * for coordination of active operations.
  */
 @Singleton
-public class StorageOperationalJobCoordinator implements OperationalJobCoordinator
+public class StorageBackedOperationalJobCoordinator implements OperationalJobCoordinator
 {
     private final StorageProvider storageProvider;
 
     @Inject
-    public StorageOperationalJobCoordinator(StorageProvider storageProvider)
+    public StorageBackedOperationalJobCoordinator(StorageProvider storageProvider)
     {
         this.storageProvider = storageProvider;
     }

--- a/server/src/main/java/org/apache/cassandra/sidecar/job/StorageOperationalJobCoordinator.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/job/StorageOperationalJobCoordinator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.Map;
+import java.util.UUID;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.cassandra.sidecar.common.data.OperationType;
+import org.apache.cassandra.sidecar.job.storage.StorageProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * An {@link OperationalJobCoordinator} implementation that delegates to a {@link StorageProvider}
+ * for coordination of active operations.
+ */
+@Singleton
+public class StorageOperationalJobCoordinator implements OperationalJobCoordinator
+{
+    private final StorageProvider storageProvider;
+
+    @Inject
+    public StorageOperationalJobCoordinator(StorageProvider storageProvider)
+    {
+        this.storageProvider = storageProvider;
+    }
+
+    @Override
+    public boolean trySetActive(OperationType operationType, UUID operationId)
+    {
+        return storageProvider.trySetActiveOperation(operationType, operationId);
+    }
+
+    @Override
+    public boolean clearActive(OperationType operationType, UUID operationId)
+    {
+        return storageProvider.clearActiveOperation(operationType, operationId);
+    }
+
+    @Override
+    @Nullable
+    public UUID getActiveOperation(OperationType operationType)
+    {
+        return storageProvider.getActiveOperation(operationType);
+    }
+
+    @Override
+    @NotNull
+    public Map<OperationType, UUID> getActiveOperations()
+    {
+        return storageProvider.getActiveOperations();
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
@@ -61,10 +61,10 @@ import org.apache.cassandra.sidecar.handlers.TokenRangeReplicaMapHandler;
 import org.apache.cassandra.sidecar.handlers.cassandra.NodeSettingsHandler;
 import org.apache.cassandra.sidecar.handlers.v2.cassandra.V2NodeSettingsHandler;
 import org.apache.cassandra.sidecar.handlers.validations.ValidateTableExistenceHandler;
+import org.apache.cassandra.sidecar.job.DisabledOperationalJobCoordinator;
 import org.apache.cassandra.sidecar.job.InMemoryOperationalJobTracker;
 import org.apache.cassandra.sidecar.job.OperationalJobCoordinator;
 import org.apache.cassandra.sidecar.job.OperationalJobTracker;
-import org.apache.cassandra.sidecar.job.StorageBackedOperationalJobCoordinator;
 import org.apache.cassandra.sidecar.modules.multibindings.KeyClassMapKey;
 import org.apache.cassandra.sidecar.modules.multibindings.TableSchemaMapKeys;
 import org.apache.cassandra.sidecar.modules.multibindings.VertxRouteMapKeys;
@@ -85,7 +85,7 @@ public class CassandraOperationsModule extends AbstractModule
     protected void configure()
     {
         bind(OperationalJobTracker.class).to(InMemoryOperationalJobTracker.class);
-        bind(OperationalJobCoordinator.class).to(StorageBackedOperationalJobCoordinator.class);
+        bind(OperationalJobCoordinator.class).to(DisabledOperationalJobCoordinator.class);
     }
 
     @ProvidesIntoMap

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
@@ -62,7 +62,9 @@ import org.apache.cassandra.sidecar.handlers.cassandra.NodeSettingsHandler;
 import org.apache.cassandra.sidecar.handlers.v2.cassandra.V2NodeSettingsHandler;
 import org.apache.cassandra.sidecar.handlers.validations.ValidateTableExistenceHandler;
 import org.apache.cassandra.sidecar.job.InMemoryOperationalJobTracker;
+import org.apache.cassandra.sidecar.job.OperationalJobCoordinator;
 import org.apache.cassandra.sidecar.job.OperationalJobTracker;
+import org.apache.cassandra.sidecar.job.StorageOperationalJobCoordinator;
 import org.apache.cassandra.sidecar.modules.multibindings.KeyClassMapKey;
 import org.apache.cassandra.sidecar.modules.multibindings.TableSchemaMapKeys;
 import org.apache.cassandra.sidecar.modules.multibindings.VertxRouteMapKeys;
@@ -83,6 +85,7 @@ public class CassandraOperationsModule extends AbstractModule
     protected void configure()
     {
         bind(OperationalJobTracker.class).to(InMemoryOperationalJobTracker.class);
+        bind(OperationalJobCoordinator.class).to(StorageOperationalJobCoordinator.class);
     }
 
     @ProvidesIntoMap

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/CassandraOperationsModule.java
@@ -64,7 +64,7 @@ import org.apache.cassandra.sidecar.handlers.validations.ValidateTableExistenceH
 import org.apache.cassandra.sidecar.job.InMemoryOperationalJobTracker;
 import org.apache.cassandra.sidecar.job.OperationalJobCoordinator;
 import org.apache.cassandra.sidecar.job.OperationalJobTracker;
-import org.apache.cassandra.sidecar.job.StorageOperationalJobCoordinator;
+import org.apache.cassandra.sidecar.job.StorageBackedOperationalJobCoordinator;
 import org.apache.cassandra.sidecar.modules.multibindings.KeyClassMapKey;
 import org.apache.cassandra.sidecar.modules.multibindings.TableSchemaMapKeys;
 import org.apache.cassandra.sidecar.modules.multibindings.VertxRouteMapKeys;
@@ -85,7 +85,7 @@ public class CassandraOperationsModule extends AbstractModule
     protected void configure()
     {
         bind(OperationalJobTracker.class).to(InMemoryOperationalJobTracker.class);
-        bind(OperationalJobCoordinator.class).to(StorageOperationalJobCoordinator.class);
+        bind(OperationalJobCoordinator.class).to(StorageBackedOperationalJobCoordinator.class);
     }
 
     @ProvidesIntoMap

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/DisabledOperationalJobCoordinatorTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/DisabledOperationalJobCoordinatorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.job;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.datastax.driver.core.utils.UUIDs;
+import org.apache.cassandra.sidecar.common.data.OperationType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link DisabledOperationalJobCoordinator}, the coordinator used when a Sidecar instance
+ * does not support coordinated cluster-wide operations.
+ */
+class DisabledOperationalJobCoordinatorTest
+{
+    private final OperationalJobCoordinator coordinator = new DisabledOperationalJobCoordinator();
+
+    @Test
+    void testTrySetActiveThrows()
+    {
+        UUID operationId = UUIDs.timeBased();
+        assertThatThrownBy(() -> coordinator.trySetActive(OperationType.MOVE, operationId))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("coordination is not supported by this Sidecar instance");
+    }
+
+    @Test
+    void testClearActiveThrows()
+    {
+        UUID operationId = UUIDs.timeBased();
+        assertThatThrownBy(() -> coordinator.clearActive(OperationType.MOVE, operationId))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("coordination is not supported by this Sidecar instance");
+    }
+
+    @Test
+    void testGetActiveOperationReturnsNull()
+    {
+        assertThat(coordinator.getActiveOperation(OperationType.MOVE)).isNull();
+    }
+
+    @Test
+    void testGetActiveOperationsReturnsEmptyMap()
+    {
+        assertThat(coordinator.getActiveOperations()).isEmpty();
+    }
+}

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -87,7 +87,7 @@ class OperationalJobManagerTest
     void testWithNoDownstreamJob() throws InterruptedException
     {
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
-        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        OperationalJobManager manager = new OperationalJobManager(tracker, new DisabledOperationalJobCoordinator(), executorPool);
         CountDownLatch latch = new CountDownLatch(1);
 
         OperationalJob testJob = OperationalJobTest.createOperationalJob(SUCCEEDED);
@@ -108,7 +108,7 @@ class OperationalJobManagerTest
     {
         OperationalJob runningJob = OperationalJobTest.createOperationalJob(RUNNING);
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
-        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        OperationalJobManager manager = new OperationalJobManager(tracker, new DisabledOperationalJobCoordinator(), executorPool);
         CountDownLatch latch = new CountDownLatch(1);
 
         BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (job, exception) -> {
@@ -126,7 +126,7 @@ class OperationalJobManagerTest
     {
         UUID jobId = UUIDs.timeBased();
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
-        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        OperationalJobManager manager = new OperationalJobManager(tracker, new DisabledOperationalJobCoordinator(), executorPool);
         CountDownLatch latch = new CountDownLatch(1);
 
         OperationalJob testJob = OperationalJobTest.createOperationalJob(jobId, SecondBoundConfiguration.parse("2s"));
@@ -150,7 +150,7 @@ class OperationalJobManagerTest
     {
         UUID jobId = UUIDs.timeBased();
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
-        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        OperationalJobManager manager = new OperationalJobManager(tracker, new DisabledOperationalJobCoordinator(), executorPool);
         CountDownLatch latch = new CountDownLatch(1);
 
         String msg = "Test Job failed";
@@ -260,17 +260,17 @@ class OperationalJobManagerTest
     }
 
     @Test
-    void testCoordinationFailsWhenNoCoordinatorConfigured() throws InterruptedException
+    void testCoordinationFailsWhenCoordinationDisabled() throws InterruptedException
     {
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
-        // No coordinator is wired, yet the job requires coordination.
-        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        // Coordination is disabled on this instance, yet the job requires coordination.
+        OperationalJobManager manager = new OperationalJobManager(tracker, new DisabledOperationalJobCoordinator(), executorPool);
         CountDownLatch latch = new CountDownLatch(1);
 
         OperationalJob job = createCoordinatedJob(UUIDs.timeBased());
         BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (j, ex) -> {
             assertThat(ex).isInstanceOf(OperationalJobConflictException.class);
-            assertThat(ex.getMessage()).contains("no OperationalJobCoordinator is configured");
+            assertThat(ex.getMessage()).contains("coordination is not supported by this Sidecar instance");
             latch.countDown();
         };
 
@@ -279,7 +279,7 @@ class OperationalJobManagerTest
         OperationalJobInfo tracked = tracker.get(job.jobId());
         assertThat(tracked).isNotNull();
         assertThat(tracked.status()).isEqualTo(FAILED);
-        assertThat(tracked.failureReason()).contains("no OperationalJobCoordinator is configured");
+        assertThat(tracked.failureReason()).contains("coordination is not supported by this Sidecar instance");
         assertThat(tracker.inflightJobsByOperation(job.name())).doesNotContain(job);
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -49,6 +49,7 @@ import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCC
 import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -198,7 +199,7 @@ class OperationalJobManagerTest
         DurableOperationalJobTracker durableTracker = new DurableOperationalJobTracker(new ServiceConfigurationImpl(),
                                                                                        storageProvider,
                                                                                        executorPool.service());
-        OperationalJobManager manager = new OperationalJobManager(durableTracker, executorPool);
+        OperationalJobManager manager = new OperationalJobManager(durableTracker, new DisabledOperationalJobCoordinator(), executorPool);
 
         UUID jobId = UUIDs.timeBased();
         OperationalJob job = OperationalJobTest.createOperationalJob(jobId, MillisecondBoundConfiguration.parse("50ms"));
@@ -284,6 +285,29 @@ class OperationalJobManagerTest
     }
 
     @Test
+    void testLockNotReleasedWhenJobOptsOut() throws InterruptedException
+    {
+        OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
+        OperationalJobCoordinator coordinator = mock(OperationalJobCoordinator.class);
+        when(coordinator.trySetActive(any(), any())).thenReturn(true);
+        OperationalJobManager manager = new OperationalJobManager(tracker, coordinator, executorPool);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // A distributed cluster-wide job that acquires the lock locally but relies on the orchestration
+        // layer to clear it once all nodes finish, so the manager must not auto-release on local completion.
+        OperationalJob job = createNonReleasingCoordinatedJob(UUIDs.timeBased());
+        BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (j, ex) -> {
+            assertThat(ex).isNull();
+            latch.countDown();
+        };
+
+        manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        verify(coordinator).trySetActive(OperationType.MOVE, job.jobId());
+        verify(coordinator, after(1000).never()).clearActive(any(), any());
+    }
+
+    @Test
     void testCoordinatorNotCalledWhenJobDoesNotRequireCoordination() throws InterruptedException
     {
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
@@ -322,6 +346,42 @@ class OperationalJobManagerTest
             public boolean requiresCoordination()
             {
                 return true;
+            }
+
+            @Override
+            protected Future<Void> executeInternal()
+            {
+                return Future.succeededFuture();
+            }
+        };
+    }
+
+    private static OperationalJob createNonReleasingCoordinatedJob(UUID jobId)
+    {
+        return new OperationalJob(jobId)
+        {
+            @Override
+            public boolean hasConflict(@NotNull List<OperationalJob> sameOperationJobs)
+            {
+                return false;
+            }
+
+            @Override
+            public OperationType operationType()
+            {
+                return OperationType.MOVE;
+            }
+
+            @Override
+            public boolean requiresCoordination()
+            {
+                return true;
+            }
+
+            @Override
+            public boolean releasesOnCompletion()
+            {
+                return false;
             }
 
             @Override

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -41,6 +41,7 @@ import org.apache.cassandra.sidecar.config.yaml.ServiceConfigurationImpl;
 import org.apache.cassandra.sidecar.exceptions.OperationalJobConflictException;
 import org.apache.cassandra.sidecar.job.storage.StorageProvider;
 import org.apache.cassandra.sidecar.job.storage.StorageProviderException;
+import org.jetbrains.annotations.NotNull;
 
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCCEEDED;
@@ -49,6 +50,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -206,5 +209,93 @@ class OperationalJobManagerTest
         loopAssert(2, () -> {
             assertThat(durableTracker.jobsView()).doesNotContainKey(jobId);
         });
+    }
+
+    void testCoordinatorCalledWhenJobRequiresCoordination() throws InterruptedException
+    {
+        OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
+        OperationalJobCoordinator coordinator = mock(OperationalJobCoordinator.class);
+        when(coordinator.trySetActive(any(), any())).thenReturn(true);
+        OperationalJobManager manager = new OperationalJobManager(tracker, coordinator, executorPool);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        OperationalJob job = createCoordinatedJob(UUIDs.timeBased());
+        BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (j, ex) -> {
+            assertThat(ex).isNull();
+            latch.countDown();
+        };
+
+        manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        verify(coordinator).trySetActive(OperationType.MOVE, job.jobId());
+    }
+
+    @Test
+    void testConflictWhenCoordinatorReturnsFalse() throws InterruptedException
+    {
+        OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
+        OperationalJobCoordinator coordinator = mock(OperationalJobCoordinator.class);
+        when(coordinator.trySetActive(any(), any())).thenReturn(false);
+        OperationalJobManager manager = new OperationalJobManager(tracker, coordinator, executorPool);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        OperationalJob job = createCoordinatedJob(UUIDs.timeBased());
+        BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (j, ex) -> {
+            assertThat(ex).isInstanceOf(OperationalJobConflictException.class);
+            assertThat(ex.getMessage()).contains("An active operation already exists");
+            latch.countDown();
+        };
+
+        manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void testCoordinatorNotCalledWhenJobDoesNotRequireCoordination() throws InterruptedException
+    {
+        OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
+        OperationalJobCoordinator coordinator = mock(OperationalJobCoordinator.class);
+        OperationalJobManager manager = new OperationalJobManager(tracker, coordinator, executorPool);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        OperationalJob job = OperationalJobTest.createOperationalJob(SUCCEEDED);
+        BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (j, ex) -> {
+            assertThat(ex).isNull();
+            latch.countDown();
+        };
+
+        manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        verify(coordinator, never()).trySetActive(any(), any());
+    }
+
+    private static OperationalJob createCoordinatedJob(UUID jobId)
+    {
+        return new OperationalJob(jobId)
+        {
+            @Override
+            public boolean hasConflict(@NotNull List<OperationalJob> sameOperationJobs)
+            {
+                return false;
+            }
+
+            @Override
+            public OperationType operationType()
+            {
+                return OperationType.MOVE;
+            }
+
+            @Override
+            public boolean requiresCoordination()
+            {
+                return true;
+            }
+
+            @Override
+            protected Future<Void> executeInternal()
+            {
+                return Future.succeededFuture();
+            }
+        };
     }
 }

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -43,6 +43,7 @@ import org.apache.cassandra.sidecar.job.storage.StorageProvider;
 import org.apache.cassandra.sidecar.job.storage.StorageProviderException;
 import org.jetbrains.annotations.NotNull;
 
+import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.FAILED;
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.RUNNING;
 import static org.apache.cassandra.sidecar.common.data.OperationalJobStatus.SUCCEEDED;
 import static org.apache.cassandra.testing.utils.AssertionUtils.loopAssert;
@@ -248,6 +249,35 @@ class OperationalJobManagerTest
 
         manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
         assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        OperationalJobInfo tracked = tracker.get(job.jobId());
+        assertThat(tracked).isNotNull();
+        assertThat(tracked.status()).isEqualTo(FAILED);
+        assertThat(tracked.failureReason()).contains("An active operation already exists");
+        assertThat(tracker.inflightJobsByOperation(job.name())).doesNotContain(job);
+    }
+
+    @Test
+    void testCoordinationFailsWhenNoCoordinatorConfigured() throws InterruptedException
+    {
+        OperationalJobTracker tracker = new InMemoryOperationalJobTracker(4);
+        // No coordinator is wired, yet the job requires coordination.
+        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        OperationalJob job = createCoordinatedJob(UUIDs.timeBased());
+        BiConsumer<OperationalJob, OperationalJobConflictException> onComplete = (j, ex) -> {
+            assertThat(ex).isInstanceOf(OperationalJobConflictException.class);
+            assertThat(ex.getMessage()).contains("no OperationalJobCoordinator is configured");
+            latch.countDown();
+        };
+
+        manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        OperationalJobInfo tracked = tracker.get(job.jobId());
+        assertThat(tracked).isNotNull();
+        assertThat(tracked.status()).isEqualTo(FAILED);
+        assertThat(tracked.failureReason()).contains("no OperationalJobCoordinator is configured");
+        assertThat(tracker.inflightJobsByOperation(job.name())).doesNotContain(job);
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/OperationalJobManagerTest.java
@@ -52,6 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -229,6 +230,7 @@ class OperationalJobManagerTest
         manager.trySubmitJob(job, onComplete, executorPool.service(), SecondBoundConfiguration.parse("5s"));
         assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
         verify(coordinator).trySetActive(OperationType.MOVE, job.jobId());
+        verify(coordinator, timeout(5000)).clearActive(OperationType.MOVE, job.jobId());
     }
 
     @Test
@@ -254,6 +256,7 @@ class OperationalJobManagerTest
         assertThat(tracked.status()).isEqualTo(FAILED);
         assertThat(tracked.failureReason()).contains("An active operation already exists");
         assertThat(tracker.inflightJobsByOperation(job.name())).doesNotContain(job);
+        verify(coordinator, never()).clearActive(any(), any());
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/job/RepairJobTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/job/RepairJobTest.java
@@ -234,7 +234,7 @@ class RepairJobTest
     {
         // Create a job tracker and manager
         OperationalJobTracker tracker = new InMemoryOperationalJobTracker(10);
-        OperationalJobManager manager = new OperationalJobManager(tracker, executorPool);
+        OperationalJobManager manager = new OperationalJobManager(tracker, new DisabledOperationalJobCoordinator(), executorPool);
 
         // Mock the storage operations
         StorageOperations storageOperations = mock(StorageOperations.class);


### PR DESCRIPTION
 ## [CASSSIDECAR-377](https://issues.apache.org/jira/browse/CASSSIDECAR-377)

Original PR made against [CASSSIDECAR-373](https://github.com/apache/cassandra-sidecar/pull/339) branch with review comments: https://github.com/andresbeckruiz/cassandra-sidecar/pull/2. 

  ### Changes

  - `OperationalJobCoordinator` interface 
  - `StorageOperationalJobCoordinator`: Implementation that delegates to `StorageProvider`'s compare and set based methods to acquire a lock for an active operation
  - `OperationalJob.operationType()`: New abstract method returning `OperationType` enum, implemented by all concrete jobs 
  - `OperationalJobManager` integration: If a job requires coordination, the manager acquires the active lock via the coordinator before execution; throws `OperationalJobConflictException` if rejected
  - Unit tests for `StorageOperationalJobCoordinator` and coordinator integration in `OperationalJobManagerTest`

 This ticket only covers the job activation path when a job is submitted to be executed immediately. Clearing locks after completion and status update activation will be implemented in later tickets (CASSSIDECAR-378, CASSSIDECAR-379).

  ### Future Work

  - [CASSSIDECAR-378](https://issues.apache.org/jira/browse/CASSSIDECAR-378): Add support for creation and coordination of local Sidecar Jobs
  - [CASSSIDECAR-379](https://issues.apache.org/jira/browse/CASSSIDECAR-379): Add PATCH operational-jobs/{id} API to update status of existing operational jobs