### PR TITLE
[CASSSIDECAR-476] Fix SpotBugs violation and add spotbugsIntegrationTest to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ jobs:
       - attach_workspace:
           at: dtest-jars
       - run: ./scripts/install-shaded-dtest-jar-local.sh
-      - run: ./gradlew --no-daemon --max-workers=2 -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" checkstyleIntegrationTest integrationTestLightWeight --stacktrace
+      - run: ./gradlew --no-daemon --max-workers=2 -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" checkstyleIntegrationTest spotbugsIntegrationTest integrationTestLightWeight --stacktrace
       - save_gradle_cache
 
       - store_artifacts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           ./gradlew --no-daemon \
             -PdtestVersion=${{ matrix.dtestVersion }} \
             -Dcassandra.sidecar.versions_to_test="${{ matrix.cassandra }}" \
-            integrationTestLightWeight \
+            spotbugsIntegrationTest integrationTestLightWeight \
             --stacktrace
         env:
           CASSANDRA_DEP_DIR: ${{ github.workspace }}/dtest-jars

--- a/server/src/test/integration/org/apache/cassandra/sidecar/db/ClusterOpsDatabaseAccessorIntegrationTest.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/db/ClusterOpsDatabaseAccessorIntegrationTest.java
@@ -112,6 +112,9 @@ class ClusterOpsDatabaseAccessorIntegrationTest extends IntegrationTestBase
         Instant firstStartTime = updated.startTime();
         accessor.updateJobStatus(clusterName, jobId1, OperationType.REPAIR, OperationalJobStatus.RUNNING, null);
         OperationalJobRecord afterSecondRunning = accessor.findJob(clusterName, jobId1);
+        assertThat(afterSecondRunning)
+                .withFailMessage("findJob should return the job after second RUNNING update")
+                .isNotNull();
         assertThat(afterSecondRunning.startTime())
                 .withFailMessage("start_time should not change on subsequent RUNNING updates")
                 .isEqualTo(firstStartTime);


### PR DESCRIPTION

## Summary

- Fix SpotBugs null pointer dereference warning in `ClusterOpsDatabaseAccessorIntegrationTest` by adding an explicit `assertThat(...).isNotNull()` before dereferencing the `findJob()` return value
- Add `spotbugsIntegrationTest` to CircleCI and GitHub CI lightweight integration jobs so SpotBugs violations in integration test sources are caught in CI

## Context

The `spotbugsIntegrationTest` task was not run in any CI pipeline:
- GitHub CI unit-tests job runs `build -x integrationTest`, which skips integration test SpotBugs
- CircleCI/GitHub integration test jobs only run `checkstyleIntegrationTest` and test execution tasks

This allowed the SpotBugs violation to go undetected during commit.
