### PR TITLE
Support Apache Cassandra 6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
       - store_test_results:
           path: build/test-results/
 
-  integration_cassandra_trunk_java11:
+  integration_cassandra_60_java11:
     docker:
       - image: cimg/openjdk:11.0
     environment:
@@ -270,7 +270,7 @@ jobs:
       - attach_workspace:
           at: dtest-jars
       - run: ./scripts/install-shaded-dtest-jar-local.sh
-      - run: ./gradlew --no-daemon --max-workers=2 -PdtestVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" checkstyleIntegrationTest spotbugsIntegrationTest integrationTestLightWeight --stacktrace
+      - run: ./gradlew --no-daemon --max-workers=2 -PdtestVersion=6.0-alpha3 -PtarballVersion=6.0 -Dcassandra.sidecar.versions_to_test="6.0" checkstyleIntegrationTest spotbugsIntegrationTest integrationTestLightWeight --stacktrace
       - save_gradle_cache
 
       - store_artifacts:
@@ -284,7 +284,7 @@ jobs:
       - store_test_results:
           path: build/test-results/
 
-  integration_heavy_cassandra_trunk_java11:
+  integration_heavy_cassandra_60_java11:
     docker:
       - image: cimg/openjdk:11.0
     environment:
@@ -301,7 +301,7 @@ jobs:
       - attach_workspace:
           at: cassandra-tarballs
       - run: ./scripts/install-shaded-dtest-jar-local.sh
-      - run: ./gradlew --no-daemon -PdtestVersion=5.1 -PtarballVersion=5.1 -Dcassandra.sidecar.versions_to_test="5.1" jar integrationTestHeavyWeight --stacktrace
+      - run: ./gradlew --no-daemon -PdtestVersion=6.0-alpha3 -PtarballVersion=6.0 -Dcassandra.sidecar.versions_to_test="6.0" jar integrationTestHeavyWeight --stacktrace
       - save_gradle_cache
 
       - store_artifacts:
@@ -439,7 +439,7 @@ workflows:
           requires:
             - unit_java11
             - build-dtest-jdk11
-      - integration_cassandra_trunk_java11:
+      - integration_cassandra_60_java11:
           requires:
             - unit_java11
             - build-dtest-jdk11
@@ -451,7 +451,7 @@ workflows:
           requires:
             - unit_java11
             - build-dtest-jdk11
-      - integration_heavy_cassandra_trunk_java11:
+      - integration_heavy_cassandra_60_java11:
           requires:
             - unit_java11
             - build-dtest-jdk11
@@ -463,8 +463,8 @@ workflows:
             - integration_heavy_cassandra_40_java11
             - integration_cassandra_50_java11
             - integration_heavy_cassandra_50_java11
-            - integration_cassandra_trunk_java11
-            - integration_heavy_cassandra_trunk_java11
+            - integration_cassandra_60_java11
+            - integration_heavy_cassandra_60_java11
       - docker_build:
           requires:
             - client_only_unit_java8
@@ -473,8 +473,8 @@ workflows:
             - integration_heavy_cassandra_40_java11
             - integration_cassandra_50_java11
             - integration_heavy_cassandra_50_java11
-            - integration_cassandra_trunk_java11
-            - integration_heavy_cassandra_trunk_java11
+            - integration_cassandra_60_java11
+            - integration_heavy_cassandra_60_java11
       - rpm_build_install:
           requires:
             - client_only_unit_java8
@@ -483,8 +483,8 @@ workflows:
             - integration_heavy_cassandra_40_java11
             - integration_cassandra_50_java11
             - integration_heavy_cassandra_50_java11
-            - integration_cassandra_trunk_java11
-            - integration_heavy_cassandra_trunk_java11
+            - integration_cassandra_60_java11
+            - integration_heavy_cassandra_60_java11
       - deb_build_install:
           requires:
             - client_only_unit_java8
@@ -493,5 +493,5 @@ workflows:
             - integration_heavy_cassandra_40_java11
             - integration_cassandra_50_java11
             - integration_heavy_cassandra_50_java11
-            - integration_cassandra_trunk_java11
-            - integration_heavy_cassandra_trunk_java11
+            - integration_cassandra_60_java11
+            - integration_heavy_cassandra_60_java11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["11", "17"]
-        cassandra: ["4.0", "4.1", "5.0", "5.1"]
+        cassandra: ["4.0", "4.1", "5.0", "6.0"]
         include:
           - cassandra: "4.0"
             dtestVersion: "4.0.20"
@@ -216,8 +216,8 @@ jobs:
             dtestVersion: "4.1.11"
           - cassandra: "5.0"
             dtestVersion: "5.0.6"
-          - cassandra: "5.1"
-            dtestVersion: "5.1"
+          - cassandra: "6.0"
+            dtestVersion: "6.0-alpha3"
         # Exclude jdk17 for 4.0/4.1 as they don't support 17
         exclude:
           - cassandra: "4.0"
@@ -264,6 +264,7 @@ jobs:
         run: |
           ./gradlew --no-daemon \
             -PdtestVersion=${{ matrix.dtestVersion }} \
+            -PtarballVersion=${{ matrix.cassandra }} \
             -Dcassandra.sidecar.versions_to_test="${{ matrix.cassandra }}" \
             spotbugsIntegrationTest integrationTestLightWeight \
             --stacktrace
@@ -294,7 +295,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["11", "17"]
-        cassandra: ["4.0", "4.1", "5.0", "5.1"]
+        cassandra: ["4.0", "4.1", "5.0", "6.0"]
         include:
           - cassandra: "4.0"
             dtestVersion: "4.0.16"
@@ -302,8 +303,8 @@ jobs:
             dtestVersion: "4.1.6"
           - cassandra: "5.0"
             dtestVersion: "5.0.3"
-          - cassandra: "5.1"
-            dtestVersion: "5.1"
+          - cassandra: "6.0"
+            dtestVersion: "6.0-alpha3"
         # Exclude jdk17 for 4.0/4.1 as they don't support 17
         exclude:
           - cassandra: "4.0"

--- a/.github/workflows/publish-test-artifacts.yml
+++ b/.github/workflows/publish-test-artifacts.yml
@@ -134,8 +134,8 @@ jobs:
 
             All tests passed before creating these artifacts:
             - ✅ Unit tests (Java 11, 17, 21)
-            - ✅ Lightweight integration tests (Java 11, 17, 21 × Cassandra 4.0, 4.1, 5.0, 5.1)
-            - ✅ Heavyweight integration tests (Java 11, 17, 21 × Cassandra 4.0, 4.1, 5.0, 5.1)
+            - ✅ Lightweight integration tests (Java 11, 17, 21 × Cassandra 4.0, 4.1, 5.0, 6.0)
+            - ✅ Heavyweight integration tests (Java 11, 17, 21 × Cassandra 4.0, 4.1, 5.0, 6.0)
             - ✅ Static analysis (SpotBugs, Apache RAT, JaCoCo)
 
             ### Artifacts

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 0.5.0
 -----
