### PR TITLE
CASSSIDECAR-496: Disable Netty wire logging on the HTTP server

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 0.5.0
 -----
+ * Disable Netty wire logging on the HTTP server (CASSSIDECAR-496)
  * Tighten path containment in Live Migration file route (CASSSIDECAR-479)
  * Add fast_forward_enabled flag to enable eager pipelining of staging and importing in coordinated writes (CASSSIDECAR-463)
  * CachingSchemaStore should be reloaded when Schemastore kafka configs are changed (CASSSIDECAR-493)

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -73,6 +73,7 @@
   </root>
 
 
+  <logger name="io.netty" level="INFO" />
   <logger name="com.datastax.driver.core" level="ERROR" />
   <logger name="com.datastax.driver.core.ControlConnection" level="OFF" />
 </configuration>

--- a/server/src/main/java/org/apache/cassandra/sidecar/server/HttpServerOptionsProvider.java
+++ b/server/src/main/java/org/apache/cassandra/sidecar/server/HttpServerOptionsProvider.java
@@ -55,7 +55,7 @@ public class HttpServerOptionsProvider implements Function<SidecarConfiguration,
     @Override
     public HttpServerOptions apply(SidecarConfiguration configuration)
     {
-        HttpServerOptions options = new HttpServerOptions().setLogActivity(true);
+        HttpServerOptions options = new HttpServerOptions();
         ServiceConfiguration serviceConf = configuration.serviceConfiguration();
         options.setIdleTimeoutUnit(MILLISECONDS)
                .setIdleTimeout(serviceConf.requestIdleTimeout().toIntMillis())


### PR DESCRIPTION
[CASSSIDECAR-496](https://issues.apache.org/jira/browse/CASSSIDECAR-496)

`HttpServerOptionsProvider` hardcoded `setLogActivity(true)`, installing Netty's `LoggingHandler` on every HTTP connection. It was the only hardcoded option in a method where every other value is read from `SidecarConfiguration`.

On a 3-node cluster running the `ghcr.io/apache/cassandra-sidecar` image this produced 8.6 million log lines in one hour, roughly 96% of all log volume, because `ByteBufUtil.appendPrettyHexDump` turns a single 95,504-byte response into about 6,000 lines. The dumps contain request and response bodies in cleartext; since schema endpoints return DDL, CQL statements are written to the logs as well:

```
|00016260| 66 61 63 74 6f 72 27 3a 20 27 31 27 20 7d 20 41 |factor': '1' } A|
|00016270| 4e 44 20 44 55 52 41 42 4c 45 5f 57 52 49 54 45 |ND DURABLE_WRITE|
|00016280| 53 20 3d 20 74 72 75 65 3b 5c 6e 5c 6e 43 52 45 |S = true;\n\nCRE|
```

It only fires when the process starts without `logback.configurationFile`, which is supplied solely by the Gradle-generated start scripts. A directly launched jar gets no logback configuration and falls back to logback's default of root DEBUG to ConsoleAppender — the common container path. The test suite could not catch it either: `server/src/test/resources/logback-test.xml` pins `LoggingHandler` to info.