### PR TITLE
[CASSSIDECAR-495] Report each instance's own Sidecar instance id in th…

### DIFF
--- a/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProvider.java
+++ b/adapters/adapters-base/src/main/java/org/apache/cassandra/sidecar/adapters/base/TokenRangeReplicaProvider.java
@@ -166,7 +166,10 @@ public class TokenRangeReplicaProvider
                                                                                           fqdn,
                                                                                           hap.getHost(),
                                                                                           hap.getPort(),
-                                                                                          datacenter));
+                                                                                          datacenter,
+                                                                                          // Sidecar instance id is resolved by the server handler,
+                                                                                          // which has access to the local instances configuration
+                                                                                          null));
                              }
                              catch (UnknownHostException e)
                              {

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/TokenRangeReplicasResponse.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/TokenRangeReplicasResponse.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.cassandra.sidecar.common.request.TokenRangeReplicasRequest;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Class response for the {@link TokenRangeReplicasRequest}
@@ -173,13 +174,16 @@ public class TokenRangeReplicasResponse
         private final String address;
         private final int port;
         private final String datacenter;
+        @Nullable
+        private final Integer sidecarInstanceId;
 
         public ReplicaMetadata(@JsonProperty("state") String state,
                                @JsonProperty("status") String status,
                                @JsonProperty("fqdn") String fqdn,
                                @JsonProperty("address") String address,
                                @JsonProperty("port") int port,
-                               @JsonProperty("datacenter") String datacenter)
+                               @JsonProperty("datacenter") String datacenter,
+                               @JsonProperty("sidecarInstanceId") @Nullable Integer sidecarInstanceId)
         {
             this.state = state;
             this.status = status;
@@ -187,6 +191,7 @@ public class TokenRangeReplicasResponse
             this.address = address;
             this.port = port;
             this.datacenter = datacenter;
+            this.sidecarInstanceId = sidecarInstanceId;
         }
 
         /**
@@ -244,6 +249,18 @@ public class TokenRangeReplicasResponse
         }
 
         /**
+         * @return the id of the Sidecar instance that manages this replica, or {@code null} when the Sidecar
+         * serving the request does not manage this replica. Clients use it to route per-replica requests
+         * through a load balancer via the {@code instanceId} query parameter.
+         */
+        @JsonProperty("sidecarInstanceId")
+        @Nullable
+        public Integer sidecarInstanceId()
+        {
+            return sidecarInstanceId;
+        }
+
+        /**
          * {@inheritDoc}
          */
         public String toString()
@@ -255,6 +272,7 @@ public class TokenRangeReplicasResponse
                    ", address='" + address + '\'' +
                    ", port='" + port + '\'' +
                    ", datacenter='" + datacenter + '\'' +
+                   ", sidecarInstanceId=" + sidecarInstanceId +
                    '}';
         }
     }

--- a/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/data/RingEntry.java
+++ b/client-common/src/main/java/org/apache/cassandra/sidecar/common/response/data/RingEntry.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A class representing an entry in the Cassandra Ring
@@ -39,6 +40,8 @@ public class RingEntry
     private final String token;
     private final String fqdn;
     private final String hostId;
+    @Nullable
+    private final Integer sidecarInstanceId;
 
     @JsonCreator
     public RingEntry(
@@ -52,7 +55,8 @@ public class RingEntry
     @JsonProperty("owns") String owns,
     @JsonProperty("token") String token,
     @JsonProperty("fqdn") String fqdn,
-    @JsonProperty("hostId") String hostId)
+    @JsonProperty("hostId") String hostId,
+    @JsonProperty("sidecarInstanceId") @Nullable Integer sidecarInstanceId)
     {
         this.datacenter = datacenter;
         this.address = address;
@@ -65,6 +69,7 @@ public class RingEntry
         this.token = token;
         this.fqdn = fqdn;
         this.hostId = hostId;
+        this.sidecarInstanceId = sidecarInstanceId;
     }
 
     private RingEntry(Builder builder)
@@ -80,6 +85,7 @@ public class RingEntry
         token = builder.token;
         fqdn = builder.fqdn;
         hostId = builder.hostId;