-  * CachingSchemaStore should be reloaded when Schemastore kafka configs are changed (CASSSIDECAR-493)
+ * Support Apache Cassandra 6.0 (CASSSIDECAR-494)
+ * CachingSchemaStore should be reloaded when Schemastore kafka configs are changed (CASSSIDECAR-493)
  * Support retrying on HTTP 429 responses and fix duplicate immediate execution in RequestExecutor retry scheduling (CASSSIDECAR-465)
  * Add RFC 6902-inspired JSON Patch support to ConfigurationManager (CASSSIDECAR-429)
  * Implement job coordination for cluster-wide operations (CASSSIDECAR-377)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We use the [Sidecar for Apache Cassandra JIRA](https://issues.apache.org/jira/pr
 Requirements
 ------------
   1. Java >= 11<sup>1</sup> (OpenJDK or Oracle)
-  2. Apache Cassandra 4.0.  We depend on virtual tables which is a 4.0 only feature.
+  2. Apache Cassandra 4.0 through 6.0.  We depend on virtual tables, which arrived in 4.0.
   3. [Docker](https://www.docker.com/products/docker-desktop/) for running integration tests.
 
 Build Prerequisites
@@ -46,9 +46,9 @@ The build script supports two parameters:
 - `REPO` - the Cassandra git repository to use for the source files. This is helpful if you need to test with a fork of the Cassandra codebase.
     - default: `git@github.com:apache/cassandra.git`
 - `BRANCHES` - a space-delimited list of branches to build.
-  -default: `"cassandra-4.1 trunk"`
+  -default: `"cassandra-4.0 cassandra-4.1 cassandra-5.0 cassandra-6.0"`
 
-Remove any versions you may not want to test with. We recommend at least the latest (released) 4.X series and `trunk`.
+Remove any versions you may not want to test with. We recommend at least the latest (released) 4.X series and `cassandra-6.0`.
 See Testing for more details on how to choose which Cassandra versions to use while testing.
 
 For multi-node in-jvm dtests, network aliases will need to be setup for each Cassandra node. The tests assume each node's 
@@ -298,9 +298,9 @@ While Sidecar includes a built-in schema store, you can integrate with external 
 Testing
 -------
 
-The test framework is set up to run 4.1 and 5.1 (Trunk) tests (see `TestVersionSupplier.java`) by default.
+The test framework is set up to run 4.1 and 6.0 tests (see `TestVersionSupplier.java`) by default.
 You can change this via the Java property `cassandra.sidecar.versions_to_test` by supplying a comma-delimited string.
-For example, `-Dcassandra.sidecar.versions_to_test=4.0,4.1,5.1`.
+For example, `-Dcassandra.sidecar.versions_to_test=4.0,4.1,6.0`.
 
 CircleCI Testing
 -----------------

--- a/TESTING.md
+++ b/TESTING.md
@@ -52,12 +52,16 @@ This script builds dtest jars for the supported Cassandra versions.
 You can customize which versions to build:
 
 - **REPO**: Cassandra git repository (default: `https://github.com/apache/cassandra.git`)
-- **BRANCHES**: Space-delimited list of branches (default: `"cassandra-4.0 cassandra-4.1 cassandra-5.0 trunk"`)
+- **BRANCHES**: Space-delimited list of branches (default: `"cassandra-4.0 cassandra-4.1 cassandra-5.0 cassandra-6.0"`)
 
 Example with custom branches:
 ```bash
-BRANCHES="cassandra-4.1 trunk" ./scripts/build-dtest-jars.sh
+BRANCHES="cassandra-4.1 cassandra-6.0" ./scripts/build-dtest-jars.sh
 ```
+
+`cassandra-6.0` is pre-release, so its dtest jar and tarball carry the `6.0-alpha3` qualifier.
+`trunk` is Cassandra 7.0. It stays in `CANDIDATE_BRANCHES` and builds with `BRANCHES="trunk"`, but no
+test job uses it until a 7.0 adapter exists.
 
 ### Network Setup for Multi-Node Tests
 
@@ -203,7 +207,7 @@ Test fixtures provide shared test utilities and data across modules.
 ./gradlew check -x containerTest
 
 # Run with specific Cassandra versions
-./gradlew test -Dcassandra.sidecar.versions_to_test=4.1,5.1
+./gradlew test -Dcassandra.sidecar.versions_to_test=4.1,6.0
 ```
 
 ### Test Execution Configuration
@@ -242,10 +246,10 @@ The test framework supports multiple Cassandra versions simultaneously. Configur
 
 **System Property**:
 ```bash
--Dcassandra.sidecar.versions_to_test=4.0,4.1,5.1
+-Dcassandra.sidecar.versions_to_test=4.0,4.1,6.0
 ```
 
-**Default versions**: `4.1,5.1` (as defined in `TestVersionSupplier.java`)
+**Default versions**: `4.1,6.0` (as defined in `TestVersionSupplier.java`)
 
 ### Test Logging
 

--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraAdapter.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraAdapter.java
@@ -205,7 +205,7 @@ public class CassandraAdapter implements ICassandraAdapter
     @Override
     public String toString()
     {
-        return "CassandraAdapter" + "@" + Integer.toHexString(hashCode());
+        return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());
     }
 
     @NotNull

--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraStorageOperations.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/CassandraStorageOperations.java
@@ -124,7 +124,7 @@ public class CassandraStorageOperations implements StorageOperations
                                         @Nullable Map<String, String> options)
     {
         requireNonNull(tag, "snapshot tag must be non-null");
-        requireNonNull(keyspace, "keyspace for the  must be non-null");
+        requireNonNull(keyspace, "keyspace must be non-null");
         requireNonNull(table, "table must be non-null");
         try
         {
@@ -133,34 +133,57 @@ public class CassandraStorageOperations implements StorageOperations
         }
         catch (IOException e)
         {
-            // post-5.0, IOExceptions are thrown when previously something else like
-            // an IllegalArgumentException was thrown. First, try to unwrap the IOException and throw
-            // the original cause, which we will process correctly in CreateSnapshotHandler
-            // if the exception was an IllegalArgumentException
-            IllegalArgumentException iex = ThrowableUtils.getCause(e, IllegalArgumentException.class);
-            if (iex != null)
-            {
-                throw iex;
-            }
-            String errorMessage = e.getMessage();
-            if (errorMessage != null)
-            {
-                if (errorMessage.contains("Snapshot " + tag + " already exists") ||
-                    errorMessage.contains("Snapshot " + tag + " for " + keyspace + "." + table + " already exists"))
-                {
-                    throw new SnapshotAlreadyExistsException(e);
-                }
-                else if (errorMessage.contains("Keyspace " + keyspace + " does not exist"))
-                {
-                    throw new IllegalArgumentException(e);
-                }
-                else if (errorMessage.contains("Cannot snapshot until bootstrap completes"))
-                {
-                    throw new NodeBootstrappingException(e);
-                }
-            }
-            throw new RuntimeException(e);
+            throw translateSnapshotFailure(e, tag, keyspace, table);
         }
+    }
+
+    /**
+     * @return the exception to throw for a snapshot JMX failure
+     */
+    protected RuntimeException translateSnapshotFailure(@NotNull IOException e,
+                                                       @NotNull String tag,
+                                                       @NotNull String keyspace,
+                                                       @NotNull String table)
+    {
+        RuntimeException translated = classifySnapshotFailure(e, tag, keyspace, table);
+        return translated != null ? translated : new RuntimeException(e);
+    }
+
+    /**
+     * @return the exception that the snapshot handlers map to a response, or {@code null} when the failure
+     * matches no known snapshot failure, which lets the caller decide what to throw
+     */
+    protected @Nullable RuntimeException classifySnapshotFailure(@NotNull Exception e,
+                                                                @NotNull String tag,
+                                                                @NotNull String keyspace,
+                                                                @NotNull String table)
+    {
+        // post-5.0 wraps in IOException what earlier releases threw directly, so unwrap first
+        IllegalArgumentException iex = ThrowableUtils.getCause(e, IllegalArgumentException.class);
+        if (iex != null)
+        {
+            return iex;
+        }
+        // 6.0 wraps a snapshot task failure without carrying its message forward, so search the whole chain
+        if (messageContains(e, "Snapshot " + tag + " already exists") ||
+            messageContains(e, "Snapshot " + tag + " for " + keyspace + "." + table + " already exists"))
+        {
+            return new SnapshotAlreadyExistsException(e);
+        }
+        else if (messageContains(e, "Keyspace " + keyspace + " does not exist"))
+        {
+            return new IllegalArgumentException(e);
+        }
+        else if (messageContains(e, "Cannot snapshot until bootstrap completes"))
+        {
+            return new NodeBootstrappingException(e);
+        }
+        return null;
+    }
+
+    private static boolean messageContains(@NotNull Throwable throwable, @NotNull String text)
+    {
+        return ThrowableUtils.getCause(throwable, t -> t.getMessage() != null && t.getMessage().contains(text)) != null;
     }
 
     /**

--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/db/ConnectedClientStats.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/db/ConnectedClientStats.java
@@ -55,7 +55,8 @@ public class ConnectedClientStats
     {
         this.address = row.getInet("address").getHostAddress();
         this.port = row.getInt("port");
-        this.hostname = row.getString("hostname");
+        // Cassandra 6.0 removed the hostname column under CASSANDRA-21539 to avoid a DNS lookup per row
+        this.hostname = getStringFieldIfExists(row, "hostname");
         this.username = row.getString("username");
         this.connectionStage = row.getString("connection_stage");
         this.protocolVersion = Integer.toString(row.getInt("protocol_version"));

--- a/adapters/adapters-base/src/test/java/org/apache/cassandra/sidecar/adapters/base/db/ConnectedClientStatsTest.java
+++ b/adapters/adapters-base/src/test/java/org/apache/cassandra/sidecar/adapters/base/db/ConnectedClientStatsTest.java
@@ -65,6 +65,20 @@ public class ConnectedClientStatsTest
         assertThat(stats.clientOptions).isNull();
     }
 
+    @Test
+    public void connectedClientStatsWithoutHostnameTest()
+    {
+        // Cassandra 6.0 removed the hostname column from system_views.clients under CASSANDRA-21539
+        setupMockData(mockRow, false);
+        when(mockRow.getColumnDefinitions().contains(anyString()))
+        .thenAnswer(i -> !"hostname".equals(i.getArgument(0, String.class)));
+
+        ConnectedClientStats stats = new ConnectedClientStats(mockRow);
+        assertThat(stats.hostname).isNull();
+        assertThat(stats.username).isEqualTo("u1");
+        assertThat(stats.authenticationMode).isEqualTo("password");
+    }
+
     private void setupMockData(Row mockRow, boolean isMissingFields)
     {
         ColumnDefinitions mockColumnDefinitions = mock(ColumnDefinitions.class);

--- a/adapters/adapters-cassandra60/build.gradle
+++ b/adapters/adapters-cassandra60/build.gradle
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+
+plugins {
+    id 'java-library'
+    id 'idea'
+    id 'maven-publish'
+    id "com.github.spotbugs"
+}
+
+apply from: "$rootDir/gradle/common/publishing.gradle"
+
+sourceCompatibility = JavaVersion.VERSION_11
+
+test {
+    useJUnitPlatform()
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
+dependencies {
+    api(project(":server-common"))
+    api(project(":adapters:adapters-base"))
+    api(project(":adapters:adapters-cassandra41"))
+    api(project(":adapters:adapters-cassandra50"))
+
+    compileOnly('org.jetbrains:annotations:23.0.0')
+    compileOnly('com.datastax.cassandra:cassandra-driver-core:3.11.3')
+    implementation("org.slf4j:slf4j-api:${project.slf4jVersion}")
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${project.junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${project.junitVersion}"
+    testImplementation "org.assertj:assertj-core:${project.assertjCoreVersion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${project.junitVersion}"
+
+    testImplementation('org.mockito:mockito-core:4.10.0')
+    testImplementation('org.mockito:mockito-inline:4.10.0')
+}
+
+spotbugsTest.enabled = false

--- a/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60Adapter.java
+++ b/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60Adapter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.cassandra60;
+
+import java.net.InetSocketAddress;
+
+import org.apache.cassandra.sidecar.adapters.cassandra50.Cassandra50Adapter;
+import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
+import org.apache.cassandra.sidecar.common.server.ICassandraAdapter;
+import org.apache.cassandra.sidecar.common.server.JmxClient;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
+import org.apache.cassandra.sidecar.common.server.utils.DriverUtils;
+import org.apache.cassandra.sidecar.db.schema.TableSchemaFetcher;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A {@link ICassandraAdapter} implementation for Cassandra 6.0
+ * <p>
+ * Cassandra 6.0 keeps the table and compaction manager MBean contracts of 5.0.
+ */
+public class Cassandra60Adapter extends Cassandra50Adapter
+{
+    public Cassandra60Adapter(DnsResolver dnsResolver,
+                              JmxClient jmxClient,
+                              CQLSessionProvider session,
+                              InetSocketAddress localNativeTransportAddress,
+                              DriverUtils driverUtils,
+                              TableSchemaFetcher tableSchemaFetcher)
+    {
+        super(dnsResolver, jmxClient, session, localNativeTransportAddress, driverUtils, tableSchemaFetcher);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NotNull
+    protected StorageOperations createStorageOperations(DnsResolver dnsResolver, JmxClient jmxClient)
+    {
+        return new Cassandra60StorageOperations(jmxClient, dnsResolver);
+    }
+}

--- a/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60Factory.java
+++ b/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60Factory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.cassandra60;
+
+import java.net.InetSocketAddress;
+import java.util.Objects;
+
+import org.apache.cassandra.sidecar.common.server.CQLSessionProvider;
+import org.apache.cassandra.sidecar.common.server.ICassandraAdapter;
+import org.apache.cassandra.sidecar.common.server.ICassandraFactory;
+import org.apache.cassandra.sidecar.common.server.JmxClient;
+import org.apache.cassandra.sidecar.common.server.MinimumVersion;
+import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
+import org.apache.cassandra.sidecar.common.server.utils.DriverUtils;
+import org.apache.cassandra.sidecar.db.schema.TableSchemaFetcher;
+
+/**
+ * Factory to produce the Cassandra 6.x adapter
+ */
+@MinimumVersion("6.0.0")
+public class Cassandra60Factory implements ICassandraFactory
+{
+    private final DnsResolver dnsResolver;
+    private final DriverUtils driverUtils;
+    private final TableSchemaFetcher tableSchemaFetcher;
+
+    public Cassandra60Factory(DnsResolver dnsResolver, DriverUtils driverUtils, TableSchemaFetcher tableSchemaFetcher)
+    {
+        this.dnsResolver = Objects.requireNonNull(dnsResolver, "dnsResolver is required");
+        this.driverUtils = Objects.requireNonNull(driverUtils, "driverUtils is required");
+        this.tableSchemaFetcher = Objects.requireNonNull(tableSchemaFetcher, "tableSchemaFetcher is required");
+    }
+
+    /**
+     * Returns a new adapter for Cassandra 6.x clusters.
+     *
+     * @param session                     the session to the Cassandra database
+     * @param jmxClient                   the JMX client to connect to the Cassandra database
+     * @param localNativeTransportAddress the native transport address and port of the instance
+     * @return a new adapter for the 6.x clusters
+     */
+    @Override
+    public ICassandraAdapter create(CQLSessionProvider session, JmxClient jmxClient,
+                                    InetSocketAddress localNativeTransportAddress)
+    {
+        return new Cassandra60Adapter(dnsResolver, jmxClient, session, localNativeTransportAddress, driverUtils, tableSchemaFetcher);
+    }
+}

--- a/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60StorageOperations.java
+++ b/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60StorageOperations.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.cassandra60;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.management.InstanceNotFoundException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.cassandra.sidecar.adapters.base.RingProvider;
+import org.apache.cassandra.sidecar.adapters.base.TokenRangeReplicaProvider;
+import org.apache.cassandra.sidecar.adapters.cassandra50.Cassandra50StorageOperations;
+import org.apache.cassandra.sidecar.adapters.cassandra60.jmx.SnapshotManagerJmxOperations;
+import org.apache.cassandra.sidecar.common.server.JmxClient;
+import org.apache.cassandra.sidecar.common.server.StorageOperations;
+import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
+import org.apache.cassandra.sidecar.common.server.utils.ThrowableUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.cassandra.sidecar.adapters.cassandra60.jmx.SnapshotManagerJmxOperations.SNAPSHOT_MANAGER_OBJ_NAME;
+
+/**
+ * An implementation of the {@link StorageOperations} that interfaces with Cassandra 6.0 and later.
+ * <p>
+ * Cassandra 6.0 deprecated the snapshot methods on the Storage Service MBean in favour of the Snapshot Manager
+ * MBean, so the snapshot operations are routed there.
+ * <p>
+ * Only {@code CassandraDaemon} registers the Snapshot Manager MBean. A node that starts without it, such as an
+ * in-JVM dtest node, does not export it, so this class falls back to the deprecated methods, which 6.0 keeps.
+ * Both routes reach the same Snapshot Manager, so they behave alike.
+ * <p>
+ * The fallback holds for the life of the instance, which the delegate rebuilds on a JMX reconnect. A node that
+ * registers the MBean later in its own startup therefore keeps the deprecated route until the next reconnect.
+ */
+public class Cassandra60StorageOperations extends Cassandra50StorageOperations
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(Cassandra60StorageOperations.class);
+
+    private final AtomicBoolean snapshotManagerMBeanAbsent = new AtomicBoolean(false);
+
+    /**
+     * Creates a new instance with the provided {@link JmxClient} and {@link DnsResolver}
+     *
+     * @param jmxClient   the JMX client used to communicate with the Cassandra instance
+     * @param dnsResolver the DNS resolver used to lookup replicas
+     */
+    public Cassandra60StorageOperations(JmxClient jmxClient, DnsResolver dnsResolver)
+    {
+        super(jmxClient, dnsResolver);
+    }
+
+    /**
+     * This constructor is exposed for extensibility.
+     *
+     * @param jmxClient                 the JMX client used to communicate with the Cassandra instance
+     * @param ringProvider              the ring provider instance
+     * @param tokenRangeReplicaProvider the token range replica provider
+     */
+    public Cassandra60StorageOperations(JmxClient jmxClient,
+                                        RingProvider ringProvider,
+                                        TokenRangeReplicaProvider tokenRangeReplicaProvider)
+    {
+        super(jmxClient, ringProvider, tokenRangeReplicaProvider);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void takeSnapshot(@NotNull String tag,
+                             @NotNull String keyspace,
+                             @NotNull String table,
+                             @Nullable Map<String, String> options)
+    {
+        requireNonNull(tag, "snapshot tag must be non-null");
+        requireNonNull(keyspace, "keyspace must be non-null");
+        requireNonNull(table, "table must be non-null");
+        // SnapshotOptions.userSnapshot reads the map without a null check, so normalise before either route
+        Map<String, String> opts = options != null ? options : Collections.emptyMap();
+        if (snapshotManagerMBeanAbsent.get())
+        {
+            super.takeSnapshot(tag, keyspace, table, opts);
+            return;
+        }
+        try
+        {
+            jmxClient.proxy(SnapshotManagerJmxOperations.class, SNAPSHOT_MANAGER_OBJ_NAME)
+                     .takeSnapshot(tag, opts, keyspace + "." + table);
+        }
+        catch (IOException e)
+        {
+            throw translateSnapshotFailure(e, tag, keyspace, table);
+        }
+        catch (RuntimeException e)
+        {
+            if (isSnapshotManagerMBeanAbsent(e))
+            {
+                super.takeSnapshot(tag, keyspace, table, opts);
+                return;
+            }
+            throw translateRuntimeSnapshotFailure(e, tag, keyspace, table);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The Snapshot Manager options map filters by age only, so {@code table} is still ignored.
+     */
+    @Override
+    public void clearSnapshot(@NotNull String tag, @NotNull String keyspace, @NotNull String table)
+    {
+        requireNonNull(tag, "snapshot tag must be non-null");
+        requireNonNull(keyspace, "keyspace must be non-null");
+        requireNonNull(table, "table must be non-null");
+        if (snapshotManagerMBeanAbsent.get())
+        {
+            clearSnapshotViaStorageService(tag, keyspace, table);
+            return;
+        }
+        LOGGER.debug("Table is not supported by Cassandra JMX endpoints. " +
+                     "Clearing snapshot with tag={} and keyspace={}; table={} is ignored", tag, keyspace, table);
+        try
+        {
+            jmxClient.proxy(SnapshotManagerJmxOperations.class, SNAPSHOT_MANAGER_OBJ_NAME)
+                     .clearSnapshot(tag, Collections.emptyMap(), keyspace);
+        }
+        catch (IOException e)
+        {
+            throw translateSnapshotFailure(e, tag, keyspace, table);
+        }
+        catch (RuntimeException e)
+        {
+            if (isSnapshotManagerMBeanAbsent(e))
+            {
+                clearSnapshotViaStorageService(tag, keyspace, table);
+                return;
+            }
+            throw translateRuntimeSnapshotFailure(e, tag, keyspace, table);
+        }
+    }
+
+    /**
+     * The deprecated method delegates to the same Snapshot Manager, so it raises the same unwrapped failures. The
+     * base implementation does not classify them, so classify here to keep both routes equivalent.
+     */
+    private void clearSnapshotViaStorageService(@NotNull String tag, @NotNull String keyspace, @NotNull String table)
+    {
+        try
+        {
+            super.clearSnapshot(tag, keyspace, table);
+        }
+        catch (RuntimeException e)
+        {
+            throw translateRuntimeSnapshotFailure(e, tag, keyspace, table);
+        }
+    }
+
+    /**
+     * Remembers the answer, so that later calls skip the failing round trip. Logs one warning per instance.
+     *
+     * @return {@code true} when the node does not export the Snapshot Manager MBean
+     */
+    private boolean isSnapshotManagerMBeanAbsent(@NotNull RuntimeException e)
+    {
+        if (ThrowableUtils.getCause(e, InstanceNotFoundException.class) == null)
+        {
+            return false;
+        }
+        if (snapshotManagerMBeanAbsent.compareAndSet(false, true))
+        {
+            LOGGER.warn("The node does not export the {} MBean. Using the deprecated snapshot methods of the "
+                        + "Storage Service MBean instead", SNAPSHOT_MANAGER_OBJ_NAME, e);
+        }
+        return true;
+    }
+
+    /**
+     * {@code SnapshotManager.clearSnapshot} declares {@link IOException} but does not wrap its failures, so the
+     * JMX proxy raises the original {@link RuntimeException}.
+     *
+     * @return the exception to throw, which is {@code e} itself when it is not a known snapshot failure
+     */
+    private RuntimeException translateRuntimeSnapshotFailure(@NotNull RuntimeException e,
+                                                            @NotNull String tag,
+                                                            @NotNull String keyspace,
+                                                            @NotNull String table)
+    {
+        RuntimeException translated = classifySnapshotFailure(e, tag, keyspace, table);
+        return translated != null ? translated : e;
+    }
+}

--- a/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/jmx/SnapshotManagerJmxOperations.java
+++ b/adapters/adapters-cassandra60/src/main/java/org/apache/cassandra/sidecar/adapters/cassandra60/jmx/SnapshotManagerJmxOperations.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.cassandra60.jmx;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * An interface that pulls methods from the Cassandra Snapshot Manager MBean. Cassandra 6.0 introduced this MBean
+ * and deprecated the snapshot methods on the Storage Service MBean.
+ */
+public interface SnapshotManagerJmxOperations
+{
+    String SNAPSHOT_MANAGER_OBJ_NAME = "org.apache.cassandra.service.snapshot:type=SnapshotManager";
+
+    /**
+     * Takes the snapshot of tables in one or more keyspaces.
+     *
+     * @param tag      the tag given to the snapshot; may not be null or empty
+     * @param options  map of options, for example skipFlush
+     * @param entities an empty list, a list of keyspaces, or a list of {@code keyspace.table} pairs
+     * @throws IOException when the snapshot operation fails
+     */
+    void takeSnapshot(String tag, Map<String, String> options, String... entities) throws IOException;
+
+    /**
+     * Deletes the snapshot with the given tag from the listed keyspaces. A null or empty tag clears every snapshot.
+     *
+     * @param tag           the tag of the snapshot to clear
+     * @param options       map of options; Cassandra 6.0 accepts {@code older_than} and {@code older_than_timestamp}
+     * @param keyspaceNames the keyspaces to clear the snapshot from
+     * @throws IOException when the clear snapshot operation fails
+     */
+    void clearSnapshot(String tag, Map<String, Object> options, String... keyspaceNames) throws IOException;
+}

--- a/adapters/adapters-cassandra60/src/test/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60StorageOperationsTest.java
+++ b/adapters/adapters-cassandra60/src/test/java/org/apache/cassandra/sidecar/adapters/cassandra60/Cassandra60StorageOperationsTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.adapters.cassandra60;
+
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.Collections;
+import java.util.Map;
+import javax.management.InstanceNotFoundException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.cassandra.sidecar.adapters.base.jmx.StorageJmxOperations;
+import org.apache.cassandra.sidecar.adapters.cassandra60.jmx.SnapshotManagerJmxOperations;
+import org.apache.cassandra.sidecar.common.server.JmxClient;
+import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
+import org.apache.cassandra.sidecar.common.server.exceptions.NodeBootstrappingException;
+import org.apache.cassandra.sidecar.common.server.exceptions.SnapshotAlreadyExistsException;
+
+import static org.apache.cassandra.sidecar.adapters.base.jmx.StorageJmxOperations.STORAGE_SERVICE_OBJ_NAME;
+import static org.apache.cassandra.sidecar.adapters.cassandra60.jmx.SnapshotManagerJmxOperations.SNAPSHOT_MANAGER_OBJ_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link Cassandra60StorageOperations}, which routes the snapshot operations to the
+ * Snapshot Manager MBean that Cassandra 6.0 introduced.
+ */
+class Cassandra60StorageOperationsTest
+{
+    private static final String TAG = "my-snapshot";
+    private static final String KEYSPACE = "ks";
+    private static final String TABLE = "tbl";
+
+    private JmxClient mockJmxClient;
+    private SnapshotManagerJmxOperations mockSnapshotManager;
+    private StorageJmxOperations mockStorageService;
+    private Cassandra60StorageOperations storageOperations;
+
+    @BeforeEach
+    void setUp()
+    {
+        mockJmxClient = mock(JmxClient.class);
+        mockSnapshotManager = mock(SnapshotManagerJmxOperations.class);
+        mockStorageService = mock(StorageJmxOperations.class);
+        when(mockJmxClient.proxy(SnapshotManagerJmxOperations.class, SNAPSHOT_MANAGER_OBJ_NAME))
+        .thenReturn(mockSnapshotManager);
+        when(mockJmxClient.proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME))
+        .thenReturn(mockStorageService);
+        storageOperations = new Cassandra60StorageOperations(mockJmxClient, mock(DnsResolver.class));
+    }
+
+    private static RuntimeException mBeanAbsentFailure()
+    {
+        return new UndeclaredThrowableException(new InstanceNotFoundException(SNAPSHOT_MANAGER_OBJ_NAME));
+    }
+
+    @Test
+    void testTakeSnapshotUsesTheSnapshotManagerMBean() throws IOException
+    {
+        Map<String, String> options = Collections.singletonMap("skipFlush", "true");
+        storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, options);
+
+        verify(mockJmxClient, times(1)).proxy(SnapshotManagerJmxOperations.class, SNAPSHOT_MANAGER_OBJ_NAME);
+        verify(mockJmxClient, never()).proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME);
+        verify(mockSnapshotManager, times(1)).takeSnapshot(TAG, options, KEYSPACE + "." + TABLE);
+    }
+
+    @Test
+    void testClearSnapshotUsesTheSnapshotManagerMBean() throws IOException
+    {
+        storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE);
+
+        verify(mockJmxClient, times(1)).proxy(SnapshotManagerJmxOperations.class, SNAPSHOT_MANAGER_OBJ_NAME);
+        verify(mockJmxClient, never()).proxy(StorageJmxOperations.class, STORAGE_SERVICE_OBJ_NAME);
+        // the Snapshot Manager options map filters by age only, so the table is not passed
+        verify(mockSnapshotManager, times(1)).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+    }
+
+    @Test
+    void testTakeSnapshotTranslatesTheCassandra60AlreadyExistsMessage() throws IOException
+    {
+        // the message that the Cassandra 6.0 Snapshot Manager produces for a duplicate tag
+        String message = "Exception occured while executing org.apache.cassandra.service.snapshot.TakeSnapshotTask: "
+                         + "Snapshot " + TAG + " for " + KEYSPACE + "." + TABLE + " already exists.";
+        doThrow(new IOException(message))
+        .when(mockSnapshotManager).takeSnapshot(TAG, Collections.emptyMap(), KEYSPACE + "." + TABLE);
+
+        assertThatThrownBy(() -> storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, null))
+        .isInstanceOf(SnapshotAlreadyExistsException.class);
+    }
+
+    @Test
+    void testTakeSnapshotTranslatesTheBootstrapMessage() throws IOException
+    {
+        doThrow(new IOException("Cannot snapshot until bootstrap completes"))
+        .when(mockSnapshotManager).takeSnapshot(TAG, Collections.emptyMap(), KEYSPACE + "." + TABLE);
+
+        assertThatThrownBy(() -> storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, null))
+        .isInstanceOf(NodeBootstrappingException.class);
+    }
+
+    @Test
+    void testTakeSnapshotReplacesNullOptionsWithAnEmptyMap() throws IOException
+    {
+        // SnapshotOptions.userSnapshot reads the map without a null check
+        storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, null);
+
+        verify(mockSnapshotManager, times(1)).takeSnapshot(TAG, Collections.emptyMap(), KEYSPACE + "." + TABLE);
+    }
+
+    @Test
+    void testClearSnapshotTranslatesAnIOException() throws IOException
+    {
+        // the Snapshot Manager MBean declares IOException, although the 6.0 clear implementation raises a
+        // RuntimeException instead
+        doThrow(new IOException("Keyspace " + KEYSPACE + " does not exist"))
+        .when(mockSnapshotManager).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+
+        assertThatThrownBy(() -> storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE))
+        .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testClearSnapshotClassifiesAFailureCarriedOnlyByTheCause() throws IOException
+    {
+        // SnapshotManager wraps a clear failure without appending the task message, so the text is in the cause alone
+        RuntimeException wrapped = new RuntimeException(
+        "Exception occured while executing org.apache.cassandra.service.snapshot.ClearSnapshotTask",
+        new RuntimeException("Keyspace " + KEYSPACE + " does not exist"));
+        doThrow(wrapped).when(mockSnapshotManager).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+
+        assertThatThrownBy(() -> storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE))
+        .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testClearSnapshotRethrowsAnUnrelatedRuntimeFailure() throws IOException
+    {
+        RuntimeException unrelated = new RuntimeException("the JMX connection is closed");
+        doThrow(unrelated).when(mockSnapshotManager).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+
+        assertThatThrownBy(() -> storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE))
+        .isSameAs(unrelated);
+    }
+
+    @Test
+    void testTakeSnapshotTranslatesTheWrappedCassandra60Message() throws IOException
+    {
+        // SnapshotManager.takeSnapshot wraps its failures as new IOException(cause), so the message is cause.toString()
+        RuntimeException cause = new RuntimeException(
+        "Exception occured while executing org.apache.cassandra.service.snapshot.TakeSnapshotTask: "
+        + "Snapshot " + TAG + " for " + KEYSPACE + "." + TABLE + " already exists.");
+        doThrow(new IOException(cause))
+        .when(mockSnapshotManager).takeSnapshot(TAG, Collections.emptyMap(), KEYSPACE + "." + TABLE);
+
+        assertThatThrownBy(() -> storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, null))
+        .isInstanceOf(SnapshotAlreadyExistsException.class);
+    }
+
+    @Test
+    void testTakeSnapshotFallsBackWhenTheMBeanIsAbsent() throws IOException
+    {
+        // only CassandraDaemon registers the Snapshot Manager MBean, so an in-JVM dtest node does not export it
+        Map<String, String> options = Collections.singletonMap("skipFlush", "true");
+        doThrow(mBeanAbsentFailure())
+        .when(mockSnapshotManager).takeSnapshot(TAG, options, KEYSPACE + "." + TABLE);
+
+        storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, options);
+
+        verify(mockStorageService, times(1)).takeSnapshot(TAG, options, KEYSPACE + "." + TABLE);
+    }
+
+    @Test
+    void testClearSnapshotFallsBackWhenTheMBeanIsAbsent() throws IOException
+    {
+        doThrow(mBeanAbsentFailure())
+        .when(mockSnapshotManager).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+
+        storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE);
+
+        verify(mockStorageService, times(1)).clearSnapshot(TAG, KEYSPACE);
+    }
+
+    @Test
+    void testTheFallbackIsRememberedAcrossCalls() throws IOException
+    {
+        doThrow(mBeanAbsentFailure())
+        .when(mockSnapshotManager).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+
+        storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE);
+        storageOperations.clearSnapshot(TAG, KEYSPACE, TABLE);
+        storageOperations.takeSnapshot(TAG, KEYSPACE, TABLE, null);
+
+        // the second clear and the take go straight to the Storage Service MBean
+        verify(mockSnapshotManager, times(1)).clearSnapshot(TAG, Collections.emptyMap(), KEYSPACE);
+        verify(mockSnapshotManager, never()).takeSnapshot(TAG, Collections.emptyMap(), KEYSPACE + "." + TABLE);
+        verify(mockStorageService, times(2)).clearSnapshot(TAG, KEYSPACE);
+        verify(mockStorageService, times(1)).takeSnapshot(TAG, Collections.emptyMap(), KEYSPACE + "." + TABLE);
+    }
+
+    @Test
+    void testTakeSnapshotRequiresNonNullArguments()
+    {
+        assertThatThrownBy(() -> storageOperations.takeSnapshot(null, KEYSPACE, TABLE, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("snapshot tag must be non-null");
+        assertThatThrownBy(() -> storageOperations.clearSnapshot(TAG, null, TABLE))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("keyspace must be non-null");
+    }
+
+    @Test
+    void testSnapshotManagerObjectNameMatchesCassandra60()
+    {
+        assertThat(SNAPSHOT_MANAGER_OBJ_NAME).isEqualTo("org.apache.cassandra.service.snapshot:type=SnapshotManager");
+    }
+}

--- a/docker/cdc-demo/README.md
+++ b/docker/cdc-demo/README.md
@@ -184,7 +184,7 @@ http://localhost:8080/ui/clusters/local/schemas/cdc-mutations-value
 
 ## Supported Cassandra Versions
 
-CDC is supported for **4.0, 4.1, 5.0, 5.1**. To use a different version:
+CDC is supported for **4.0, 4.1, 5.0**. To use a different version:
 
 ```bash
 CASSANDRA_VERSION=4.1 ./scripts/start.sh

--- a/docs/src/development.adoc
+++ b/docs/src/development.adoc
@@ -25,6 +25,41 @@ Implementation of ICassandraAdapter and related classes for different Cassandra 
 
 Implementation of ICassandraAdapter and related classes for Cassandra 4.0.
 
+#### adapters/adapters-cassandra41, adapters/adapters-cassandra50, adapters/adapters-cassandra60
+
+One module per release line that changes a surface the Sidecar uses.  Each module extends the module
+below it and overrides only the operations that the release changed.  `CassandraVersionProvider`
+selects the module whose `@MinimumVersion` is the highest one at or below the release version that the
+node reports.
+
+Cassandra 6.0 changes four surfaces that the Sidecar reads:
+
+* Snapshot methods on `StorageServiceMBean` are deprecated in favour of the
+  `org.apache.cassandra.service.snapshot:type=SnapshotManager` MBean, so `Cassandra60StorageOperations`
+  routes `takeSnapshot` and `clearSnapshot` there.  That MBean wraps a failed `takeSnapshot` in an
+  `IOException` but leaves a failed `clearSnapshot` as a `RuntimeException`, so the 6.0 class classifies
+  both.  Only `CassandraDaemon` registers that MBean, and the in-JVM dtest node does not, so
+  `Cassandra60StorageOperations` catches `InstanceNotFoundException` and uses the deprecated Storage Service
+  MBean methods instead.
+* CASSANDRA-21539 removed the `hostname` column from `system_views.clients`, to avoid one DNS lookup per
+  row.  `ConnectedClientStats` reads that column only when it is present, so its `hostname` is null on 6.0.
+  The connected clients response never carried that value, so API consumers see no change.
+* 6.0 adds the `authentication_mode` column to `system_views.clients`, so the connected clients response
+  carries that field on 6.0 and null below it.
+* Under CEP-21, `Gossiper` takes the gossiped release version from cluster metadata rather than from the
+  build property.  Cluster metadata holds a parsed version, so a pre-release renders differently: a node
+  built as `6.0-alpha3-SNAPSHOT` gossips `6.0.0-alpha3.SNAPSHOT`.  The gossip response carries that form,
+  and a released version is unaffected.  The node settings response still carries the build property.
+
+Two more notes for API consumers.  Since Cassandra 5.0.6, the `system_views.settings` virtual table
+renders collection and map values as JSON, so those values reach consumers as JSON in the node settings
+response; set `cassandra.virtual_table_complex_settings_format_json=false` on the node to restore the old
+form.  `EndpointSnitchInfoMBean` is deprecated at type level in 6.0 under CASSANDRA-19488.  It still
+works, and `RingProvider` and `TokenRangeReplicaProvider` still use it.
+
+Change data capture has no Cassandra 6.0 support.  cassandra-analytics ships one commit log bridge per
+release line, and no 6.0 bridge exists yet, so CDC must stay disabled on a 6.0 node.
+
 ### Cassandra Integration Tests
 
 Cassandra integration tests leverage the in-jvm dtest framework to create Cassandra nodes and test the different implementations of the ICassandraAdapters against real C* nodes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,9 +28,9 @@ jacksonVersion=2.14.3
 caffeineVersion=3.2.2
 dtestApiVersion=0.0.17
 assertjCoreVersion=3.24.2
-# trunk is currently 5.1 - update when trunk moves
-dtestVersion=5.1
-tarballVersion=5.1
+dtestVersion=6.0
+# tarballVersion selects the heavy-weight test tarball; 6.0 matches apache-cassandra-6.0-alpha3-SNAPSHOT
+tarballVersion=6.0
 dtestDependencyName=cassandra-dtest-local-all
 awsSdkVersion=2.26.12
 # The dep is to introduce xxhash impl

--- a/gradle/common/integrationTestTask.gradle
+++ b/gradle/common/integrationTestTask.gradle
@@ -30,9 +30,12 @@ apply from: "${project.rootDir}/gradle/common/java11Options.gradle"
 def getCassandraTarballLocation() {
     def tarballsDirFile = file(tarballsDir)
     if (tarballsDirFile.exists() && tarballsDirFile.isDirectory()) {
-        def matchingFiles = fileTree(tarballsDirFile).files.findAll {it.name ==~ /^apache-cassandra-${tarballVersion}\.?\d*(-SNAPSHOT){0,1}-bin\.tar.gz$/ }
+        // the pre-release group matches apache-cassandra-6.0-alpha3-SNAPSHOT-bin.tar.gz
+        def matchingFiles = fileTree(tarballsDirFile).files.findAll {it.name ==~ /^apache-cassandra-${tarballVersion}\.?\d*(-(alpha|beta|rc)\d+)?(-SNAPSHOT){0,1}-bin\.tar.gz$/ }
         if (matchingFiles.size() > 0) {
-            def tarballToTest = matchingFiles.first()
+            // more than one qualifier of the same series can match, so prefer a release over a pre-release
+            def released = matchingFiles.findAll { !(it.name =~ /-(alpha|beta|rc)\d+/) }
+            def tarballToTest = (released ?: matchingFiles).toSorted { a, b -> a.name <=> b.name }.last()
             println("Testing with tarball ${tarballToTest}")
             return tarballToTest
         } else {

--- a/integration-framework/build.gradle
+++ b/integration-framework/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation(project(":adapters:adapters-base"))
     implementation(project(":adapters:adapters-cassandra41"))
     implementation(project(":adapters:adapters-cassandra50"))
+    implementation(project(":adapters:adapters-cassandra60"))
 
     // Needed by the Cassandra dtest framework
     // JUnit

--- a/integration-framework/src/main/java/org/apache/cassandra/testing/TestUtils.java
+++ b/integration-framework/src/main/java/org/apache/cassandra/testing/TestUtils.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.cassandra.sidecar.adapters.base.CassandraFactory;
 import org.apache.cassandra.sidecar.adapters.cassandra41.Cassandra41Factory;
 import org.apache.cassandra.sidecar.adapters.cassandra50.Cassandra50Factory;
+import org.apache.cassandra.sidecar.adapters.cassandra60.Cassandra60Factory;
 import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
 import org.apache.cassandra.sidecar.common.server.utils.DriverUtils;
 import org.apache.cassandra.sidecar.db.schema.TableSchemaFetcher;
@@ -118,6 +119,7 @@ public final class TestUtils
                .add(new CassandraFactory(dnsResolver, driverUtils, tableSchemaFetcher))
                .add(new Cassandra41Factory(dnsResolver, driverUtils, tableSchemaFetcher))
                .add(new Cassandra50Factory(dnsResolver, driverUtils, tableSchemaFetcher))
+               .add(new Cassandra60Factory(dnsResolver, driverUtils, tableSchemaFetcher))
                .build();
     }
 

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/acl/authorization/RoleBasedAuthorizationIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/acl/authorization/RoleBasedAuthorizationIntegrationTest.java
@@ -102,8 +102,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
  * Note:
  * - Create a new keyspace or test role for each test method as required to prevent permissions overlapping
  * Note: locally when running authorization tests you need to comment out version 4.1 in
- * {@link org.apache.cassandra.testing.TestVersionSupplier}. Authorization tests do not run for 4.1, hence 5.1 run
- * gets skipped too.
+ * {@link org.apache.cassandra.testing.TestVersionSupplier}. Authorization tests do not run for 4.1, hence the 6.0
+ * run gets skipped too.
  */
 class RoleBasedAuthorizationIntegrationTest extends SharedClusterSidecarIntegrationTestBase
 {

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CassandraNodeOperationsIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CassandraNodeOperationsIntegrationTest.java
@@ -76,7 +76,8 @@ public class CassandraNodeOperationsIntegrationTest extends SharedClusterSidecar
         trustedClient().put(serverWrapper.serverPort, "localhost", ApiEndpointsV1.NODE_DRAIN_ROUTE)
                        .send());
 
-        assertThat(drainResponse.statusCode()).isEqualTo(OK.code());
+        // the handler answers 202 while the job still runs, which 6.0 reaches because its drain does more work
+        assertThat(drainResponse.statusCode()).isIn(OK.code(), ACCEPTED.code());
 
         JsonObject responseBody = drainResponse.bodyAsJsonObject();
         assertThat(responseBody).isNotNull();

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CassandraStatsIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CassandraStatsIntegrationTest.java
@@ -270,9 +270,19 @@ class CassandraStatsIntegrationTest extends SharedClusterSidecarIntegrationTestB
                     assertThat(stat.clientOptions()).isNotNull();
                     assertThat(stat.clientOptions().containsKey("CQL_VERSION")).isTrue();
                 }
+                if (majorVersion.compareTo(SimpleCassandraVersion.create("6.0.0")) >= 0)
+                {
+                    // 6.0 added authentication_mode to system_views.clients, and the test cluster runs
+                    // AllowAllAuthenticator, which reports AuthenticationMode.UNAUTHENTICATED
+                    assertThat(stat.authenticationMode()).isEqualTo("Unauthenticated");
+                }
+                else
+                {
+                    // the column does not exist below 6.0
+                    assertThat(stat.authenticationMode()).isNull();
+                }
             }
 
-            // TODO: Add validations for fields in trunk once dtest jars can advance beyond TCM commit
             if (usingKeyspace
                 && majorVersion.compareTo(SimpleCassandraVersion.create("5.0.0")) >= 0)
             {

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CompactionStopIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/CompactionStopIntegrationTest.java
@@ -223,7 +223,7 @@ class CompactionStopIntegrationTest extends SharedClusterSidecarIntegrationTestB
         );
         String cassandraVersion = testVersion.version();
 
-        // Check MAJOR_COMPACTION rejected with Cassandra 4.x, accepted with 5.x
+        // Check MAJOR_COMPACTION rejected with Cassandra 4.x, accepted from 5.0 onwards
         if (cassandraVersion.startsWith("4."))
         {
             assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
@@ -238,17 +238,12 @@ class CompactionStopIntegrationTest extends SharedClusterSidecarIntegrationTestB
                     msg -> assertThat(msg).contains("MAJOR_COMPACTION")
                 );
         }
-        else if (cassandraVersion.startsWith("5."))
+        else
         {
             assertThat(response.statusCode()).isEqualTo(HttpResponseStatus.OK.code());
             CompactionStopResponse stopResponse = response.bodyAsJson(CompactionStopResponse.class);
             assertThat(stopResponse.status()).isEqualTo(CompactionStopStatus.SUBMITTED);
             assertThat(stopResponse.compactionType()).isEqualTo("MAJOR_COMPACTION");
-        }
-        else
-        {
-            // Unknown Cassandra version
-            throw new AssertionError("Unexpected Cassandra version: " + cassandraVersion);
         }
     }
 

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/RoutesIntegrationTest.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/routes/RoutesIntegrationTest.java
@@ -27,6 +27,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import org.apache.cassandra.sidecar.common.response.GossipInfoResponse;
 import org.apache.cassandra.sidecar.common.response.HealthResponse;
 import org.apache.cassandra.sidecar.testing.SharedClusterSidecarIntegrationTestBase;
+import org.apache.cassandra.sidecar.utils.SimpleCassandraVersion;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.apache.cassandra.testing.utils.AssertionUtils.getBlocking;
@@ -67,14 +68,11 @@ class RoutesIntegrationTest extends SharedClusterSidecarIntegrationTestBase
         assertThat(gossipInfo.generation()).isNotNull();
         assertThat(gossipInfo.heartbeat()).isNotNull();
         assertThat(gossipInfo.hostId()).isNotNull();
-        String releaseVersion = cluster.getFirstRunningInstance().getReleaseVersionString();
-        releaseVersion = stripSnapshot(releaseVersion);
-        assertThat(gossipInfo.releaseVersion()).startsWith(releaseVersion);
-    }
-
-    private String stripSnapshot(String version)
-    {
-        return version.replace("-SNAPSHOT", "");
+        // 6.0 takes the gossiped release version from cluster metadata, which renders 6.0-alpha3-SNAPSHOT as
+        // 6.0.0-alpha3.SNAPSHOT, so compare the parsed versions rather than the strings
+        SimpleCassandraVersion expected
+        = SimpleCassandraVersion.create(cluster.getFirstRunningInstance().getReleaseVersionString());
+        assertThat(SimpleCassandraVersion.create(gossipInfo.releaseVersion())).isEqualTo(expected);
     }
 
     @Test