+        sidecarInstanceId = builder.sidecarInstanceId;
     }
 
     /**
@@ -183,6 +189,18 @@ public class RingEntry
     }
 
     /**
+     * @return the id of the Sidecar instance that manages this node, or {@code null} when the Sidecar
+     * serving the request does not manage this node. Clients use it to route per-instance requests
+     * through a load balancer via the {@code instanceId} query parameter.
+     */
+    @JsonProperty("sidecarInstanceId")
+    @Nullable
+    public Integer sidecarInstanceId()
+    {
+        return sidecarInstanceId;
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -200,6 +218,7 @@ public class RingEntry
                ", token='" + token + '\'' +
                ", fqdn='" + fqdn + '\'' +
                ", hostId='" + hostId + '\'' +
+               ", sidecarInstanceId=" + sidecarInstanceId +
                '}';
     }
 
@@ -222,7 +241,8 @@ public class RingEntry
                && Objects.equals(owns, ringEntry.owns)
                && Objects.equals(token, ringEntry.token)
                && Objects.equals(fqdn, ringEntry.fqdn)
-               && Objects.equals(hostId, ringEntry.hostId);
+               && Objects.equals(hostId, ringEntry.hostId)
+               && Objects.equals(sidecarInstanceId, ringEntry.sidecarInstanceId);
     }
 
     /**
@@ -231,7 +251,8 @@ public class RingEntry
     @Override
     public int hashCode()
     {
-        return Objects.hash(datacenter, address, port, rack, status, state, load, owns, token, fqdn, hostId);
+        return Objects.hash(datacenter, address, port, rack, status, state, load, owns, token, fqdn, hostId,
+                            sidecarInstanceId);
     }
 
     /**
@@ -250,6 +271,7 @@ public class RingEntry
         private String token;
         private String fqdn;
         private String hostId;
+        private Integer sidecarInstanceId;
 
         /**
          * Sets the {@code datacenter} and returns a reference to this Builder enabling method chaining.
@@ -381,6 +403,18 @@ public class RingEntry
         public Builder hostId(String hostId)
         {
             this.hostId = hostId;
+            return this;
+        }
+
+        /**
+         * Sets the {@code sidecarInstanceId} and returns a reference to this Builder enabling method chaining.
+         *
+         * @param sidecarInstanceId the {@code sidecarInstanceId} to set
+         * @return a reference to this Builder
+         */
+        public Builder sidecarInstanceId(@Nullable Integer sidecarInstanceId)
+        {
+            this.sidecarInstanceId = sidecarInstanceId;
             return this;
         }
 

--- a/client-common/src/test/java/org/apache/cassandra/sidecar/common/response/TokenRangeReplicasResponseTest.java
+++ b/client-common/src/test/java/org/apache/cassandra/sidecar/common/response/TokenRangeReplicasResponseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.response;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse.ReplicaMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link TokenRangeReplicasResponse.ReplicaMetadata} JSON serialization and deserialization.
+ */
+class TokenRangeReplicasResponseTest
+{
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testReplicaMetadataRoundTripWithSidecarInstanceId() throws Exception
+    {
+        ReplicaMetadata original = new ReplicaMetadata("Normal", "Up", "host1.local",
+                                                       "127.0.0.1", 7000, "dc1", 5);
+
+        String json = objectMapper.writeValueAsString(original);
+        assertThat(json).contains("\"sidecarInstanceId\":5");
+
+        ReplicaMetadata deserialized = objectMapper.readValue(json, ReplicaMetadata.class);
+        assertThat(deserialized.sidecarInstanceId()).isEqualTo(5);
+        assertThat(deserialized.address()).isEqualTo("127.0.0.1");
+        assertThat(deserialized.datacenter()).isEqualTo("dc1");
+    }
+
+    @Test
+    void testReplicaMetadataDeserializeLegacyJsonWithoutSidecarInstanceId() throws Exception
+    {
+        // A response produced before this field existed must still deserialize, leaving the id null
+        String legacyJson = "{\"state\":\"Normal\",\"status\":\"Up\",\"fqdn\":\"host1.local\","
+                            + "\"address\":\"127.0.0.1\",\"port\":7000,\"datacenter\":\"dc1\"}";
+
+        ReplicaMetadata deserialized = objectMapper.readValue(legacyJson, ReplicaMetadata.class);
+        assertThat(deserialized.sidecarInstanceId()).isNull();
+        assertThat(deserialized.address()).isEqualTo("127.0.0.1");
+    }
+}

--- a/client-common/src/test/java/org/apache/cassandra/sidecar/common/response/data/RingEntryTest.java
+++ b/client-common/src/test/java/org/apache/cassandra/sidecar/common/response/data/RingEntryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.sidecar.common.response.data;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link RingEntry} JSON serialization and deserialization.
+ */
+class RingEntryTest
+{
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void testRoundTripWithSidecarInstanceId() throws Exception
+    {
+        RingEntry original = new RingEntry.Builder()
+                             .datacenter("dc1")
+                             .address("127.0.0.1")
+                             .port(7000)
+                             .rack("rack1")
+                             .status("Up")
+                             .state("Normal")
+                             .load("1 KiB")
+                             .owns("100%")
+                             .token("42")
+                             .fqdn("host1.local")
+                             .hostId("host-id-1")
+                             .sidecarInstanceId(7)
+                             .build();
+
+        String json = objectMapper.writeValueAsString(original);
+        assertThat(json).contains("\"sidecarInstanceId\":7");
+
+        RingEntry deserialized = objectMapper.readValue(json, RingEntry.class);
+        assertThat(deserialized).isEqualTo(original);
+        assertThat(deserialized.sidecarInstanceId()).isEqualTo(7);
+    }
+
+    @Test
+    void testDeserializeLegacyJsonWithoutSidecarInstanceId() throws Exception
+    {
+        // A response produced before this field existed must still deserialize, leaving the id null
+        String legacyJson = "{\"datacenter\":\"dc1\",\"address\":\"127.0.0.1\",\"port\":7000,"
+                            + "\"rack\":\"rack1\",\"status\":\"Up\",\"state\":\"Normal\",\"load\":\"1 KiB\","
+                            + "\"owns\":\"100%\",\"token\":\"42\",\"fqdn\":\"host1.local\",\"hostId\":\"host-id-1\"}";
+
+        RingEntry deserialized = objectMapper.readValue(legacyJson, RingEntry.class);
+        assertThat(deserialized.sidecarInstanceId()).isNull();
+        assertThat(deserialized.address()).isEqualTo("127.0.0.1");
+    }
+}

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/KeyspaceRingHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/KeyspaceRingHandler.java
@@ -31,6 +31,8 @@ import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.web.RoutingContext;
 import org.apache.cassandra.sidecar.acl.authorization.BasicPermissions;