--- a/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/testing/SharedClusterCdcSidecarIntegrationTestBase.java
+++ b/integration-tests/src/integrationTest/org/apache/cassandra/sidecar/testing/SharedClusterCdcSidecarIntegrationTestBase.java
@@ -60,12 +60,12 @@ import static org.assertj.core.api.Assumptions.assumeThat;
  * CDC-specific configuration and setup, including:
  * - CDC-enabled Cassandra cluster configuration
  * - TestCdcPublisher with TestCdcEventConsumer
- * - Cassandra 4.0 through 5.0 version support (analytics 0.4.0 does not support 5.1+)
+ * - Cassandra 4.0 through 5.0 version support (analytics 0.4.0 has no bridge above 5.0)
  * - Helper methods to access CDC components
  */
 public abstract class SharedClusterCdcSidecarIntegrationTestBase extends SharedClusterIntegrationTestBase
 {
-    // Analytics 0.4.0 supports up to Cassandra 5.0 (majorVersion=50). Cassandra 5.1+ requires a newer analytics version.
+    // Analytics 0.4.0 supports up to Cassandra 5.0. A later release requires a newer analytics version.
     private static final SimpleCassandraVersion MAX_SUPPORTED_CDC_VERSION = SimpleCassandraVersion.create("5.0.99");
 
     @Override

--- a/scripts/build-dtest-jars.sh
+++ b/scripts/build-dtest-jars.sh
@@ -22,9 +22,12 @@ CANDIDATE_BRANCHES=(
   "cassandra-4.0:ec3b425c38d92d20d77d3a87c782ed9c072e1cd9"
   "cassandra-4.1:2d0fda4511003c883a6a682c1572f749f6d8da10"
   "cassandra-5.0:6fd83986e91a3ce369d1f2d01a04c8c68c319ae3"
-  "trunk:66a7a366474cb9006e66737eac1746f0343db1e8"
+  # cassandra-6.0 is pre-release (base.version 6.0-alpha3), so refresh this sha as the branch moves
+  "cassandra-6.0:74d32dc66f22a047f3f16d9b99d62840cdad8fef"
+  # trunk is 7.0. No CI job consumes a 7.0 jar until a 7.0 adapter exists; build it with BRANCHES=trunk
+  "trunk:b20985d744984304434d2713faa59b4a6f766174"
 )
-BRANCHES=( ${BRANCHES:-cassandra-4.0 cassandra-4.1 cassandra-5.0 trunk} )
+BRANCHES=( ${BRANCHES:-cassandra-4.0 cassandra-4.1 cassandra-5.0 cassandra-6.0} )
 echo ${BRANCHES[*]}
 REPO=${REPO:-"https://github.com/apache/cassandra.git"}
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
@@ -83,6 +86,10 @@ for index in "${!CANDIDATE_BRANCHES[@]}"; do
     git checkout "${branch}"
   fi
   git clean -fd
+  # cassandra-6.0 and later build the accord submodule, which the shallow fetch above does not populate
+  if [ -f .gitmodules ] ; then
+    git submodule update --init --recursive
+  fi
   CASSANDRA_VERSION=$(cat build.xml | grep 'property name="base.version"' | awk -F "\"" '{print $4}')
   # Loop to prevent failure due to maven-ant-tasks not downloading a jar.
   for x in $(seq 1 3); do

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -187,6 +187,7 @@ dependencies {
     implementation(project(":adapters:adapters-base"))
     implementation(project(":adapters:adapters-cassandra41"))
     implementation(project(":adapters:adapters-cassandra50"))
+    implementation(project(":adapters:adapters-cassandra60"))
     implementation(project(":vertx-auth-mtls"))
     implementation(project(":vertx-client"))
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/CdcPublisher.java
@@ -137,10 +137,20 @@ public class CdcPublisher implements Handler<Message<Object>>, PeriodicTask
 
     public EventConsumer eventConsumer(CdcConfig conf)
     {
-        CassandraVersion version = cassandraBridgeFactory.get(
-            instanceMetadataFetcher.callOnFirstAvailableInstance(instance ->
-                instance.delegate().nodeSettings()).releaseVersion()
-        ).getVersion();
+        String releaseVersion = instanceMetadataFetcher.callOnFirstAvailableInstance(instance ->
+            instance.delegate().nodeSettings()).releaseVersion();
+        CassandraVersion version;
+        try
+        {
+            version = cassandraBridgeFactory.get(releaseVersion).getVersion();
+        }
+        catch (RuntimeException e)
+        {
+            // cassandra-analytics ships one commit log bridge per supported release, and has none for 6.0. It rejects
+            // an unsupported release with IllegalArgumentException and a pre-release version with RuntimeException
+            throw new UnsupportedOperationException("CDC does not support Cassandra release version "
+                                                    + releaseVersion + ". Disable CDC on this node.", e);
+        }
         this.kafkaPublisher = KafkaPublisher.create(version,
                                                     buildTopicSupplier(conf),
                                                     conf.kafkaConfigs(),

--- a/server/src/main/java/org/apache/cassandra/sidecar/cdc/SidecarCdcOptions.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/cdc/SidecarCdcOptions.java
@@ -19,7 +19,9 @@
 package org.apache.cassandra.sidecar.cdc;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.cdc.api.CdcOptions;
@@ -59,12 +61,38 @@ public class SidecarCdcOptions implements CdcOptions
         return instanceMetadataFetcher.callOnFirstAvailableInstance(instance-> instance.delegate().nodeSettings().datacenter());
     }
 
+    /**
+     * Resolve the commit log format from the release version that the local node reports.
+     *
+     * <p>A release without a cassandra-analytics bridge fails here, rather than reading its commit logs with a
+     * bridge for another format. cassandra-analytics {@code 0.4.0} has no 6.0 bridge, so CDC is unavailable on 6.0.
+     */
     @Override
     public CassandraVersion version()
     {
         String releaseVersion = instanceMetadataFetcher.callOnFirstAvailableInstance(
                 instance -> instance.delegate().nodeSettings().releaseVersion());
-        return CassandraVersion.fromVersion(releaseVersion).orElse(CassandraVersion.FOURZERO);
+        // fromVersion rejects a pre-release version such as 6.0-alpha3-SNAPSHOT by throwing, and returns an empty
+        // Optional for a release it has no bridge for, so both outcomes carry the same message
+        try
+        {
+            return CassandraVersion.fromVersion(releaseVersion)
+                                   .orElseThrow(() -> unsupportedRelease(releaseVersion, null));
+        }
+        catch (RuntimeException e)
+        {
+            throw e instanceof UnsupportedOperationException ? e : unsupportedRelease(releaseVersion, e);
+        }
+    }
+
+    private static UnsupportedOperationException unsupportedRelease(String releaseVersion, Throwable cause)
+    {
+        String supported = Arrays.stream(CassandraVersion.values())
+                                 .map(CassandraVersion::versionName)
+                                 .collect(Collectors.joining(", "));
+        return new UnsupportedOperationException("CDC does not support Cassandra release version " + releaseVersion
+                                                 + ". Supported versions are " + supported
+                                                 + ". Disable CDC on this node.", cause);
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/TokenRangeReplicaMapHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/TokenRangeReplicaMapHandler.java
@@ -107,7 +107,8 @@ public class TokenRangeReplicaMapHandler extends AbstractHandler<Name> implement
                                   SocketAddress remoteAddress,
                                   Name keyspace)
     {
-        if (cause instanceof AssertionError &&
+        // Cassandra raises an AssertionError up to 5.0, and an IllegalArgumentException from 6.0 onwards
+        if ((cause instanceof AssertionError || cause instanceof IllegalArgumentException) &&
             StringUtils.contains(cause.getMessage(), "Unknown keyspace"))
         {
             context.fail(HttpExceptions.wrapHttpException(HttpResponseStatus.NOT_FOUND, cause.getMessage()));

--- a/server/src/main/java/org/apache/cassandra/sidecar/modules/ConfigurationModule.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/modules/ConfigurationModule.java
@@ -38,6 +38,7 @@ import io.vertx.core.Vertx;
 import org.apache.cassandra.sidecar.adapters.base.CassandraFactory;
 import org.apache.cassandra.sidecar.adapters.cassandra41.Cassandra41Factory;
 import org.apache.cassandra.sidecar.adapters.cassandra50.Cassandra50Factory;
+import org.apache.cassandra.sidecar.adapters.cassandra60.Cassandra60Factory;
 import org.apache.cassandra.sidecar.cluster.CQLSessionProviderImpl;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
@@ -202,6 +203,7 @@ public class ConfigurationModule extends AbstractModule
                .add(new CassandraFactory(dnsResolver, driverUtils, tableSchemaFetcher))
                .add(new Cassandra41Factory(dnsResolver, driverUtils, tableSchemaFetcher))
                 .add(new Cassandra50Factory(dnsResolver, driverUtils, tableSchemaFetcher))
+                .add(new Cassandra60Factory(dnsResolver, driverUtils, tableSchemaFetcher))
                 .build();
     }
 

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/CassandraVersionProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/CassandraVersionProvider.java
@@ -19,6 +19,7 @@
 package org.apache.cassandra.sidecar.utils;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -105,6 +106,9 @@ public class CassandraVersionProvider
             {
                 throw new IllegalStateException("At least one ICassandraFactory is required");
             }
+            // cassandra() seeds its answer with the first element and only moves upward, so sort here rather than
+            // require every registration site to add its factories in ascending order
+            versions.sort(Comparator.comparing(SimpleCassandraVersion::create));
             return new CassandraVersionProvider(versions);
         }
 

--- a/server/src/test/integration/org/apache/cassandra/sidecar/testing/CassandraSidecarTestContext.java
+++ b/server/src/test/integration/org/apache/cassandra/sidecar/testing/CassandraSidecarTestContext.java
@@ -38,6 +38,7 @@ import org.apache.cassandra.distributed.shared.JMXUtil;
 import org.apache.cassandra.sidecar.adapters.base.CassandraFactory;
 import org.apache.cassandra.sidecar.adapters.cassandra41.Cassandra41Factory;
 import org.apache.cassandra.sidecar.adapters.cassandra50.Cassandra50Factory;
+import org.apache.cassandra.sidecar.adapters.cassandra60.Cassandra60Factory;
 import org.apache.cassandra.sidecar.cluster.CQLSessionProviderImpl;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.cluster.InstancesMetadata;
@@ -132,6 +133,7 @@ public class CassandraSidecarTestContext implements AutoCloseable
                .add(new CassandraFactory(dnsResolver, driverUtils, tableSchemaFetcher))
                .add(new Cassandra41Factory(dnsResolver, driverUtils, tableSchemaFetcher))
                .add(new Cassandra50Factory(dnsResolver, driverUtils, tableSchemaFetcher))
+               .add(new Cassandra60Factory(dnsResolver, driverUtils, tableSchemaFetcher))
                .build();
     }
 

--- a/server/src/test/java/org/apache/cassandra/sidecar/cdc/SidecarCdcOptionsTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/cdc/SidecarCdcOptionsTest.java
@@ -24,11 +24,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.cassandra.bridge.CassandraVersion;
 import org.apache.cassandra.sidecar.common.server.utils.MillisecondBoundConfiguration;
 import org.apache.cassandra.sidecar.common.server.utils.SecondBoundConfiguration;
 import org.apache.cassandra.sidecar.utils.InstanceMetadataFetcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,14 +49,46 @@ import static org.mockito.Mockito.when;
 class SidecarCdcOptionsTest
 {
     private CdcConfig conf;
+    private InstanceMetadataFetcher instanceMetadataFetcher;
     private SidecarCdcOptions options;
 
     @BeforeEach
     void setUp()
     {
         conf = mock(CdcConfig.class);
-        InstanceMetadataFetcher instanceMetadataFetcher = mock(InstanceMetadataFetcher.class);
+        instanceMetadataFetcher = mock(InstanceMetadataFetcher.class);
         options = new SidecarCdcOptions(instanceMetadataFetcher, conf);
+    }
+
+    @Test
+    void versionResolvesASupportedRelease()
+    {
+        when(instanceMetadataFetcher.callOnFirstAvailableInstance(any())).thenReturn("5.0.7");
+
+        assertThat(options.version()).isEqualTo(CassandraVersion.FIVEZERO);
+    }
+
+    @Test
+    void versionFailsForAPreReleaseVersion()
+    {
+        // fromVersion throws rather than returns an empty Optional for this form
+        when(instanceMetadataFetcher.callOnFirstAvailableInstance(any())).thenReturn("6.0-alpha3-SNAPSHOT");
+
+        assertThatThrownBy(() -> options.version())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("6.0-alpha3-SNAPSHOT")
+        .hasMessageContaining("Disable CDC on this node");
+    }
+
+    @Test
+    void versionFailsForAReleaseWithoutABridge()
+    {
+        when(instanceMetadataFetcher.callOnFirstAvailableInstance(any())).thenReturn("6.0.0");
+
+        assertThatThrownBy(() -> options.version())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("6.0.0")
+        .hasMessageContaining("5.0");
     }
 
     @Test

--- a/server/src/test/java/org/apache/cassandra/sidecar/utils/SimpleCassandraVersionProviderTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/utils/SimpleCassandraVersionProviderTest.java
@@ -21,12 +21,20 @@ package org.apache.cassandra.sidecar.utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.cassandra.sidecar.adapters.base.CassandraFactory;
+import org.apache.cassandra.sidecar.adapters.cassandra41.Cassandra41Factory;
+import org.apache.cassandra.sidecar.adapters.cassandra50.Cassandra50Factory;
+import org.apache.cassandra.sidecar.adapters.cassandra60.Cassandra60Factory;
 import org.apache.cassandra.sidecar.common.server.ICassandraFactory;
+import org.apache.cassandra.sidecar.common.server.dns.DnsResolver;
+import org.apache.cassandra.sidecar.common.server.utils.DriverUtils;
+import org.apache.cassandra.sidecar.db.schema.TableSchemaFetcher;
 import org.apache.cassandra.sidecar.mocks.V30;
 import org.apache.cassandra.sidecar.mocks.V40;
 import org.apache.cassandra.sidecar.mocks.V41;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class SimpleCassandraVersionProviderTest
 {
@@ -81,6 +89,48 @@ class SimpleCassandraVersionProviderTest
 
         ICassandraFactory cassandra = provider.cassandra(SimpleCassandraVersion.create("4.0.0"));
         assertThat(cassandra).hasSameClassAs(new V40());
+    }
+
+    @Test
+    void ensureDescendingInsertionWorks()
+    {
+        // the requested version is below the first factory registered, which the seeding in cassandra() would
+        // otherwise return
+        provider = new CassandraVersionProvider.Builder().add(new V41())
+                                                         .add(new V40())
+                                                         .add(new V30()).build();
+
+        assertThat(provider.cassandra(SimpleCassandraVersion.create("4.0.7"))).hasSameClassAs(new V40());
+        assertThat(provider.cassandra(SimpleCassandraVersion.create("3.0.7"))).hasSameClassAs(new V30());
+    }
+
+    @Test
+    void ensureProductionFactoriesMatchTheirReleaseLine()
+    {
+        DnsResolver dnsResolver = mock(DnsResolver.class);
+        DriverUtils driverUtils = new DriverUtils();
+        TableSchemaFetcher tableSchemaFetcher = mock(TableSchemaFetcher.class);
+        CassandraVersionProvider productionProvider
+        = new CassandraVersionProvider.Builder()
+          .add(new CassandraFactory(dnsResolver, driverUtils, tableSchemaFetcher))
+          .add(new Cassandra41Factory(dnsResolver, driverUtils, tableSchemaFetcher))
+          .add(new Cassandra50Factory(dnsResolver, driverUtils, tableSchemaFetcher))
+          .add(new Cassandra60Factory(dnsResolver, driverUtils, tableSchemaFetcher))
+          .build();
+
+        assertThat(productionProvider.cassandra(SimpleCassandraVersion.create("4.0.13")))
+        .isExactlyInstanceOf(CassandraFactory.class);
+        assertThat(productionProvider.cassandra(SimpleCassandraVersion.create("4.1.11")))
+        .isExactlyInstanceOf(Cassandra41Factory.class);
+        assertThat(productionProvider.cassandra(SimpleCassandraVersion.create("5.0.6")))
+        .isExactlyInstanceOf(Cassandra50Factory.class);
+        assertThat(productionProvider.cassandra(SimpleCassandraVersion.create("6.0.1")))
+        .isExactlyInstanceOf(Cassandra60Factory.class);
+        // a pre-release node reports 6.0-alpha3-SNAPSHOT, which is the string that selects the adapter in practice
+        assertThat(productionProvider.cassandra(SimpleCassandraVersion.create("6.0-alpha3-SNAPSHOT")))
+        .isExactlyInstanceOf(Cassandra60Factory.class);
+        assertThat(productionProvider.cassandra(SimpleCassandraVersion.create("6.0")))
+        .isExactlyInstanceOf(Cassandra60Factory.class);
     }
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,6 +30,7 @@ if (JavaVersion.current().isJava11Compatible()) {
     include "adapters:adapters-base"
     include "adapters:adapters-cassandra41"
     include "adapters:adapters-cassandra50"
+    include "adapters:adapters-cassandra60"
     include "docs"
     include "server"
     include "server-common"

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -24,7 +24,8 @@ plugins {
 
 version project.version
 
-ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-4.1.11.jar" // latest supported Cassandra build is 5.1
+// Compile classpath of the test fixtures only; it does not limit the versions under test
+ext.dtestJar = System.getenv("DTEST_JAR") ?: "dtest-4.1.11.jar"
 def dtestJarFullPath = "${dependencyLocation}${ext.dtestJar}"
 File dtestJarFile = new File(dtestJarFullPath)
 println("Using DTest jar: " + dtestJarFullPath + "; present? " + dtestJarFile.exists())

--- a/test-common/src/testFixtures/java/org/apache/cassandra/testing/TestVersionSupplier.java
+++ b/test-common/src/testFixtures/java/org/apache/cassandra/testing/TestVersionSupplier.java
@@ -45,7 +45,7 @@ public final class TestVersionSupplier
     public static Stream<TestVersion> testVersions()
     {
         // By default, we test 2 versions that will exercise oldest and newest supported versions
-        String versions = System.getProperty("cassandra.sidecar.versions_to_test", "4.1,5.1");
+        String versions = System.getProperty("cassandra.sidecar.versions_to_test", "4.1,6.0");
         LOGGER.info("Testing with versions={}", versions);
         return Arrays.stream(versions.split(",")).map(String::trim).map(TestVersion::new);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CASSSIDECAR-494

Register a 6.0 adapter and adapt to the surfaces that 6.0 changed.  This adds no new Sidecar endpoints.

Add adapters/adapters-cassandra60, which extends the 5.0 module and overrides storage operations alone.  Cassandra 6.0 deprecates the StorageServiceMBean snapshot methods in favour of a SnapshotManager MBean, so Cassandra60StorageOperations routes takeSnapshot and clearSnapshot there.  Only CassandraDaemon registers that MBean, so an in-JVM dtest node needs the deprecated methods; the class falls back to them and classifies failures on both routes alike.

Adapt three more 6.0 surfaces.  CASSANDRA-21539 removed the hostname column from system_views.clients, 6.0 added authentication_mode, and under CEP-21 Gossiper takes the release version from cluster metadata, which renders a pre-release differently.

Fail fast for change data capture on 6.0.  cassandra-analytics 0.4.0 ships no 6.0 commit log bridge, so name the unsupported release rather than read its commit logs with a bridge for another format.

Name 6.0 in the test matrix.  The matrix tested a branch called trunk and labelled it 5.1; that release line is now cassandra-6.0, and trunk has become 7.0.  Pin a cassandra-6.0 dtest jar and keep trunk buildable on demand.

Sort factories in CassandraVersionProvider.Builder.build().  Selection seeds its answer with the first element and only moves upward, so it was correct only when every registration site added factories in ascending order.