+import org.apache.cassandra.sidecar.common.response.RingResponse;
+import org.apache.cassandra.sidecar.common.response.data.RingEntry;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
@@ -75,9 +77,38 @@ public class KeyspaceRingHandler extends AbstractHandler<Name> implements Access
     {
         StorageOperations operations = metadataFetcher.delegate(host).storageOperations();
         executorPools.service()
-                     .executeBlocking(() -> operations.ring(keyspace))
+                     .executeBlocking(() -> withSidecarInstanceIds(operations.ring(keyspace)))
                      .onSuccess(context::json)
                      .onFailure(cause -> processFailure(cause, context, host, remoteAddress, keyspace));
+    }
+
+    /**
+     * Enriches each ring entry with the id of the local Sidecar instance managing the node, so that clients
+     * behind a load balancer can route per-instance requests via the {@code instanceId} query parameter.
+     * Nodes not managed by this Sidecar retain a {@code null} id.
+     */
+    private RingResponse withSidecarInstanceIds(RingResponse response)
+    {
+        RingResponse enriched = new RingResponse(response.size());
+        for (RingEntry entry : response)
+        {
+            Integer sidecarInstanceId = metadataFetcher.sidecarInstanceId(entry.address());
+            enriched.add(new RingEntry.Builder()
+                         .datacenter(entry.datacenter())
+                         .address(entry.address())
+                         .port(entry.port())
+                         .rack(entry.rack())
+                         .status(entry.status())
+                         .state(entry.state())
+                         .load(entry.load())
+                         .owns(entry.owns())
+                         .token(entry.token())
+                         .fqdn(entry.fqdn())
+                         .hostId(entry.hostId())
+                         .sidecarInstanceId(sidecarInstanceId)
+                         .build());
+        }
+        return enriched;
     }
 
     /**

--- a/server/src/main/java/org/apache/cassandra/sidecar/handlers/TokenRangeReplicaMapHandler.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/handlers/TokenRangeReplicaMapHandler.java
@@ -19,6 +19,8 @@
 package org.apache.cassandra.sidecar.handlers;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -33,6 +35,8 @@ import io.vertx.ext.web.RoutingContext;
 import org.apache.cassandra.sidecar.acl.authorization.BasicPermissions;
 import org.apache.cassandra.sidecar.cluster.CassandraAdapterDelegate;
 import org.apache.cassandra.sidecar.common.response.NodeSettings;
+import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse;
+import org.apache.cassandra.sidecar.common.response.TokenRangeReplicasResponse.ReplicaMetadata;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.common.server.data.Name;
 import org.apache.cassandra.sidecar.concurrent.ExecutorPools;
@@ -84,9 +88,33 @@ public class TokenRangeReplicaMapHandler extends AbstractHandler<Name> implement
         NodeSettings nodeSettings = delegate.nodeSettings();
         StorageOperations operations = delegate.storageOperations();
         executorPools.service()
-                     .executeBlocking(() -> operations.tokenRangeReplicas(keyspace, nodeSettings.partitioner()))
+                     .executeBlocking(() -> withSidecarInstanceIds(operations.tokenRangeReplicas(keyspace, nodeSettings.partitioner())))
                      .onSuccess(context::json)
                      .onFailure(cause -> processFailure(cause, context, host, remoteAddress, keyspace));
+    }
+
+    /**
+     * Enriches the replica metadata with the id of the local Sidecar instance managing each replica, so that
+     * clients behind a load balancer can route per-replica requests via the {@code instanceId} query parameter.
+     * Replicas not managed by this Sidecar retain a {@code null} id.
+     */
+    private TokenRangeReplicasResponse withSidecarInstanceIds(TokenRangeReplicasResponse response)
+    {
+        Map<String, ReplicaMetadata> replicaMetadata = response.replicaMetadata();
+        Map<String, ReplicaMetadata> enriched = new LinkedHashMap<>(replicaMetadata.size());
+        for (Map.Entry<String, ReplicaMetadata> entry : replicaMetadata.entrySet())
+        {
+            ReplicaMetadata metadata = entry.getValue();
+            Integer sidecarInstanceId = metadataFetcher.sidecarInstanceId(metadata.address());
+            enriched.put(entry.getKey(), new ReplicaMetadata(metadata.state(),
+                                                             metadata.status(),
+                                                             metadata.fqdn(),
+                                                             metadata.address(),
+                                                             metadata.port(),
+                                                             metadata.datacenter(),
+                                                             sidecarInstanceId));
+        }
+        return new TokenRangeReplicasResponse(response.writeReplicas(), response.readReplicas(), enriched);
     }
 
     @Override

--- a/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcher.java
@@ -33,6 +33,7 @@ import org.apache.cassandra.sidecar.cluster.instance.InstanceMetadata;
 import org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException;
 import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.cassandra.sidecar.exceptions.CassandraUnavailableException.Service.CQL_AND_JMX;
 
@@ -77,6 +78,31 @@ public class InstanceMetadataFetcher
     public InstanceMetadata instance(int instanceId) throws NoSuchCassandraInstanceException
     {
         return instancesMetadata.instanceFromId(instanceId);
+    }
+
+    /**
+     * Returns the id of the local Sidecar instance that manages the Cassandra node at the given {@code host},
+     * or {@code null} when this Sidecar does not manage that node.
+     *
+     * <p>This is used to enrich ring/token-range responses so that clients behind a load balancer can route
+     * per-instance requests via the {@code instanceId} query parameter. In a topology where a single Sidecar
+     * configuration knows all instances, every replica resolves to an id; in a one-Sidecar-per-node topology,
+     * only the locally managed node resolves and the rest are {@code null}.
+     *
+     * @param host the Cassandra node hostname or IP address
+     * @return the managing Sidecar instance id, or {@code null} when not managed locally
+     */
+    @Nullable
+    public Integer sidecarInstanceId(@NotNull String host)
+    {
+        try
+        {
+            return instancesMetadata.instanceFromHost(host).id();
+        }
+        catch (NoSuchCassandraInstanceException e)
+        {
+            return null;
+        }
     }
 
     /**

--- a/server/src/test/java/org/apache/cassandra/sidecar/handlers/RingHandlerTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/handlers/RingHandlerTest.java
@@ -54,6 +54,7 @@ import org.apache.cassandra.sidecar.common.response.RingResponse;
 import org.apache.cassandra.sidecar.common.response.data.RingEntry;
 import org.apache.cassandra.sidecar.common.server.StorageOperations;
 import org.apache.cassandra.sidecar.common.server.exceptions.JmxAuthenticationException;
+import org.apache.cassandra.sidecar.exceptions.NoSuchCassandraInstanceException;
 import org.apache.cassandra.sidecar.modules.SidecarModules;
 import org.apache.cassandra.sidecar.server.Server;
 import org.mockito.stubbing.Answer;
@@ -61,6 +62,7 @@ import org.mockito.stubbing.Answer;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -152,6 +154,14 @@ class RingHandlerTest
                       assertThat(entry.state()).isEqualTo("Normal");
                       assertThat(entry.status()).isEqualTo("Up");
                       assertThat(entry.token()).isEqualTo(String.valueOf(i));
+                      if (i == 1)
+                      {
+                          assertThat(entry.sidecarInstanceId()).isEqualTo(100);
+                      }
+                      else
+                      {
+                          assertThat(entry.sidecarInstanceId()).isNull();
+                      }
                   }
 
                   context.completeNow();
@@ -223,7 +233,14 @@ class RingHandlerTest
             InstancesMetadata mockInstancesMetadata = mock(InstancesMetadata.class);
             when(mockInstancesMetadata.instances()).thenReturn(Collections.singletonList(instanceMetadata));
             when(mockInstancesMetadata.instanceFromId(instanceId)).thenReturn(instanceMetadata);
-            when(mockInstancesMetadata.instanceFromHost(host)).thenReturn(instanceMetadata);
+            when(mockInstancesMetadata.instanceFromHost(anyString())).thenAnswer(invocation -> {
+                String requestedHost = invocation.getArgument(0);
+                if (host.equals(requestedHost))
+                {
+                    return instanceMetadata;
+                }
+                throw new NoSuchCassandraInstanceException("Instance with host address '" + requestedHost + "' not found");
+            });
 
             return mockInstancesMetadata;
         }

--- a/server/src/test/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcherTest.java
+++ b/server/src/test/java/org/apache/cassandra/sidecar/utils/InstanceMetadataFetcherTest.java
@@ -69,6 +69,28 @@ class InstanceMetadataFetcherTest
         .hasMessageContaining("All local Cassandra nodes are exhausted. But none is available");
     }
 
+    @Test
+    void testSidecarInstanceIdResolvesManagedHost()
+    {
+        List<InstanceMetadata> instances = Arrays.asList(instance(1, "127.0.0.1", false),
+                                                         instance(2, "127.0.0.2", false),
+                                                         instance(3, "127.0.0.3", false));
+        InstancesMetadataImpl instancesMetadata = new InstancesMetadataImpl(instances, DnsResolvers.DEFAULT);
+        InstanceMetadataFetcher fetcher = new InstanceMetadataFetcher(instancesMetadata);
+        assertThat(fetcher.sidecarInstanceId("127.0.0.1")).isEqualTo(1);
+        assertThat(fetcher.sidecarInstanceId("127.0.0.2")).isEqualTo(2);
+        assertThat(fetcher.sidecarInstanceId("127.0.0.3")).isEqualTo(3);
+    }
+
+    @Test
+    void testSidecarInstanceIdReturnsNullForUnmanagedHost()
+    {
+        List<InstanceMetadata> instances = Arrays.asList(instance(1, "127.0.0.1", false));
+        InstancesMetadataImpl instancesMetadata = new InstancesMetadataImpl(instances, DnsResolvers.DEFAULT);
+        InstanceMetadataFetcher fetcher = new InstanceMetadataFetcher(instancesMetadata);
+        assertThat(fetcher.sidecarInstanceId("127.0.0.99")).isNull();
+    }
+
     private InstanceMetadata instance(int id, String host, boolean isAvailable)
     {
         InstanceMetadataImpl.Builder builder = InstanceMetadataImpl.builder()


### PR DESCRIPTION
…e ring / token-range-replicas response

Enrich RingEntry and ReplicaMetadata with the id of the local Sidecar instance managing each node/replica, resolved via
InstanceMetadataFetcher#sidecarInstanceId(host) in KeyspaceRingHandler and TokenRangeReplicaMapHandler. Entries not managed by this Sidecar retain a null id. This lets clients discover which instanceId to pass for a given node/replica in a follow-up request, which matters most when the client sits behind a load balancer and cannot otherwise guarantee it reaches the Sidecar managing that node.